### PR TITLE
dartsim: support non-tree kinematics in AttachFixedJoint

### DIFF
--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -372,6 +372,7 @@ class Base : public Implements3d<FeatureList<Feature>>
     // First create a new body node with FreeJoint and a unique name based
     // on the number of welded miror nodes.
     dart::dynamics::BodyNode::Properties weldedBodyProperties;
+    weldedBodyProperties.mIsCollidable = false;
     {
       std::size_t weldedBodyCount = _link->weldedNodes.size();
       weldedBodyProperties.mName =

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -417,6 +417,7 @@ class Base : public Implements3d<FeatureList<Feature>>
       }
     }
 
+    this->linkByWeldedNode[pairJointBodyNode.second] = _link;
     return pairJointBodyNode.second;
   }
 
@@ -523,6 +524,10 @@ class Base : public Implements3d<FeatureList<Feature>>
   /// to the BodyNode object. This is useful for keeping track of BodyNodes even
   /// as they move to other skeletons.
   public: std::unordered_map<std::string, DartBodyNode*> linksByName;
+
+  /// \brief Map from welded body nodes to the LinkInfo for the original link
+  /// they are welded to. This is useful when detaching joints.
+  public: std::unordered_map<DartBodyNode*, LinkInfo*> linkByWeldedNode;
 };
 
 }

