### PR TITLE
Use GzBullet instead of IgnBullet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ gz_find_package(DART
 
 #--------------------------------------
 # Find bullet for the bullet plugin wrapper
-gz_find_package(IgnBullet
+gz_find_package(GzBullet
   VERSION 2.87
   REQUIRED_BY bullet
   PKGCONFIG bullet

--- a/bullet/CMakeLists.txt
+++ b/bullet/CMakeLists.txt
@@ -5,7 +5,7 @@ gz_add_component(bullet INTERFACE
   GET_TARGET_NAME features)
 
 link_directories(${BULLET_LIBRARY_DIRS})
-target_link_libraries(${features} INTERFACE IgnBullet::IgnBullet)
+target_link_libraries(${features} INTERFACE GzBullet::GzBullet)
 
 gz_get_libsources_and_unittests(sources test_sources)
 


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Bug fix

## Summary

Remove warning, Use `GzBullet` instead of `IgnBullet`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

