### PR TITLE
dartsim: fix handling inertia matrix pose rotation

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -591,11 +591,6 @@ Identity SDFFeatures::ConstructSdfLink(
   const ignition::math::Inertiald &sdfInertia = _sdfLink.Inertial();
   bodyProperties.mInertia.setMass(sdfInertia.MassMatrix().Mass());
 
-  // TODO(addisu) Resolve the pose of inertials when frame information is
-  // availabile for ignition::math::Inertial
-  const Eigen::Matrix3d R_inertial{
-        math::eigen3::convert(sdfInertia.Pose().Rot())};
-
   const Eigen::Matrix3d I_link = math::eigen3::convert(sdfInertia.Moi());
 
   bodyProperties.mInertia.setMoment(I_link);

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -596,10 +596,7 @@ Identity SDFFeatures::ConstructSdfLink(
   const Eigen::Matrix3d R_inertial{
         math::eigen3::convert(sdfInertia.Pose().Rot())};
 
-  const Eigen::Matrix3d I_link =
-      R_inertial
-      * math::eigen3::convert(sdfInertia.Moi())
-      * R_inertial.inverse();
+  const Eigen::Matrix3d I_link = math::eigen3::convert(sdfInertia.Moi());
 
   bodyProperties.mInertia.setMoment(I_link);
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a bug in moment of inertia calculation

## Summary

When loading a model from SDF in the dartsim plugin, the moment of inertia matrix is currently applying any rotations in the `//inertial/pose` two times, since the rotations are applied explicitly in SDFFeatures.cc, but they are already applied in [math::Inertial::Moi](https://github.com/gazebosim/gz-math/blob/ign-math6/include/ignition/math/Inertial.hh#L131-L132).

I confirmed the bug with a slightly modified version of the [inertia_rotations](https://github.com/osrf/gazebo/blob/gazebo11/test/worlds/inertia_rotations.world) test world from gazebo classic. That world has multiple 1x4x9 boxes with identical inertia values that are expressed with different inertial pose rotations. The boxes are initially standing up on a ground plane. Setting gravity to `[2, 0, -9.8]` causes the boxes to tip over, and they should move at the same rate and hit the ground at the same time. This works properly in gazebo-classic with DART but not fortress or citadel.

I'll upload a copy of the example world for use with fortress as well as screen captures of my testing and then mark this ready for review.

* https://github.com/gazebosim/gz-physics/blob/fd4fead203ef5da7743a48e501e575a0c688cbaf/dartsim/worlds/inertia_rotations_ign.world
* ![inertia_pose_rotations_ign_fortress](https://user-images.githubusercontent.com/3650755/177665173-7a96010a-d6e2-4fb7-bca3-6a6d9ce0539c.png)
* ![inertia_pose_rotations_ign_gazebo11](https://user-images.githubusercontent.com/3650755/177665222-dbc8c9c1-3a1d-45e4-aaec-51a707be0c4e.png)



## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
