### PR TITLE
Prepare for 2.5.0-pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-physics2 VERSION 2.4.0)
+project(ignition-physics2 VERSION 2.5.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -13,7 +13,7 @@ find_package(ignition-cmake2 2.8.0 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project()
+ign_configure_project(VERSION_SUFFIX pre1)
 
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,31 @@
 
 ### Ignition Physics 2.x.x (20XX-XX-XX)
 
+### Ignition Physics 2.5.0 (2021-10-28)
+
+1. Added DART feature for setting joint limits dynamically.
+    * [Pull request #260](https://github.com/ignitionrobotics/ign-physics/pull/260)
+
+1. Allow customization of contact surface properties
+    * [Pull request #267](https://github.com/ignitionrobotics/ign-physics/pull/267)
+
+1. [dartsim] Add support for joint frame semantics
+    * [Pull request #288](https://github.com/ignitionrobotics/ign-physics/pull/288)
+
+1. Use slip compliance API's available in upstream dartsim release
+    * [Pull request #265](https://github.com/ignitionrobotics/ign-physics/pull/265)
+
+1. Fix dart deprecation warning
+    * [Pull request #263](https://github.com/ignitionrobotics/ign-physics/pull/263)
+
+1. [Citadel] Update tutorials
+    * [Pull request #204](https://github.com/ignitionrobotics/ign-physics/pull/204)
+
+1. Infrastructure
+    * [Pull request #257](https://github.com/ignitionrobotics/ign-physics/pull/257)
+    * [Pull request #281](https://github.com/ignitionrobotics/ign-physics/pull/281)
+    * [Pull request #287](https://github.com/ignitionrobotics/ign-physics/pull/287)
+
 ### Ignition Physics 2.4.0 (2021-04-14)
 
 1. [TPE] Update link pose and velocity


### PR DESCRIPTION
# 🎈 Prerelease

Preparation for 2.5.0-pre1 release.

Comparison to 2.4.0: https://github.com/ignitionrobotics/ign-physics/compare/ignition-physics2_2.4.0...ign-physics2

<!-- Add links to PRs that require this release (if needed) -->
Needed by:
  * https://github.com/ignitionrobotics/ign-gazebo/pull/847
  * https://github.com/ignitionrobotics/ign-gazebo/pull/869

## Checklist
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
~- [ ] Updated migration guide (as needed)~
- [ ] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
