### PR TITLE
Improved 04-switching-physics-engines instructions

### DIFF
--- a/tutorials/04-switching-physics-engines.md
+++ b/tutorials/04-switching-physics-engines.md
@@ -20,7 +20,7 @@ At the time of writing, there are three physics engines available (more detail
 in \ref physicsplugin "Physics plugin tutorial"):
 - **DART**: `gz-physics-dartsim-plugin`.
 - **TPE**: `gz-physics-tpe-plugin`.
-- **Bulet**: `gz-physics-bullet-plugin`.
+- **Bullet**: `gz-physics-bullet-plugin`.
 
 If you've created a custom engine plugin, you can tell Gazebo where to
 find it by setting the `GZ_SIM_PHYSICS_ENGINE_PATH` environment variable to

--- a/tutorials/04-switching-physics-engines.md
+++ b/tutorials/04-switching-physics-engines.md
@@ -16,10 +16,11 @@ new engine.
 
 Gazebo automatically looks for all physics engine plugins that are
 installed with Gazebo Physics.
-At the time of writing, there are two physics engines available (more detail
+At the time of writing, there are three physics engines available (more detail
 in \ref physicsplugin "Physics plugin tutorial"):
 - **DART**: `gz-physics-dartsim-plugin`.
 - **TPE**: `gz-physics-tpe-plugin`.
+- **Bulet**: `gz-physics-bullet-plugin`.
 
 If you've created a custom engine plugin, you can tell Gazebo where to
 find it by setting the `GZ_SIM_PHYSICS_ENGINE_PATH` environment variable to
@@ -100,8 +101,9 @@ gz::sim::Server server(serverConfig);
 ## Troubleshooting
 These are common error messages that you may encounter:
 
-> Failed to find plugin [libCustomEngine.so]. Have you checked the
-GZ_SIM_PHYSICS_ENGINE_PATH environment variable?
+```{.bash}
+Failed to find plugin [libCustomEngine.so]. Have you checked the GZ_SIM_PHYSICS_ENGINE_PATH environment variable?
+```
 
 Gazebo can't find out where `libCustomEngine.so` is located.
 
@@ -111,19 +113,24 @@ check if the relevant plugin is installed.
 If that's a 3rd party engine, find where the `.so` file is installed and add
 that path to the environment variable as described above.
 
-> Unable to load the [/home/physics_engines/libCustomEngine.so] library.
+```{.bash}
+Unable to load the [/home/physics_engines/libCustomEngine.so] library.
+```
 
 There was some problem loading that file. Check that it exists, that you have
 permissions to access it, and that it's a physics engine plugin.
 
-> No plugins with all required features found in library
-[/home/physics_engines/libCustomEngine.so]
+```{.bash}
+No plugins with all required features found in library [/home/physics_engines/libCustomEngine.so]
+```
 
 This means that there are plugins on that library, but none of them satisfies
 the minimum requirement of features needed to run a Gazebo simulation.
 Be sure to implement all the necessary features.
 
-> Failed to load a valid physics engine from [/home/physics_engines/libCustomEngine.so]
+```{.bash}
+Failed to load a valid physics engine from [/home/physics_engines/libCustomEngine.so]
+```
 
 Some engines were found in that library, but none of them could be loaded.
 Check that the engines implement all the necessary features.


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Improved 04-switching-physics-engines instructions. Related to https://github.com/gazebosim/garden-tutorial-party/issues/330

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
