### PR TITLE
Added Common test

### DIFF
--- a/bullet/src/EntityManagementFeatures.cc
+++ b/bullet/src/EntityManagementFeatures.cc
@@ -168,6 +168,104 @@ bool EntityManagementFeatures::RemoveModelByName(
   return false;
 }
 
+const std::string &EntityManagementFeatures::GetEngineName(const Identity &) const
+{
+  static const std::string engineName = "bullet";
+  return engineName;
+}
+
+std::size_t EntityManagementFeatures::GetEngineIndex(const Identity &) const
+{
+  return 0;
+}
+
+std::size_t EntityManagementFeatures::GetWorldCount(const Identity &) const
+{
+  return worlds.size();
+}
+Identity EntityManagementFeatures::GetWorld(
+    const Identity &, std::size_t _worldIndex) const
+{
+}
+
+Identity EntityManagementFeatures::GetWorld(
+    const Identity &, const std::string &_worldName) const {}
+const std::string &EntityManagementFeatures::GetWorldName(
+    const Identity &_worldID) const {}
+
+std::size_t EntityManagementFeatures::GetWorldIndex(const Identity &_worldID) const {}
+
+Identity EntityManagementFeatures::GetEngineOfWorld(const Identity &_worldID) const {}
+
+std::size_t EntityManagementFeatures::GetModelCount(
+    const Identity &_worldID) const {}
+
+Identity EntityManagementFeatures::GetModel(
+    const Identity &_worldID, std::size_t _modelIndex) const {}
+
+Identity EntityManagementFeatures::GetModel(
+    const Identity &_worldID, const std::string &_modelName) const {}
+
+const std::string &EntityManagementFeatures::GetModelName(
+    const Identity &_modelID) const {}
+
+std::size_t EntityManagementFeatures::GetModelIndex(const Identity &_modelID) const {}
+
+Identity EntityManagementFeatures::GetWorldOfModel(const Identity &_modelID) const {}
+
+std::size_t EntityManagementFeatures::GetNestedModelCount(
+  const Identity &_modelID) const {}
+
+Identity EntityManagementFeatures::GetNestedModel(
+  const Identity &_modelID, std::size_t _modelIndex) const {}
+
+Identity EntityManagementFeatures::GetNestedModel(
+  const Identity &_modelID, const std::string &_modelName) const {}
+
+std::size_t EntityManagementFeatures::GetLinkCount(const Identity &_modelID) const {}
+
+Identity EntityManagementFeatures::GetLink(
+    const Identity &_modelID, std::size_t _linkIndex) const {}
+
+Identity EntityManagementFeatures::GetLink(
+    const Identity &_modelID, const std::string &_linkName) const {}
+
+std::size_t EntityManagementFeatures::GetJointCount(const Identity &_modelID) const {}
+
+Identity EntityManagementFeatures::GetJoint(
+    const Identity &_modelID, std::size_t _jointIndex) const {}
+
+Identity EntityManagementFeatures::GetJoint(
+    const Identity &_modelID, const std::string &_jointName) const {}
+
+const std::string &EntityManagementFeatures::GetLinkName(
+    const Identity &_linkID) const {}
+
+std::size_t EntityManagementFeatures::GetLinkIndex(const Identity &_linkID) const {}
+
+Identity EntityManagementFeatures::GetModelOfLink(const Identity &_linkID) const {}
+
+std::size_t EntityManagementFeatures::GetShapeCount(const Identity &_linkID) const {}
+
+Identity EntityManagementFeatures::GetShape(
+    const Identity &_linkID, std::size_t _shapeIndex) const {}
+
+Identity EntityManagementFeatures::GetShape(
+    const Identity &_linkID, const std::string &_shapeName) const {}
+
+const std::string &EntityManagementFeatures::GetJointName(
+    const Identity &_jointID) const {}
+
+std::size_t EntityManagementFeatures::GetJointIndex(const Identity &_jointID) const {}
+
+Identity EntityManagementFeatures::GetModelOfJoint(const Identity &_jointID) const {}
+
+const std::string &EntityManagementFeatures::GetShapeName(
+    const Identity &_shapeID) const {}
+
+std::size_t EntityManagementFeatures::GetShapeIndex(const Identity &_shapeID) const {}
+
+Identity EntityManagementFeatures::GetLinkOfShape(const Identity &_shapeID) const {}
 }  // namespace bullet
 }  // namespace physics
 }  // namespace gz

