### PR TITLE
ABI tweaks to help bullet-featherstone

### DIFF
--- a/include/gz/physics/ForwardStep.hh
+++ b/include/gz/physics/ForwardStep.hh
@@ -155,7 +155,8 @@ namespace gz
               ApplyExternalForceTorques,
               ApplyGeneralizedForces,
               VelocityControlCommands,
-              ServoControlCommands>;
+              ServoControlCommands,
+              std::chrono::steady_clock::duration>;
 
       public: using Output = SpecifyData<
           RequireData<WorldPoses>,

--- a/include/gz/physics/FrameID.hh
+++ b/include/gz/physics/FrameID.hh
@@ -109,7 +109,7 @@ namespace gz
       /// Objects that don't support reference counting will leave this as a
       /// nullptr.
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
-      private: std::shared_ptr<const void> ref;
+      private: std::shared_ptr<void> ref;
       GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
     };
   }

--- a/include/gz/physics/FrameSemantics.hh
+++ b/include/gz/physics/FrameSemantics.hh
@@ -162,7 +162,7 @@ namespace gz
         /// \tparam T The stored pointer is cast to this type.
         /// \param[in] _frameID the frame identifier to cast an interface from
         /// \return A raw pointer from the stored shared_ptr but cast to the
-        ///         /// provided type T
+        ///         provided type T
         protected: template<typename T>
         T *FrameInterface(const FrameID &_frameID) const;
       };

--- a/include/gz/physics/FrameSemantics.hh
+++ b/include/gz/physics/FrameSemantics.hh
@@ -156,6 +156,15 @@ namespace gz
         /// \return A FrameID object that corresponds to _identity.
         protected: virtual FrameID GenerateFrameID(
             const Identity &_identity) const;
+
+        /// \brief An implementation class can use this function to get the
+        /// interface that _frameID holds onto in its reference-counted pointer.
+        /// \tparam T The stored pointer is cast to this type.
+        /// \param[in] _frameID the frame identifier to cast an interface from
+        /// \return A raw pointer from the stored shared_ptr but cast to the
+        ///         /// provided type T
+        protected: template<typename T>
+        T *FrameInterface(const FrameID &_frameID) const;
       };
     };
 

--- a/include/gz/physics/detail/FrameSemantics.hh
+++ b/include/gz/physics/detail/FrameSemantics.hh
@@ -215,6 +215,15 @@ namespace gz
     {
       return FrameID(_identity);
     }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT>
+    template <typename T>
+    T *FrameSemantics::Implementation<PolicyT>::FrameInterface(
+        const FrameID &_frameID) const
+    {
+      return static_cast<T *>(_frameID.ref.get());
+    }
   }
 }
 


### PR DESCRIPTION
These small tweaks to the ABI are needed for #373, and if we can merge these before code freeze then we can introduce `bullet-featherstone` post-release without and harmful effects.