### PR TITLE
Restore CXX_STANDARD export from core library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 gz_get_libsources_and_unittests(sources gtest_sources)
-gz_create_core_library(SOURCES ${sources}) 
+gz_create_core_library(SOURCES ${sources} CXX_STANDARD 17)
 
 
 target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}


### PR DESCRIPTION
# 🦟 Bug fix

Restore `CXX_STANDARD` export in core library that was removed in #1059 and also tests https://github.com/gazebosim/gz-cmake/pull/273

## Summary

Similar to https://github.com/gazebosim/sdformat/pull/1072, this is mainly testing https://github.com/gazebosim/gz-cmake/pull/273 using the `ci_matching_branch/` trickery with https://github.com/osrf/homebrew-simulation/commit/406b74a7e7c19591d62437fb1d57d1dadd012e3d and https://github.com/gazebo-tooling/gazebodistro/commit/b4274333b8b0810cd72368c2372895bd1acd9b2a, but it does make a small improvement of its own, restoring the `CXX_STANDARD` export.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