--- a/bullet/src/EntityManagementFeatures.hh
+++ b/bullet/src/EntityManagementFeatures.hh
@@ -32,6 +32,7 @@ namespace physics {
 namespace bullet {
 
 struct EntityManagementFeatureList : gz::physics::FeatureList<
+  GetEntities,
   RemoveModelFromWorld,
   ConstructEmptyWorldFeature
 > { };
@@ -56,6 +57,96 @@ class EntityManagementFeatures :
   // ----- Construct empty entities -----
   public: Identity ConstructEmptyWorld(
       const Identity &_engineID, const std::string & _name) override;
+
+  // ----- Get entities -----
+  public: const std::string &GetEngineName(const Identity &) const override;
+  public: std::size_t GetEngineIndex(const Identity &) const override;
+
+  public: std::size_t GetWorldCount(const Identity &) const override;
+
+  public: Identity GetWorld(
+      const Identity &, std::size_t _worldIndex) const override;
+
+  public: Identity GetWorld(
+      const Identity &, const std::string &_worldName) const override;
+
+  public: const std::string &GetWorldName(
+      const Identity &_worldID) const override;
+
+  public: std::size_t GetWorldIndex(const Identity &_worldID) const override;
+
+  public: Identity GetEngineOfWorld(const Identity &_worldID) const override;
+
+  public: std::size_t GetModelCount(
+      const Identity &_worldID) const override;
+
+  public: Identity GetModel(
+      const Identity &_worldID, std::size_t _modelIndex) const override;
+
+  public: Identity GetModel(
+      const Identity &_worldID, const std::string &_modelName) const override;
+
+  public: const std::string &GetModelName(
+      const Identity &_modelID) const override;
+
+  public: std::size_t GetModelIndex(const Identity &_modelID) const override;
+
+  public: Identity GetWorldOfModel(const Identity &_modelID) const override;
+
+  public: std::size_t GetNestedModelCount(
+    const Identity &_modelID) const override;
+
+  public: Identity GetNestedModel(
+    const Identity &_modelID, std::size_t _modelIndex) const override;
+
+  public: Identity GetNestedModel(
+    const Identity &_modelID, const std::string &_modelName) const override;
+
+  public: std::size_t GetLinkCount(const Identity &_modelID) const override;
+
+  public: Identity GetLink(
+      const Identity &_modelID, std::size_t _linkIndex) const override;
+
+  public: Identity GetLink(
+      const Identity &_modelID, const std::string &_linkName) const override;
+
+  public: std::size_t GetJointCount(const Identity &_modelID) const override;
+
+  public: Identity GetJoint(
+      const Identity &_modelID, std::size_t _jointIndex) const override;
+
+  public: Identity GetJoint(
+      const Identity &_modelID, const std::string &_jointName) const override;
+
+  public: const std::string &GetLinkName(
+      const Identity &_linkID) const override;
+
+  public: std::size_t GetLinkIndex(const Identity &_linkID) const override;
+
+  public: Identity GetModelOfLink(const Identity &_linkID) const override;
+
+  public: std::size_t GetShapeCount(const Identity &_linkID) const override;
+
+  public: Identity GetShape(
+      const Identity &_linkID, std::size_t _shapeIndex) const override;
+
+  public: Identity GetShape(
+      const Identity &_linkID, const std::string &_shapeName) const override;
+
+  public: const std::string &GetJointName(
+      const Identity &_jointID) const override;
+
+  public: std::size_t GetJointIndex(const Identity &_jointID) const override;
+
+  public: Identity GetModelOfJoint(const Identity &_jointID) const override;
+
+  public: const std::string &GetShapeName(
+      const Identity &_shapeID) const override;
+
+  public: std::size_t GetShapeIndex(const Identity &_shapeID) const override;
+
+  public: Identity GetLinkOfShape(const Identity &_shapeID) const override;
+
 };
 
 }  // namespace bullet

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,8 @@ include_directories (
   ${CMAKE_BINARY_DIR}/include
 )
 
