### PR TITLE
Removed GetCollision API it's redundant

### DIFF
--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -945,18 +945,6 @@ bool SDFFeatures::AddSdfCollision(
   return true;
 }
 
-Identity SDFFeatures::GetCollision(
-  const Identity &_linkID,
-  const std::string &_collisionName)
-{
-  const auto *link = this->ReferenceInterface<LinkInfo>(_linkID);
-  const auto it = link->collisionNameToEntityId.find(_collisionName);
-  if (it == link->collisionNameToEntityId.end())
-    return this->GenerateInvalidId();
-
-  return this->GenerateIdentity(it->second, this->collisions.at(it->second));
-}
-
 Identity SDFFeatures::ConstructSdfCollision(
     const Identity &_linkID,
     const ::sdf::Collision &_collision)

--- a/bullet-featherstone/src/SDFFeatures.hh
+++ b/bullet-featherstone/src/SDFFeatures.hh
@@ -59,10 +59,6 @@ class SDFFeatures :
   private: Identity ConstructSdfCollision(
       const Identity &_linkID,
       const ::sdf::Collision &_collision) override;
-
-  private: Identity GetCollision(
-      const Identity &_linkID,
-      const std::string &_collisionName) override;
 };
 
 }  // namespace bullet_featherstone

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -202,25 +202,6 @@ Identity SDFFeatures::ConstructSdfLink(
   return linkIdentity;
 }
 
-Identity SDFFeatures::GetCollision(
-  const Identity &_linkID,
-  const std::string &_collisionName)
-{
-  const auto link = this->ReferenceInterface<LinkInfo>(_linkID);
-  const auto it = std::find_if(
-        link->shapes.begin(),
-        link->shapes.end(),
-        [this, &_collisionName](const auto& shapeID)
-    {
-      return _collisionName == this->collisions.at(shapeID)->name;
-    });
-
-  if (it == link->shapes.end())
-    return this->GenerateInvalidId();
-
-  return this->GenerateIdentity(*it, this->collisions.at(*it));
-}
-
 Identity SDFFeatures::ConstructSdfCollision(
     const Identity &_linkID,
     const ::sdf::Collision &_collision)

--- a/bullet/src/SDFFeatures.hh
+++ b/bullet/src/SDFFeatures.hh
@@ -62,10 +62,6 @@ class SDFFeatures :
       const Identity &_linkID,
       const ::sdf::Collision &_collision) override;
 
-  private: Identity GetCollision(
-      const Identity &_linkID,
-      const std::string &_collisionName) override;
-
   private: Identity ConstructSdfJoint(
       const Identity &_modelID,
       const ::sdf::Joint &_sdfJoint) override;

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -669,32 +669,6 @@ Identity SDFFeatures::ConstructSdfLink(
   return linkIdentity;
 }
 
-Identity SDFFeatures::GetCollision(
-  const Identity &_linkID,
-  const std::string &_collisionName)
-{
-  auto bn = this->ReferenceInterface<LinkInfo>(_linkID)->link;
-
-  DartShapeNode *const sn = bn->getSkeleton()->getShapeNode(
-          bn->getName() + ":" + _collisionName);
-
-  // If the shape doesn't exist in "shapes", it means the containing entity has
-  // been removed.
-  if (this->shapes.HasEntity(sn))
-  {
-    const std::size_t shapeID = this->shapes.IdentityOf(sn);
-    return this->GenerateIdentity(shapeID, this->shapes.at(shapeID));
-  }
-  else
-  {
-    // TODO(addisu) It's not clear what to do when `GetShape` is called on a
-    // link that has been removed. Right now we are returning an invalid
-    // identity, but that could cause a segfault if the use doesn't check if
-    // returned value before using it.
-    return this->GenerateInvalidId();
-  }
-}
-
 /////////////////////////////////////////////////
 Identity SDFFeatures::ConstructSdfJoint(
     const Identity &_modelID,

--- a/dartsim/src/SDFFeatures.hh
+++ b/dartsim/src/SDFFeatures.hh
@@ -75,10 +75,6 @@ class SDFFeatures :
       const Identity &_linkID,
       const ::sdf::Collision &_collision) override;
 
-  public: Identity GetCollision(
-      const Identity &_linkID,
-      const std::string &_collisionName) override;
-
   public: Identity ConstructSdfVisual(
       const Identity &_linkID,
       const ::sdf::Visual &_visual) override;

--- a/sdf/include/gz/physics/sdf/ConstructCollision.hh
+++ b/sdf/include/gz/physics/sdf/ConstructCollision.hh
@@ -36,8 +36,6 @@ class ConstructSdfCollision : public virtual Feature
     public: using ShapePtrType = ShapePtr<PolicyT, FeaturesT>;
 
     public: ShapePtrType ConstructCollision(const ::sdf::Collision &_collision);
-
-    public: ShapePtrType GetCollision(const std::string &_collisionName);
   };
 
   public: template <typename PolicyT>
@@ -45,9 +43,6 @@ class ConstructSdfCollision : public virtual Feature
   {
     public: virtual Identity ConstructSdfCollision(
         const Identity &_linkID, const ::sdf::Collision &_collision) = 0;
-
-    public: virtual Identity GetCollision(
-        const Identity &_linkID, const std::string &_collisionName) = 0;
   };
 };
 
@@ -59,15 +54,6 @@ auto ConstructSdfCollision::Link<PolicyT, FeaturesT>::ConstructCollision(
   return ShapePtrType(this->pimpl,
         this->template Interface<ConstructSdfCollision>()
             ->ConstructSdfCollision(this->identity, _collision));
-}
-/////////////////////////////////////////////////
-template <typename PolicyT, typename FeaturesT>
-auto ConstructSdfCollision::Link<PolicyT, FeaturesT>::GetCollision(
-    const std::string &_collisionName) -> ShapePtrType
-{
-  return ShapePtrType(this->pimpl,
-        this->template Interface<ConstructSdfCollision>()
-            ->GetCollision(this->identity, _collisionName));
 }
 }
 }

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -251,32 +251,6 @@ Identity SDFFeatures::ConstructSdfLink(
 }
 
 /////////////////////////////////////////////////
-Identity SDFFeatures::GetCollision(
-  const Identity &_linkID,
-  const std::string &_collisionName)
-{
-  auto linkInfo = this->ReferenceInterface<LinkInfo>(_linkID);
-  if (linkInfo != nullptr)
-  {
-    tpelib::Entity &shapeEnt = linkInfo->link->GetChildByName(_collisionName);
-    for (auto it = this->collisions.begin();
-         it != this->collisions.end();
-         ++it)
-    {
-      if (it->second != nullptr)
-      {
-        std::string name = it->second->collision->GetName();
-        if (it->first == shapeEnt.GetId() && name == shapeEnt.GetName())
-        {
-          return this->GenerateIdentity(it->first, it->second);
-        }
-      }
-    }
-  }
-  return this->GenerateInvalidId();
-}
-
-/////////////////////////////////////////////////
 Identity SDFFeatures::ConstructSdfCollision(
     const Identity &_linkID,
     const ::sdf::Collision &_sdfCollision)

--- a/tpe/plugin/src/SDFFeatures.hh
+++ b/tpe/plugin/src/SDFFeatures.hh
@@ -63,10 +63,6 @@ class SDFFeatures :
   private: Identity ConstructSdfCollision(
     const Identity &_linkID,
     const ::sdf::Collision &_collision) override;
-
-  private: Identity GetCollision(
-      const Identity &_linkID,
-      const std::string &_collisionName) override;
 };
 
 }


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

## Summary

Removed `GetCollision`. FYI @scpeters and @mjcarroll 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

