### PR TITLE
Add code coverage ignore file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,10 +86,10 @@ set(IGNITION_PHYSICS_ENGINE_INSTALL_DIR
 #============================================================================
 # Configure the build
 #============================================================================
-ign_configure_build(QUIT_IF_BUILD_ERRORS
-  COMPONENTS sdf mesh dartsim tpe)
 configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
                ${PROJECT_BINARY_DIR}/coverage.ignore)
+ign_configure_build(QUIT_IF_BUILD_ERRORS
+  COMPONENTS sdf mesh dartsim tpe)
 
 #============================================================================
 # Create package information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(ignition-physics2 VERSION 2.5.0)
 #============================================================================
 # Find ignition-cmake
 #============================================================================
-find_package(ignition-cmake2 2.12.0 REQUIRED)
+find_package(ignition-cmake2 2.14.0 REQUIRED)
 
 #============================================================================
 # Configure the project
@@ -88,6 +88,7 @@ set(IGNITION_PHYSICS_ENGINE_INSTALL_DIR
 #============================================================================
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS sdf mesh dartsim tpe)
+
 
 #============================================================================
 # Create package information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,6 @@ set(IGNITION_PHYSICS_ENGINE_INSTALL_DIR
 #============================================================================
 # Configure the build
 #============================================================================
-configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
-               ${PROJECT_BINARY_DIR}/coverage.ignore)
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS sdf mesh dartsim tpe)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,8 @@ set(IGNITION_PHYSICS_ENGINE_INSTALL_DIR
 #============================================================================
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS sdf mesh dartsim tpe)
-
+configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
+               ${PROJECT_BINARY_DIR}/coverage.ignore)
 
 #============================================================================
 # Create package information

--- a/coverage.ignore.in
+++ b/coverage.ignore.in
@@ -1,2 +1,1 @@
-tpe/lib/src/aabb_tree/AABB.h
-tpe/lib/src/aabb_tree/AABB.cc
+tpe/lib/src/aabb_tree/*

--- a/coverage.ignore.in
+++ b/coverage.ignore.in
@@ -1,0 +1,2 @@
+tpe/lib/src/aabb_tree/AABB.h
+tpe/lib/src/aabb_tree/AABB.cc


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# New feature

Part of [gz-sim#1575](https://github.com/gazebosim/gz-sim/issues/1575)

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add `coverage.ignore.in` to ignore vendor code in code coverage report. See [gz-cmake#279](https://github.com/gazebosim/gz-cmake/pull/279) for detail.

Remove vendor source files from Codecov and `build/`, `install/`, `/opt/ros/` folders from the local code coverage report. 


![20220719165940](https://user-images.githubusercontent.com/50132891/179855867-bb4be991-e435-45a8-8730-be7f5b19cf34.png)


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