+configure_file (test_integration_config.h.in ${PROJECT_BINARY_DIR}/test_integration_config.h)
+
 # Build gtest
 add_library(gtest STATIC gtest/src/gtest-all.cc)
 add_library(gtest_main STATIC gtest/src/gtest_main.cc)
@@ -47,6 +49,7 @@ ExternalProject_Add(
 add_subdirectory(benchmark)
 add_subdirectory(plugins)
 add_subdirectory(integration)
+add_subdirectory(new_integration)
 add_subdirectory(performance)
 add_subdirectory(regression)
 add_subdirectory(static_assert)

--- a/test/new_integration/CMakeLists.txt
+++ b/test/new_integration/CMakeLists.txt
@@ -1,0 +1,31 @@
+set(TEST_TYPE "INTEGRATIONNEW")
+
+set(tests
+  EntityManagementFeatures
+)
+
+link_directories(${PROJECT_BINARY_DIR}/test)
+
+set(PHYSICS_COMPONENTS bullet dartsim tpe)
+
+if (UNIX AND NOT APPLE)
+  configure_file(all_symbols_have_version.bash.in ${CMAKE_CURRENT_BINARY_DIR}/all_symbols_have_version.bash @ONLY)
+  add_test(NAME NEWINTEGRATION_versioned_symbols
+    COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/all_symbols_have_version.bash $<TARGET_FILE:${PROJECT_LIBRARY_TARGET_NAME}>)
+
+  foreach(comp ${PHYSICS_COMPONENTS})
+   set(comp_target_name "${PROJECT_LIBRARY_TARGET_NAME}-${comp}-plugin")
+   add_test(NAME "NEWINTEGRATION_versioned_symbols_${comp}"
+    COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/all_symbols_have_version.bash $<TARGET_FILE:${comp_target_name}>)
+  endforeach()
+endif()
+
+ign_build_tests(
+    TYPE
+      NEWINTEGRATION
+    SOURCES
+      ${tests}
+    LIB_DEPS
+      ignition-plugin${IGN_PLUGIN_VER}::loader
+      ignition-common5::ignition-common5
+)

--- a/test/new_integration/EntityManagementFeatures.cc
+++ b/test/new_integration/EntityManagementFeatures.cc
@@ -1,0 +1,316 @@
+/*
+ * Copyright (C) 2017 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_integration_config.h"  // NOLINT(build/include)
+
+#include <gz/common/Filesystem.hh>
+#include <gz/common/Console.hh>
+#include <gz/plugin/Loader.hh>
+
+#include <gz/physics/ConstructEmpty.hh>
+#include <gz/physics/Shape.hh>
+#include <gz/physics/FindFeatures.hh>
+#include <gz/physics/GetEntities.hh>
+#include <gz/physics/RequestEngine.hh>
+#include <gz/physics/RevoluteJoint.hh>
+#include "gz/physics/Joint.hh"
+#include "gz/physics/BoxShape.hh"
+#include <gz/physics/RemoveEntities.hh>
+
+class EntityManagementFeaturesTest:
+  public testing::Test,
+  public testing::WithParamInterface<const char *>
+{
+  // Documentation inherited
+  public: void SetUp() override
+  {
+    gz::common::Console::SetVerbosity(4);
+
+    gz::plugin::Loader loader;
+    std::string pluginPath = gz::common::joinPaths(GZ_PHYSICS_TEST_PLUGIN_PATH,
+      std::string("libignition-physics6-") + std::string(GetParam()) +
+      std::string("-plugin.so"));
+    loader.LoadLib(pluginPath);
+
+    std::string physicsPluginName = GetParam();
+    if (std::string(GetParam()) == "tpe")
+    {
+      physicsPluginName = GetParam() + std::string("plugin");
+    }
+
+    physicsPlugin =
+      loader.Instantiate(std::string("gz::physics::") +
+                         physicsPluginName +
+                         std::string("::Plugin"));
+  }
+
+  public: gz::plugin::PluginPtr physicsPlugin;
+};
+
+// The features that an engine must have to be loaded by this loader.
+using Features = gz::physics::FeatureList<
+    gz::physics::GetEngineInfo,
+    gz::physics::GetWorldFromEngine,
+    gz::physics::ConstructEmptyWorldFeature,
+    gz::physics::ConstructEmptyModelFeature,
+    gz::physics::GetModelFromWorld,
+    gz::physics::GetLinkFromModel,
+    gz::physics::ConstructEmptyLinkFeature,
+    gz::physics::AttachBoxShapeFeature,
+    gz::physics::GetShapeFromLink,
+    gz::physics::GetBoxShapeProperties,
+    gz::physics::RemoveEntities,
+    gz::physics::GetNestedModelFromModel,
+    gz::physics::ConstructEmptyNestedModelFeature
+    // gz::physics::AttachFixedJointFeature
+    // gz::physics::AttachRevoluteJointFeature,
+    // gz::physics::GetRevoluteJointProperties,
+    // gz::physics::GetBasicJointState
+>;
+
+// ** dartsim
+// GetEntities,
+// RemoveEntities,
+// ConstructEmptyWorldFeature,
+// ConstructEmptyModelFeature,
+// ConstructEmptyNestedModelFeature,
+// ConstructEmptyLinkFeature,
+// CollisionFilterMaskFeature
+
+// ** tpe
+// GetEngineInfo,
+// GetWorldFromEngine,
+// GetModelFromWorld,
+// GetNestedModelFromModel,
+// GetLinkFromModel,
+// GetShapeFromLink,
+// RemoveEntities,
+// ConstructEmptyWorldFeature,
+// ConstructEmptyModelFeature,
+// ConstructEmptyNestedModelFeature,
+// ConstructEmptyLinkFeature,
+// CollisionFilterMaskFeature
+
+using FeaturesBullet = gz::physics::FeatureList<
+  gz::physics::GetEntities,
+  gz::physics::RemoveModelFromWorld,
+  gz::physics::ConstructEmptyWorldFeature
+  // gz::physics::ConstructEmptyModelFeature
+>;
+
+// bullet
+// GetEntities,
+// RemoveModelFromWorld,
+// ConstructEmptyWorldFeature
+
+/////////////////////////////////////////////////
+TEST_P(EntityManagementFeaturesTest, ConstructEmptyWorld)
+{
+  auto commonTest = [&](auto engine)
+  {
+    ASSERT_NE(nullptr, engine);
+    EXPECT_TRUE(engine->GetName().find(GetParam()) != std::string::npos);
+    // EXPECT_EQ(0u, engine->GetIndex());
+    // EXPECT_EQ(0u, engine->GetWorldCount());
+  };
+
+  auto specificTest = [&](auto engine)
+  {
+    auto world = engine->ConstructEmptyWorld("empty world");
+    ASSERT_NE(nullptr, world);
+    EXPECT_EQ("empty world", world->GetName());
+    EXPECT_EQ(1u, engine->GetWorldCount());
+    // EXPECT_EQ(0u, world->GetIndex());
+    // EXPECT_EQ(0u, world->GetModelCount());
+
+    EXPECT_EQ(engine, world->GetEngine());
+    EXPECT_EQ(world, engine->GetWorld(0));
+    EXPECT_EQ(world, engine->GetWorld("empty world"));
+
+    auto model = world->ConstructEmptyModel("empty model");
+    ASSERT_NE(nullptr, model);
+    EXPECT_EQ("empty model", model->GetName());
+    EXPECT_EQ(world, model->GetWorld());
+    EXPECT_NE(model, world->ConstructEmptyModel("dummy"));
+
+    // auto nestedModel = model->ConstructEmptyNestedModel("empty nested model");
+    // ASSERT_NE(nullptr, nestedModel);
+    // EXPECT_EQ("empty nested model", nestedModel->GetName());
+    // EXPECT_EQ(1u, model->GetNestedModelCount());
+    // EXPECT_EQ(world, nestedModel->GetWorld());
+    // EXPECT_EQ(0u, model->GetIndex());
+    // EXPECT_EQ(nestedModel, model->GetNestedModel(0));
+    // EXPECT_EQ(nestedModel, model->GetNestedModel("empty nested model"));
+    // EXPECT_NE(nestedModel, nestedModel->ConstructEmptyNestedModel("dummy"));
+
+    auto link = model->ConstructEmptyLink("empty link");
+    ASSERT_NE(nullptr, link);
+    EXPECT_EQ("empty link", link->GetName());
+    EXPECT_EQ(model, link->GetModel());
+    EXPECT_NE(link, model->ConstructEmptyLink("dummy"));
+    EXPECT_EQ(0u, link->GetIndex());
+    EXPECT_EQ(model, link->GetModel());
+
+    // auto joint = link->AttachRevoluteJoint(nullptr);
+    // EXPECT_NEAR((Eigen::Vector3d::UnitX() - joint->GetAxis()).norm(), 0.0, 1e-6);
+    // EXPECT_DOUBLE_EQ(0.0, joint->GetPosition(0));
+
+    // joint->SetAxis(Eigen::Vector3d::UnitZ());
+    // EXPECT_NEAR((Eigen::Vector3d::UnitZ() - joint->GetAxis()).norm(), 0.0, 1e-6);
+
+    auto child = model->ConstructEmptyLink("child link");
+    EXPECT_EQ(2u, child->GetIndex());
+    EXPECT_EQ(model, child->GetModel());
+
+    const std::string boxName = "box";
+    const Eigen::Vector3d boxSize(0.1, 0.2, 0.3);
+    auto box = link->AttachBoxShape(boxName, boxSize);
+    EXPECT_EQ(boxName, box->GetName());
+    EXPECT_NEAR((boxSize - box->GetSize()).norm(), 0.0, 1e-6);
+
+    EXPECT_EQ(1u, link->GetShapeCount());
+    auto boxCopy = link->GetShape(0u);
+    EXPECT_EQ(box, boxCopy);
+
+
+    // auto meshLink = model->ConstructEmptyLink("mesh_link");
+    // meshLink->AttachFixedJoint(child, "fixed");
+    //
+    // const std::string meshFilename = gz::common::joinPaths(
+    //     GZ_PHYSICS_RESOURCE_DIR, "chassis.dae");
+    // auto &meshManager = *gz::common::MeshManager::Instance();
+    // auto *mesh = meshManager.Load(meshFilename);
+    //
+    // auto meshShape = meshLink->AttachMeshShape("chassis", *mesh);
+    // const auto originalMeshSize = mesh->Max() - mesh->Min();
+    // const auto meshShapeSize = meshShape->GetSize();
+  };
+
+  if (std::string(GetParam()) == "bullet")
+  {
+    auto engineBullet =
+        gz::physics::RequestEngine3d<FeaturesBullet>::From(physicsPlugin);
+    ASSERT_NE(nullptr, engineBullet);
+    commonTest(engineBullet);
+  }
+  else
+  {
+    auto engine =
+        gz::physics::RequestEngine3d<Features>::From(physicsPlugin);
+    ASSERT_NE(nullptr, engine);
+    commonTest(engine);
+    specificTest(engine);
+  }
+
+}
+
+TEST_P(EntityManagementFeaturesTest, RemoveEntities)
+{
+  auto commonTest = [&](auto engine)
+  {
+      ASSERT_NE(nullptr, engine);
+      if (std::string(GetParam()) == "bullet")
+        return;
+      auto world = engine->ConstructEmptyWorld("empty world");
+      ASSERT_NE(nullptr, world);
+  };
+
+  auto specificTest = [&](auto engine)
+  {
+    auto world = engine->ConstructEmptyWorld("empty world");
+    auto model = world->ConstructEmptyModel("empty model");
+    ASSERT_NE(nullptr, model);
+    auto modelAlias = world->GetModel(0);
+
+    model->Remove();
+    EXPECT_TRUE(model->Removed());
+    EXPECT_TRUE(modelAlias->Removed());
+    EXPECT_EQ(nullptr, world->GetModel(0));
+    EXPECT_EQ(nullptr, world->GetModel("empty model"));
+    EXPECT_EQ(0ul, world->GetModelCount());
+
+    auto model2 = world->ConstructEmptyModel("model2");
+    ASSERT_NE(nullptr, model2);
+    EXPECT_EQ(0ul, model2->GetIndex());
+    world->RemoveModel(0);
+    EXPECT_EQ(0ul, world->GetModelCount());
+
+    auto model3 = world->ConstructEmptyModel("model 3");
+    ASSERT_NE(nullptr, model3);
+    EXPECT_EQ(1u, world->GetModelCount());
+    world->RemoveModel("model 3");
+    EXPECT_EQ(0ul, world->GetModelCount());
+    EXPECT_EQ(nullptr, world->GetModel("model 3"));
+  };
+
+  if (std::string(GetParam()) == "bullet")
+  {
+    auto engineBullet =
+        gz::physics::RequestEngine3d<FeaturesBullet>::From(physicsPlugin);
+    commonTest(engineBullet);
+  }
+  else
+  {
+    auto engine =
+        gz::physics::RequestEngine3d<Features>::From(physicsPlugin);
+    commonTest(engine);
+    specificTest(engine);
+  }
+
+  //
+  // auto parentModel = world->ConstructEmptyModel("parent model");
+  // ASSERT_NE(nullptr, parentModel);
+  // EXPECT_EQ(0u, parentModel->GetNestedModelCount());
+  // auto nestedModel1 =
+  //     parentModel->ConstructEmptyNestedModel("empty nested model1");
+  // ASSERT_NE(nullptr, nestedModel1);
+  // EXPECT_EQ(1u, parentModel->GetNestedModelCount());
+  //
+  // EXPECT_TRUE(parentModel->RemoveNestedModel(0));
+  // EXPECT_EQ(0u, parentModel->GetNestedModelCount());
+  // EXPECT_TRUE(nestedModel1->Removed());
+  //
+  // auto nestedModel2 =
+  //     parentModel->ConstructEmptyNestedModel("empty nested model2");
+  // ASSERT_NE(nullptr, nestedModel2);
+  // EXPECT_EQ(nestedModel2, parentModel->GetNestedModel(0));
+  // EXPECT_TRUE(parentModel->RemoveNestedModel("empty nested model2"));
+  // EXPECT_EQ(0u, parentModel->GetNestedModelCount());
+  // EXPECT_TRUE(nestedModel2->Removed());
+  //
+  // auto nestedModel3 =
+  //     parentModel->ConstructEmptyNestedModel("empty nested model3");
+  // ASSERT_NE(nullptr, nestedModel3);
+  // EXPECT_EQ(nestedModel3, parentModel->GetNestedModel(0));
+  // EXPECT_TRUE(nestedModel3->Remove());
+  // EXPECT_EQ(0u, parentModel->GetNestedModelCount());
+  // EXPECT_TRUE(nestedModel3->Removed());
+  //
+  // auto nestedModel4 =
+  //     parentModel->ConstructEmptyNestedModel("empty nested model4");
+  // ASSERT_NE(nullptr, nestedModel4);
+  // EXPECT_EQ(nestedModel4, parentModel->GetNestedModel(0));
+  // // Remove the parent model and check that the nested model is removed as well
+  // EXPECT_TRUE(parentModel->Remove());
+  // EXPECT_TRUE(nestedModel4->Removed());
+}
+
+INSTANTIATE_TEST_CASE_P(EntityManagementFeatures, EntityManagementFeaturesTest,
+    PHYSICS_ENGINE_VALUES,
+    gz::physics::PrintToStringParam());

--- a/test/new_integration/all_symbols_have_version.bash.in
+++ b/test/new_integration/all_symbols_have_version.bash.in
@@ -1,0 +1,27 @@
+# Returns non-zero exit code if there are symbols which don't contain the project major version
+
+LIBPATH=$1
+VERSIONED_NS=v@PROJECT_VERSION_MAJOR@
+IGN_PROJECT=@IGN_DESIGNATION@
+
+# Sanity check - there should be at least one symbol
+NUM_SYMBOLS=$(nm $LIBPATH | grep -e "gz.*$IGN_PROJECT" | wc -l)
+
+if [ $NUM_SYMBOLS -eq 0 ]
+then
+  echo >&2 "ERROR: Did not find any symbols in the project library"
+  exit 1
+fi
+
+# There must be no unversioned symbols
+UNVERSIONED_SYMBOLS=$(nm $LIBPATH | grep -e "gz.*$IGN_PROJECT" | grep -e "$VERSIONED_NS" -v)
+UNVERSIONED_SYMBOL_CHARS=$(printf "$UNVERSIONED_SYMBOLS" | wc -m)
+
+if [ $UNVERSIONED_SYMBOL_CHARS -ne 0 ]
+then
+  echo >&2 "ERROR: Found unversioned symbols:\n$UNVERSIONED_SYMBOLS"
+  exit 1
+fi
+
+echo "No unversioned symbols found (num versioned symbols:$NUM_SYMBOLS)"
+exit 0

--- a/test/test_integration_config.h.in
+++ b/test/test_integration_config.h.in
@@ -1,0 +1,56 @@
+#ifndef GZ_PHYSICS_TEST_CONFIG_HH_
+#define GZ_PHYSICS_TEST_CONFIG_HH_
+
+#define PROJECT_SOURCE_PATH "${PROJECT_SOURCE_DIR}"
+#define PROJECT_BUILD_PATH "${PROJECT_BINARY_DIR}"
+#define GZ_PHYSICS_TEST_PLUGIN_PATH "${CMAKE_BINARY_DIR}/lib"
+
+/// \brief Helper macro to instantiate gtest for different engines
+#define PHYSICS_ENGINE_VALUES ::testing::ValuesIn(\
+    gz::physics::TestValues())
+
+static const std::vector<const char *> kPhysicsEngineTestValues{"bullet", "dartsim", "tpe"};
+
+#include <vector>
+#include <gz/common/Util.hh>
+
+namespace gz
+{
+  namespace physics
+  {
+    /// \brief Helper function used with INSTANTIATE_TEST_CASE_P.
+    struct PrintToStringParam
+    {
+      template<class T>
+      std::string operator()(const ::testing::TestParamInfo<T> &_info) const
+      {
+        return static_cast<std::string>(_info.param);
+      }
+    };
+
+    /// \brief Helper function used with ::testing::Values
+    /// Checks env variable for physics engine values to be used in tests.
+    /// If env variable exists, it overrides the default physics engine values
+    std::vector<const char *> TestValues()
+    {
+      std::string envTestValueStr;
+      if (!common::env("PHYSICS_ENGINE_VALUES", envTestValueStr))
+        return kPhysicsEngineTestValues;
+      static std::vector<std::string> physicsEngineEnvTestValues
+          = common::split(envTestValueStr, ",");
+      if (physicsEngineEnvTestValues.empty())
+      {
+        std::cerr << "Error parsing 'PHYSICS_ENGINE_VALUES'. "
+                  << "Using default test values" << std::endl;
+        return kPhysicsEngineTestValues;
+      }
+      std::vector<const char *> values;
+      values.resize(physicsEngineEnvTestValues.size());
+      for (unsigned int i = 0; i < physicsEngineEnvTestValues.size(); ++i)
+        values[i] = physicsEngineEnvTestValues[i].c_str();
+      return values;
+    }
+  }
+}
+
+#endif


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

## Summary

This draft PR try to set up a common arquitecture to test all physics engine under the same tests avoiding duplication and improving coverage.

The general idea is similar to `gz-rendering` with `GetParam()`, we will get the physics engine that we are testing and then we need to define the set of features associated to a specific physics engine (at compile time). Right now, Bullet supports a small set of features and TPE doesn't support joints. For this reason I used `auto` in the function signature of `commonTest` and `specificTest` to allow the compiler to compile test with less features that others.

I don't know if you have a better sugestion or improvements @mjcarroll @scpeters 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
