### PR TITLE
Use new Joint APIs for Parent/Child name

### DIFF
--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -127,10 +127,10 @@ Identity SDFFeatures::ConstructSdfModel(
     }
 
     const std::size_t parent = this->FindOrConstructLink(
-      modelIdentity, _sdfModel, sdfJoint->ParentLinkName());
+      modelIdentity, _sdfModel, sdfJoint->ParentName());
 
     const std::size_t child = this->FindOrConstructLink(
-      modelIdentity, _sdfModel, sdfJoint->ChildLinkName());
+      modelIdentity, _sdfModel, sdfJoint->ChildName());
 
     this->ConstructSdfJoint(modelIdentity, *sdfJoint, parent, child);
   }
@@ -329,11 +329,11 @@ Identity SDFFeatures::ConstructSdfJoint(
   const ::sdf::Model dummyEmptyModel;
 
   // Get the parent and child ids
-  const std::string parentLinkName = _sdfJoint.ParentLinkName();
+  const std::string parentLinkName = _sdfJoint.ParentName();
   std::size_t parentId =
     this->FindOrConstructLink(_modelID, dummyEmptyModel, parentLinkName);
 
-  const std::string childLinkName = _sdfJoint.ChildLinkName();
+  const std::string childLinkName = _sdfJoint.ChildName();
   std::size_t childId =
     this->FindOrConstructLink(_modelID, dummyEmptyModel, childLinkName);
 

--- a/bullet/src/SDFFeatures_TEST.cc
+++ b/bullet/src/SDFFeatures_TEST.cc
@@ -78,22 +78,22 @@ auto CreateTestModel(WorldPtr _world, const std::string &_model,
   {
     auto parent = model->ConstructLink(*_parentLink);
     EXPECT_NE(nullptr, parent);
-    sdfJoint.SetParentLinkName(_parentLink->Name());
+    sdfJoint.SetParentName(_parentLink->Name());
   }
   else
   {
-    sdfJoint.SetParentLinkName("world");
+    sdfJoint.SetParentName("world");
   }
 
   if (_childLink)
   {
     auto child = model->ConstructLink(*_childLink);
     EXPECT_NE(nullptr, child);
-    sdfJoint.SetChildLinkName(_childLink->Name());
+    sdfJoint.SetChildName(_childLink->Name());
   }
   else
   {
-    sdfJoint.SetChildLinkName("world");
+    sdfJoint.SetChildName("world");
   }
 
   auto joint0 = model->ConstructJoint(sdfJoint);

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -507,7 +507,7 @@ Identity SDFFeatures::ConstructSdfModelImpl(
     ::sdf::Errors errors = sdfJoint->ResolveParentLink(parentLinkName);
     if (!errors.empty())
     {
-      gzerr << "The link of the parent frame [" << sdfJoint->ParentLinkName()
+      gzerr << "The link of the parent frame [" << sdfJoint->ParentName()
              << "] of joint [" << sdfJoint->Name() << "] in model ["
              << modelName
              << "] could not be resolved. The joint will not be constructed\n";
@@ -521,7 +521,7 @@ Identity SDFFeatures::ConstructSdfModelImpl(
     errors = sdfJoint->ResolveChildLink(childLinkName);
     if (!errors.empty())
     {
-      gzerr << "The link of the child frame [" << sdfJoint->ChildLinkName()
+      gzerr << "The link of the child frame [" << sdfJoint->ChildName()
              << "] of joint [" << sdfJoint->Name() << "] in model ["
              << modelName
              << "] could not be resolved. The joint will not be constructed\n";
@@ -536,7 +536,7 @@ Identity SDFFeatures::ConstructSdfModelImpl(
     if (nullptr == parentSdfLink && parentLinkName != "world")
     {
       gzerr << "The link [" << parentLinkName << "] of the parent frame ["
-             << sdfJoint->ParentLinkName() << "] of joint [" << sdfJoint->Name()
+             << sdfJoint->ParentName() << "] of joint [" << sdfJoint->Name()
              << "] in model [" << modelName
              << "] could not be resolved. The joint will not be constructed\n";
       continue;
@@ -546,7 +546,7 @@ Identity SDFFeatures::ConstructSdfModelImpl(
     if (nullptr == childSdfLink)
     {
       gzerr << "The link [" << childLinkName << "] of the child frame ["
-             << sdfJoint->ChildLinkName() << "] of joint [" << sdfJoint->Name()
+             << sdfJoint->ChildName() << "] of joint [" << sdfJoint->Name()
              << "] in model [" << modelName
              << "] could not be resolved. The joint will not be constructed\n";
       continue;
@@ -557,7 +557,7 @@ Identity SDFFeatures::ConstructSdfModelImpl(
 
     if (nullptr == parent && parentLinkName != "world")
     {
-      gzerr << "The parent [" << sdfJoint->ParentLinkName() << "] of joint ["
+      gzerr << "The parent [" << sdfJoint->ParentName() << "] of joint ["
              << sdfJoint->Name() << "] in model [" << modelName
              << "] was not found. The joint will not be constructed\n";
       continue;
@@ -684,7 +684,7 @@ Identity SDFFeatures::ConstructSdfJoint(
 {
   const auto &modelInfo = *this->ReferenceInterface<ModelInfo>(_modelID);
 
-  if (_sdfJoint.ChildLinkName() == "world")
+  if (_sdfJoint.ChildName() == "world")
   {
     gzerr << "Asked to create a joint with the world as the child in model "
            << "[" << modelInfo.model->getName() << "]. This is currently not "
@@ -707,7 +707,7 @@ Identity SDFFeatures::ConstructSdfJoint(
   // Since (1) is an error that should be reported and (2) might be a valid use
   // case, the solution is, when an error is encountered, we first assume (2)
   // and set the parent and child link names to whatever returned from
-  // sdf::Joint::ParentLinkName() and sdf::Joint::ChildLinkName respectively.
+  // sdf::Joint::ParentName() and sdf::Joint::ChildName respectively.
   // Then we check if a body node with the same relative name exists in DART. If
   // the link is nested inside a child model, it will be necessary to split the
   // name to identify the correct parent skeleton. If the corresponding body
@@ -720,9 +720,9 @@ Identity SDFFeatures::ConstructSdfJoint(
   const auto resolveParentErrors = _sdfJoint.ResolveParentLink(parentLinkName);
   if (!resolveParentErrors.empty()) {
     // It's possible this wasn't created from an sdf::Model object, like
-    // SDFFeatures_TEST.WorldIsParentOrChild. Try using raw ParentLinkName() in
+    // SDFFeatures_TEST.WorldIsParentOrChild. Try using raw ParentName() in
     // that case
-    parentLinkName = _sdfJoint.ParentLinkName();
+    parentLinkName = _sdfJoint.ParentName();
   }
 
   dart::dynamics::BodyNode * const parent =
@@ -731,7 +731,7 @@ Identity SDFFeatures::ConstructSdfJoint(
   std::string childLinkName;
   const auto childResolveErrors = _sdfJoint.ResolveChildLink(childLinkName);
   if (!childResolveErrors.empty()) {
-    childLinkName = _sdfJoint.ChildLinkName();
+    childLinkName = _sdfJoint.ChildName();
   }
 
   dart::dynamics::BodyNode * const child =
@@ -739,7 +739,7 @@ Identity SDFFeatures::ConstructSdfJoint(
 
   if (nullptr == parent && parentLinkName != "world")
   {
-    gzerr << "The link of the parent frame [" << _sdfJoint.ParentLinkName()
+    gzerr << "The link of the parent frame [" << _sdfJoint.ParentName()
            << "] with resolved link name [" << parentLinkName
            << "] of joint [" << _sdfJoint.Name()
            << "] could not be resolved. The joint will not be constructed\n";
@@ -747,7 +747,7 @@ Identity SDFFeatures::ConstructSdfJoint(
   }
   if (nullptr == child)
   {
-    gzerr << "The link of the child frame [" << _sdfJoint.ChildLinkName()
+    gzerr << "The link of the child frame [" << _sdfJoint.ChildName()
            << "] with resolved link name [" << childLinkName
            << "] of joint [" << _sdfJoint.Name() << "] in model ["
            << modelInfo.model->getName()
@@ -978,8 +978,8 @@ Identity SDFFeatures::ConstructSdfJoint(
 {
   // if a specified link is named "world" but cannot be found, we'll assume the
   // joint is connected to the world
-  bool worldParent = (!_parent && _sdfJoint.ParentLinkName() == "world");
-  bool worldChild = (!_child && _sdfJoint.ChildLinkName() == "world");
+  bool worldParent = (!_parent && _sdfJoint.ParentName() == "world");
+  bool worldChild = (!_child && _sdfJoint.ChildName() == "world");
 
   if (worldChild)
   {
@@ -996,8 +996,8 @@ Identity SDFFeatures::ConstructSdfJoint(
   {
     {
       std::stringstream msg;
-      msg << "Asked to create a joint from link [" << _sdfJoint.ParentLinkName()
-          << "] to link [" << _sdfJoint.ChildLinkName() << "] in the model "
+      msg << "Asked to create a joint from link [" << _sdfJoint.ParentName()
+          << "] to link [" << _sdfJoint.ChildName() << "] in the model "
           << "[" << _modelInfo.model->getName() << "], but ";
 
       if (!_parent && !worldParent)

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -272,8 +272,8 @@ WorldPtr LoadWorldPiecemeal(const std::string &_world)
       newSdfJoint.SetRawPose(ResolveSdfPose(sdfJoint->SemanticPose()));
       newSdfJoint.SetThreadPitch(sdfJoint->ThreadPitch());
 
-      newSdfJoint.SetParentLinkName(resolvedParentLinkName);
-      newSdfJoint.SetChildLinkName(resolvedChildLinkName);
+      newSdfJoint.SetParentName(resolvedParentLinkName);
+      newSdfJoint.SetChildName(resolvedChildLinkName);
 
       physModel->ConstructJoint(newSdfJoint);
     }
@@ -473,22 +473,22 @@ auto CreateTestModel(WorldPtr _world, const std::string &_model,
   {
     auto parent = model->ConstructLink(*_parentLink);
     EXPECT_NE(nullptr, parent);
-    sdfJoint.SetParentLinkName(_parentLink->Name());
+    sdfJoint.SetParentName(_parentLink->Name());
   }
   else
   {
-    sdfJoint.SetParentLinkName("world");
+    sdfJoint.SetParentName("world");
   }
 
   if (_childLink)
   {
     auto child = model->ConstructLink(*_childLink);
     EXPECT_NE(nullptr, child);
-    sdfJoint.SetChildLinkName(_childLink->Name());
+    sdfJoint.SetChildName(_childLink->Name());
   }
   else
   {
-    sdfJoint.SetChildLinkName("world");
+    sdfJoint.SetChildName("world");
   }
 
   auto joint0 = model->ConstructJoint(sdfJoint);


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to gazebosim/sdformat#1053.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
