### PR TITLE
Fix broken links in the physics plugin tutorial

### DIFF
--- a/tutorials/03_physics_plugins.md
+++ b/tutorials/03_physics_plugins.md
@@ -78,12 +78,12 @@ Users do not need to organize their own plugin implementations this way.
 
 Dart ([Dynamic Animation and Robotics Toolkit](https://dartsim.github.io/)) is an open source library that provides data structures and algorithms for kinematic and dynamic applications in robotics and computer animation.
 It is the default physics engine used in Gazebo Simulation.
-The source code for Dartsim plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/ign-physics6) under `dartsim` directory.
+The source code for Dartsim plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/gz-physics6) under `dartsim` directory.
 
-TPE ([Trivial Physics Engine](https://github.com/gazebosim/gz-physics/tree/ign-physics6/tpe)) is an open source library created by Open Robotics that enables fast, inexpensive kinematics simulation for entities at large scale.
+TPE ([Trivial Physics Engine](https://github.com/gazebosim/gz-physics/tree/gz-physics6/tpe)) is an open source library created by Open Robotics that enables fast, inexpensive kinematics simulation for entities at large scale.
 It supports higher-order fleet dynamics without real physics (eg. gravity, force, constraint etc.) and multi-machine synchronization.
 Gazebo support for TPE targets [Citadel](https://gazebosim.org/docs/citadel) and onward releases.
-The source code for TPE plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/ign-physics6) under the `tpe/plugin` directory.
+The source code for TPE plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/gz-physics6) under the `tpe/plugin` directory.
 
 The following is a list of features supported by each physics engine to help users select one that fits their needs.
 


### PR DESCRIPTION
Signed-off-by: Joan Aguilar Mayans <joan@openrobotics.org>

# 🦟 Bug fix

Fixes https://github.com/gazebosim/garden-tutorial-party/issues/333 through https://github.com/gazebosim/garden-tutorial-party/issues/340.

## Summary
Updated some links to point to the `gz-physics6` branch rather than the (nonexisting) `ign-physics6` branch.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.