### PR TITLE
Fix bullet classic entity management

### DIFF
--- a/bullet/src/Base.hh
+++ b/bullet/src/Base.hh
@@ -57,6 +57,8 @@ struct WorldInfo
   std::shared_ptr<btBroadphaseInterface> broadphase;
   std::shared_ptr<btConstraintSolver> solver;
   std::shared_ptr<btDiscreteDynamicsWorld> world;
+  std::vector<std::size_t> models = {};
+  std::unordered_map<std::string, std::size_t> modelsByName = {};
 };
 
 struct ModelInfo
@@ -67,6 +69,9 @@ struct ModelInfo
   bool fixed;
   math::Pose3d pose;
   std::vector<std::size_t> links = {};
+  std::unordered_map<std::string, std::size_t> linksByName = {};
+  std::vector<std::size_t> joints = {};
+  std::unordered_map<std::string, std::size_t> jointsByName = {};
 };
 
 struct LinkInfo
@@ -81,6 +86,7 @@ struct LinkInfo
   std::shared_ptr<btDefaultMotionState> motionState;
   std::shared_ptr<btCompoundShape> collisionShape;
   std::shared_ptr<btRigidBody> link;
+  std::vector<std::size_t> shapes = {};
 };
 
 struct CollisionInfo
@@ -201,7 +207,10 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: inline Identity AddWorld(WorldInfo _worldInfo)
   {
     const auto id = this->GetNextEntity();
-    this->worlds[id] = std::make_shared<WorldInfo>(_worldInfo);
+    const auto world = std::make_shared<WorldInfo>(_worldInfo);
+    this->worlds[id] = world;
+    this->worldsByName[world->name] = id;
+    this->worldsByIndex.push_back(id);
     this->childIdToParentId.insert({id, -1});
     return this->GenerateIdentity(id, this->worlds.at(id));
   }
@@ -209,7 +218,11 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: inline Identity AddModel(std::size_t _worldId, ModelInfo _modelInfo)
   {
     const auto id = this->GetNextEntity();
-    this->models[id] = std::make_shared<ModelInfo>(_modelInfo);
+    const auto model = std::make_shared<ModelInfo>(_modelInfo);
+    this->models[id] = model;
+    const auto world = this->worlds.at(_worldId);
+    world->models.push_back(id);
+    world->modelsByName[model->name] = id;
     this->childIdToParentId.insert({id, _worldId});
     return this->GenerateIdentity(id, this->models.at(id));
   }
@@ -217,10 +230,12 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: inline Identity AddLink(std::size_t _modelId, LinkInfo _linkInfo)
   {
     const auto id = this->GetNextEntity();
-    this->links[id] = std::make_shared<LinkInfo>(_linkInfo);
+    const auto link = std::make_shared<LinkInfo>(_linkInfo);
+    this->links[id] = link;
 
     auto model = this->models.at(_linkInfo.model);
     model->links.push_back(id);
+    model->linksByName[link->name] = id;
 
     this->childIdToParentId.insert({id, _modelId});
     return this->GenerateIdentity(id, this->links.at(id));
@@ -230,14 +245,23 @@ class Base : public Implements3d<FeatureList<Feature>>
   {
    const auto id = this->GetNextEntity();
    this->collisions[id] = std::make_shared<CollisionInfo>(_collisionInfo);
+   this->links.at(_linkId)->shapes.push_back(id);
    this->childIdToParentId.insert({id, _linkId});
    return this->GenerateIdentity(id, this->collisions.at(id));
   }
 
-  public: inline Identity AddJoint(JointInfo _jointInfo)
+  public: inline Identity AddJoint(
+    std::optional<std::size_t> _modelId, JointInfo _jointInfo)
   {
     const auto id = this->GetNextEntity();
-    this->joints[id] = std::make_shared<JointInfo>(_jointInfo);
+    const auto joint = std::make_shared<JointInfo>(_jointInfo);
+    this->joints[id] = joint;
+    if (_modelId.has_value())
+    {
+      const auto model = this->models.at(*_modelId);
+      model->joints.push_back(id);
+      model->jointsByName[joint->name] = id;
+    }
 
     return this->GenerateIdentity(id, this->joints.at(id));
   }
@@ -249,6 +273,8 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: using JointInfoPtr  = std::shared_ptr<JointInfo>;
 
   public: std::unordered_map<std::size_t, WorldInfoPtr> worlds;
+  public: std::vector<std::size_t> worldsByIndex;
+  public: std::unordered_map<std::string, std::size_t> worldsByName;
   public: std::unordered_map<std::size_t, ModelInfoPtr> models;
   public: std::unordered_map<std::size_t, LinkInfoPtr> links;
   public: std::unordered_map<std::size_t, CollisionInfoPtr> collisions;

--- a/bullet/src/EntityManagementFeatures.hh
+++ b/bullet/src/EntityManagementFeatures.hh
@@ -32,7 +32,12 @@ namespace physics {
 namespace bullet {
 
 struct EntityManagementFeatureList : gz::physics::FeatureList<
-  GetEntities,
+  GetEngineInfo,
+  GetWorldFromEngine,
+  GetModelFromWorld,
+  GetLinkFromModel,
+  GetJointFromModel,
+  GetShapeFromLink,
   RemoveModelFromWorld,
   ConstructEmptyWorldFeature
 > { };
@@ -92,15 +97,6 @@ class EntityManagementFeatures :
   public: std::size_t GetModelIndex(const Identity &_modelID) const override;
 
   public: Identity GetWorldOfModel(const Identity &_modelID) const override;
-
-  public: std::size_t GetNestedModelCount(
-    const Identity &_modelID) const override;
-
-  public: Identity GetNestedModel(
-    const Identity &_modelID, std::size_t _modelIndex) const override;
-
-  public: Identity GetNestedModel(
-    const Identity &_modelID, const std::string &_modelName) const override;
 
   public: std::size_t GetLinkCount(const Identity &_modelID) const override;
 

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -188,7 +188,7 @@ Identity SDFFeatures::ConstructSdfLink(
 
   // Generate an identity for it
   const auto linkIdentity =
-    this->AddLink(_modelID, {name, _modelID, pose, inertialPose,
+    this->AddLink({name, _modelID, pose, inertialPose,
     mass, linkInertiaDiag, myMotionState, collisionShape, body});
 
   // Create associated collisions to this model

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -460,7 +460,7 @@ Identity SDFFeatures::ConstructSdfJoint(
 
   // Generate an identity for it and return it
   auto identity =
-    this->AddJoint({_sdfJoint.Name(), joint, childId, parentId,
+    this->AddJoint(_modelID.id, {_sdfJoint.Name(), joint, childId, parentId,
     static_cast<int>(type), axis});
   return identity;
 }


### PR DESCRIPTION
This PR fixes the entity management features for the bullet classic plugin. It also fixes the seg fault that was reported [in this other PR](https://github.com/gazebosim/gz-sim/pull/1560) for gz-sim.