### PR TITLE
Improved joints in bullet featherstone

### DIFF
--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -528,13 +528,15 @@ Identity SDFFeatures::ConstructSdfModel(
           btPosParentComToJoint,
           btJointToChildCom);
       }
-      if (::sdf::JointType::PRISMATIC == joint->Type() || ::sdf::JointType::REVOLUTE == joint->Type())
+      if (::sdf::JointType::PRISMATIC == joint->Type() ||
+        ::sdf::JointType::REVOLUTE == joint->Type())
       {
         model->body->getLink(i).m_jointLowerLimit = joint->Axis()->Lower();
         model->body->getLink(i).m_jointUpperLimit = joint->Axis()->Upper();
-        model->body->getLink(i).m_jointDamping = 100;//joint->Axis()->Damping();
+        model->body->getLink(i).m_jointDamping = joint->Axis()->Damping();
         model->body->getLink(i).m_jointFriction = joint->Axis()->Friction();
-        model->body->getLink(i).m_jointMaxVelocity = joint->Axis()->MaxVelocity();
+        model->body->getLink(i).m_jointMaxVelocity =
+          joint->Axis()->MaxVelocity();
         model->body->getLink(i).m_jointMaxForce = joint->Axis()->Effort();
 
         btMultiBodyConstraint* con = new btMultiBodyJointLimitConstraint(


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

## Summary

 - Improved joint constraint (limit, damping, friction, ...)
 - Fixed crash when a joint type is not supported or a link has several parent joints

## Test it

Launch gz-sim with `gz-sim/test/worlds/demo_joint_types.sdf`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