--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -455,7 +455,7 @@ Identity JointFeatures::AttachFixedJoint(
     const std::string &_name)
 {
   auto linkInfo = this->ReferenceInterface<LinkInfo>(_childID);
-  DartBodyNode *const bn = linkInfo->link.get();
+  DartBodyNode *bn = linkInfo->link.get();
   dart::dynamics::WeldJoint::Properties properties;
   properties.mName = _name;
 
@@ -465,8 +465,8 @@ Identity JointFeatures::AttachFixedJoint(
   if (bn->getParentJoint()->getType() != "FreeJoint")
   {
     // child already has a parent joint
-    // TODO(scpeters): use a WeldJointConstraint between the two bodies
-    return this->GenerateInvalidId();
+    // split and weld the child body node, and attach to the new welded node
+    bn = SplitAndWeldLink(linkInfo);
   }
 
   {

--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -377,12 +377,24 @@ void JointFeatures::DetachJoint(const Identity &_jointId)
           dart::dynamics::Frame::World(),
           dart::dynamics::Frame::World());
 
-  if (!this->links.HasEntity(child))
+  LinkInfo *childLinkInfo;
+  if (this->links.HasEntity(child))
   {
+    childLinkInfo = this->links.at(child).get();
+  }
+  else if (this->linkByWeldedNode.find(child) !=
+           this->linkByWeldedNode.end())
+  {
+    childLinkInfo = this->linkByWeldedNode.at(child);
+  }
+  else
+  {
+    ignerr << "Could not find LinkInfo for child link [" << child->getName()
+           << "] when detaching joint "
+           << "[" << joint->getName() << "]. Joint detaching failed."
+           << std::endl;
     return;
   }
-
-  auto childLinkInfo = this->links.at(child);
 
   dart::dynamics::SkeletonPtr skeleton;
   {

--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -386,6 +386,10 @@ void JointFeatures::DetachJoint(const Identity &_jointId)
            this->linkByWeldedNode.end())
   {
     childLinkInfo = this->linkByWeldedNode.at(child);
+    this->MergeLinkAndWeldedBody(childLinkInfo, child);
+    this->linkByWeldedNode.erase(child);
+    child->remove();
+    return;
   }
   else
   {

--- a/dartsim/src/JointFeatures_TEST.cc
+++ b/dartsim/src/JointFeatures_TEST.cc
@@ -883,6 +883,142 @@ TEST_F(JointFeaturesFixture, JointAttachDetach)
   EXPECT_NEAR(0.0, dartBody2->getLinearVelocity().z(), 1e-3);
 }
 
+////////////////////////////////////////////////
+// Essentially what happens is there are two floating boxes and a box in the
+// middle that's resting. We start the system out by creating the two
+// fixed joints between the boxes resting on the big box. The middle box will
+// now have two parents. However there should be no movement as the middle box
+// will be holding the other two boxes that are floating in mid air. We run
+// this for 100 steps to make sure that there is no movement. This is because
+// the middle box is holding on to the two side boxes. Then we release the
+// joints the two boxes should fall away.
+TEST_F(JointFeaturesFixture, JointAttachMultiple)
+{
+  sdf::Root root;
+  const sdf::Errors errors =
+      root.Load(TEST_WORLD_DIR "joint_constraint.sdf");
+  ASSERT_TRUE(errors.empty()) << errors.front();
+
+  auto world = this->engine->ConstructWorld(*root.WorldByIndex(0));
+  dart::simulation::WorldPtr dartWorld = world->GetDartsimWorld();
+  ASSERT_NE(nullptr, dartWorld);
+
+  // M1 and M3 are floating boxes
+  const std::string modelName1{"M1"};
+  const std::string modelName2{"M2"};
+  const std::string modelName3{"M3"};
+  const std::string bodyName{"link"};
+
+  auto model1 = world->GetModel(modelName1);
+  auto model2 = world->GetModel(modelName2);
+  auto model3 = world->GetModel(modelName3);
+
+  auto model1Body = model1->GetLink(bodyName);
+  auto model2Body = model2->GetLink(bodyName);
+  auto model3Body = model3->GetLink(bodyName);
+
+  const dart::dynamics::SkeletonPtr skeleton1 =
+      dartWorld->getSkeleton(modelName1);
+  const dart::dynamics::SkeletonPtr skeleton2 =
+      dartWorld->getSkeleton(modelName2);
+  const dart::dynamics::SkeletonPtr skeleton3 =
+      dartWorld->getSkeleton(modelName3);
+  ASSERT_NE(nullptr, skeleton1);
+  ASSERT_NE(nullptr, skeleton2);
+  ASSERT_NE(nullptr, skeleton3);
+
+  auto *dartBody1 = skeleton1->getBodyNode(bodyName);
+  auto *dartBody2 = skeleton2->getBodyNode(bodyName);
+  auto *dartBody3 = skeleton3->getBodyNode(bodyName);
+
+  ASSERT_NE(nullptr, dartBody1);
+  ASSERT_NE(nullptr, dartBody2);
+  ASSERT_NE(nullptr, dartBody3);
+
+  const math::Pose3d initialModel1Pose(0, -0.2, 0.45, 0, 0, 0);
+  const math::Pose3d initialModel2Pose(0, 0.2, 0.45, 0, 0, 0);
+  const math::Pose3d initialModel3Pose(0, 0.6, 0.45, 0, 0, 0);
+
+  EXPECT_EQ(initialModel1Pose,
+            math::eigen3::convert(dartBody1->getWorldTransform()));
+  EXPECT_EQ(initialModel2Pose,
+            math::eigen3::convert(dartBody2->getWorldTransform()));
+  EXPECT_EQ(initialModel3Pose,
+            math::eigen3::convert(dartBody3->getWorldTransform()));
+
+  physics::ForwardStep::Output output;
+  physics::ForwardStep::State state;
+  physics::ForwardStep::Input input;
+
+  // Create the first joint. This should be a normal fixed joint.
+  const auto poseParent1 = dartBody1->getTransform();
+  const auto poseChild1 = dartBody2->getTransform();
+  auto poseParentChild1 = poseParent1.inverse() * poseChild1;
+  auto fixedJoint1 = model2Body->AttachFixedJoint(model1Body);
+  fixedJoint1->SetTransformFromParent(poseParentChild1);
+
+  EXPECT_EQ(initialModel1Pose,
+            math::eigen3::convert(dartBody1->getWorldTransform()));
+  EXPECT_EQ(initialModel2Pose,
+            math::eigen3::convert(dartBody2->getWorldTransform()));
+  EXPECT_EQ(initialModel3Pose,
+            math::eigen3::convert(dartBody3->getWorldTransform()));
+
+  // Create the second joint. This should be a WeldJoint constraint
+  const auto poseParent2 = dartBody3->getTransform();
+  const auto poseChild2 = dartBody2->getTransform();
+  auto poseParentChild2 = poseParent2.inverse() * poseChild2;
+  auto fixedJoint2 = model2Body->AttachFixedJoint(model3Body);
+  fixedJoint2->SetTransformFromParent(poseParentChild2);
+
+  EXPECT_EQ(initialModel1Pose,
+            math::eigen3::convert(dartBody1->getWorldTransform()));
+  EXPECT_EQ(initialModel2Pose,
+            math::eigen3::convert(dartBody2->getWorldTransform()));
+  EXPECT_EQ(initialModel3Pose,
+            math::eigen3::convert(dartBody3->getWorldTransform()));
+
+  const std::size_t numSteps = 100;
+  for (std::size_t i = 0; i < numSteps; ++i)
+  {
+    world->Step(output, state, input);
+
+    // Expect all the bodies to be at rest.
+    // (since they're held in place by the joints)
+    math::Vector3d body1LinearVelocity =
+        math::eigen3::convert(dartBody1->getLinearVelocity());
+    math::Vector3d body2LinearVelocity =
+        math::eigen3::convert(dartBody2->getLinearVelocity());
+    math::Vector3d body3LinearVelocity =
+        math::eigen3::convert(dartBody3->getLinearVelocity());
+    EXPECT_NEAR(0.0, body1LinearVelocity.Z(), 1e-7);
+    EXPECT_NEAR(0.0, body2LinearVelocity.Z(), 1e-7);
+    EXPECT_NEAR(0.0, body3LinearVelocity.Z(), 1e-7);
+  }
+
+  // Detach the joints. M1 and M3 should fall as there is now nothing stopping
+  // them from falling.
+  fixedJoint1->Detach();
+  fixedJoint2->Detach();
+
+  for (std::size_t i = 0; i < numSteps; ++i)
+  {
+    world->Step(output, state, input);
+
+    // Expect the middle box to be still as it is already at rest.
+    // Expect the two side boxes to fall away.
+    math::Vector3d body1LinearVelocity =
+        math::eigen3::convert(dartBody1->getLinearVelocity());
+    math::Vector3d body2LinearVelocity =
+        math::eigen3::convert(dartBody2->getLinearVelocity());
+    math::Vector3d body3LinearVelocity =
+        math::eigen3::convert(dartBody3->getLinearVelocity());
+    EXPECT_GT(0, body1LinearVelocity.Z());
+    EXPECT_NEAR(0.0, body2LinearVelocity.Z(), 1e-7);
+    EXPECT_GT(0, body3LinearVelocity.Z());
+  }
+}
+
 /////////////////////////////////////////////////
 // Expectations on number of links before/after attach/detach
 TEST_F(JointFeaturesFixture, LinkCountsInJointAttachDetach)

--- a/dartsim/src/JointFeatures_TEST.cc
+++ b/dartsim/src/JointFeatures_TEST.cc
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <iostream>
 
 #include <ignition/physics/FindFeatures.hh>
@@ -949,6 +950,11 @@ TEST_F(JointFeaturesFixture, JointAttachMultiple)
   physics::ForwardStep::Output output;
   physics::ForwardStep::State state;
   physics::ForwardStep::Input input;
+  // 1 ms time step
+  const double dt = 0.001;
+  auto dur = std::chrono::duration<double>(dt);
+  input.Get<std::chrono::steady_clock::duration>() =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(dur);
 
   // Create the first joint. This should be a normal fixed joint.
   const auto poseParent1 = dartBody1->getTransform();
@@ -1013,9 +1019,9 @@ TEST_F(JointFeaturesFixture, JointAttachMultiple)
         math::eigen3::convert(dartBody2->getLinearVelocity());
     math::Vector3d body3LinearVelocity =
         math::eigen3::convert(dartBody3->getLinearVelocity());
-    EXPECT_GT(0, body1LinearVelocity.Z());
+    EXPECT_NEAR(dt * (i + 1) * -9.81, body1LinearVelocity.Z(), 1e-3);
     EXPECT_NEAR(0.0, body2LinearVelocity.Z(), 1e-7);
-    EXPECT_GT(0, body3LinearVelocity.Z());
+    EXPECT_NEAR(dt * (i + 1) * -9.81, body3LinearVelocity.Z(), 1e-3);
   }
 }
 

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -640,7 +640,7 @@ Identity SDFFeatures::ConstructSdfLink(
   const std::string fullName = ::sdf::JoinName(
       world->getName(),
       ::sdf::JoinName(modelInfo.model->getName(), bn->getName()));
-  const std::size_t linkID = this->AddLink(bn, fullName, _modelID);
+  const std::size_t linkID = this->AddLink(bn, fullName, _modelID, sdfInertia);
   this->AddJoint(joint);
 
   auto linkIdentity = this->GenerateIdentity(linkID, this->links.at(linkID));

--- a/dartsim/worlds/joint_constraint.sdf
+++ b/dartsim/worlds/joint_constraint.sdf
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <model name="M1">
+      <pose>0 -0.2 0.45 0 0 0</pose>
+      <static>false</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="M2">
+      <pose>0 0.2 0.45 0 0 0</pose>
+      <static>false</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="M3">
+      <pose>0 0.6 0.45 0 0 0</pose>
+      <static>false</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="tabletop">
+      <pose>0 0.2 0.2 0 0 0</pose>
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

Alternative to #345 and #347 

## Summary

With inspiration from #345 and #347, this implements a variation on the approach from gazebo-classic for handling non-tree kinematics (including kinematic loops) with the reduced coordinate Featherstone formulation by splitting links and welding them back together with a constraint. This adds data to the `LinkInfo` struct and a `SplitAndWeldLink` helper function to `Base.hh`. The test made by @arjo129 is included as well.

This only implements support for kinematic loops in the `AttachFixedJoint` method, but it should be applicable in other `Attach*Joint` methods and the `ConstructSdfJoint` method to support non-tree kinematics in more cases.

This implementation differs slightly from the approach in gazebo-classic. In gazebo11, all joints that are created dynamically using [gazebo::physics::Model::CreateJoint](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1physics_1_1Model.html#aaf0402c1e9df1bc45ccecc135bf576af) use the approach of splitting and welding a link, even if the joint could simply be added as part of the existing Skeleton (see the call to `DARTModelPrivate::CreateLoopJointAndNodePair` in `DARTModel::CreateJointHelper` in [DARTModel.cc](https://github.com/osrf/gazebo/blob/gazebo11_11.11.0/gazebo/physics/dart/DARTModel.cc#L372-L373)). Within [DARTModlPrivate::CreateLoopJointAndNodePair](https://github.com/osrf/gazebo/blob/gazebo11_11.11.0/gazebo/physics/dart/DARTModelPrivate.hh#L147-L162), a new joint and node pair are created for the desired joint type by calling `DARTModelPrivate::CreateJointAndNodePair` and then welded to the desired child link with blended inertia by calling `DARTLink::AddSlaveBodyNode`.

In this implementation, the split-and-weld approach is only taken if the target child link already has a parent joint that is not FreeJoint. To minimize changes to the existing code, when an existing parent joint is detected, the split-and-weld is done first, by creating a new FreeJoint and node pair and passing it to the `SplitAndWeldLink` helper function, which blends the inertia between the nodes and creates a WeldJointConstraint. The newly welded body node is then moved to a WeldJoint using the `moveTo` API. This move requires the transform for the WeldJointConstraint to be updated to ensure consistency.

UPDATE: with thanks to @azeey for the changes in #367, the welded links are now properly removed when joints are detached.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
