### PR TITLE
Fixed bullet-featherstone mesh collisions

### DIFF
--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -341,8 +341,8 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: std::unordered_map<std::size_t, CollisionInfoPtr> collisions;
   public: std::unordered_map<std::size_t, JointInfoPtr> joints;
 
-  public: std::vector<btGImpactMeshShape*> meshesGImpact;
-  public: btAlignedObjectArray<btTriangleMesh*> triangleMeshes;
+  public: std::vector<std::unique_ptr<btGImpactMeshShape>> meshesGImpact;
+  public: std::vector<std::unique_ptr<btTriangleMesh>> triangleMeshes;
 };
 
 }  // namespace bullet_featherstone

--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -28,6 +28,7 @@
 #include <BulletDynamics/Featherstone/btMultiBodyLinkCollider.h>
 #include <LinearMath/btVector3.h>
 #include <btBulletDynamicsCommon.h>
+#include "BulletCollision/Gimpact/btGImpactShape.h"
 
 #include <Eigen/Geometry>
 
@@ -340,7 +341,7 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: std::unordered_map<std::size_t, CollisionInfoPtr> collisions;
   public: std::unordered_map<std::size_t, JointInfoPtr> joints;
 
-  public: std::vector<std::unique_ptr<btBvhTriangleMeshShape>> meshes;
+  public: std::vector<btGImpactMeshShape*> meshesGImpact;
   public: btAlignedObjectArray<btTriangleMesh*> triangleMeshes;
 };
 

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -745,7 +745,6 @@ bool SDFFeatures::AddSdfCollision(
       this->meshesGImpact.back()->setMargin(0.001);
       compoundShape->addChildShape(btTransform::getIdentity(),
         this->meshesGImpact.back().get());
-      //
     }
     shape = std::move(compoundShape);
   }

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -740,10 +740,12 @@ bool SDFFeatures::AddSdfCollision(
         btTrimesh->addTriangle(v0, v1, v2);
       }
 
-      this->meshes.push_back(std::make_unique<btBvhTriangleMeshShape>(
-          btTrimesh, true, true));
+      btGImpactMeshShape *gImpactMesh = new btGImpactMeshShape(btTrimesh);
+      gImpactMesh->updateBound();
+      gImpactMesh->setMargin(0.001);
+      this->meshesGImpact.push_back(gImpactMesh);
       compoundShape->addChildShape(
-          btTransform::getIdentity(), this->meshes.back().get());
+          btTransform::getIdentity(), gImpactMesh);
     }
     shape = std::move(compoundShape);
   }

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -729,23 +729,23 @@ bool SDFFeatures::AddSdfCollision(
               s->Vertex(i).Z() * scale.Z()));
       }
 
-      auto *btTrimesh = new btTriangleMesh();
-      this->triangleMeshes.push_back(btTrimesh);
-
+      this->triangleMeshes.push_back(std::make_unique<btTriangleMesh>());
       for (unsigned int i = 0; i < indexCount/3; i++)
       {
         const btVector3& v0 = convertedVerts[s->Index(i*3)];
         const btVector3& v1 = convertedVerts[s->Index(i*3 + 1)];
         const btVector3& v2 = convertedVerts[s->Index(i*3 + 2)];
-        btTrimesh->addTriangle(v0, v1, v2);
+        this->triangleMeshes.back()->addTriangle(v0, v1, v2);
       }
 
-      btGImpactMeshShape *gImpactMesh = new btGImpactMeshShape(btTrimesh);
-      gImpactMesh->updateBound();
-      gImpactMesh->setMargin(0.001);
-      this->meshesGImpact.push_back(gImpactMesh);
-      compoundShape->addChildShape(
-          btTransform::getIdentity(), gImpactMesh);
+      this->meshesGImpact.push_back(
+        std::make_unique<btGImpactMeshShape>(
+          this->triangleMeshes.back().get()));
+      this->meshesGImpact.back()->updateBound();
+      this->meshesGImpact.back()->setMargin(0.001);
+      compoundShape->addChildShape(btTransform::getIdentity(),
+        this->meshesGImpact.back().get());
+      //
     }
     shape = std::move(compoundShape);
   }


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary
Meshes were not colliding with the static plane. This PR should fix this issue.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
