### PR TITLE
Fix cmake script for bullet

### DIFF
--- a/bullet/CMakeLists.txt
+++ b/bullet/CMakeLists.txt
@@ -34,7 +34,7 @@ set(versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${bullet_plugin}${CMAKE_SHARED_LIBRA
 set(unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
 if (WIN32)
   # disable MSVC inherit via dominance warning
-  target_compile_options(${dartsim_plugin} PUBLIC "/wd4250")
+  target_compile_options(${bullet_plugin} PUBLIC "/wd4250")
   INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
       ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned}
       ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR}\/${unversioned})")


### PR DESCRIPTION
In conda-forge we got this error:
```
CMake Error at bullet/CMakeLists.txt:37 (target_compile_options):
  Cannot specify compile options for target "PUBLIC" which is not built by
  this project.
```

This fixes it.