### PR TITLE
Fix construction of nested models

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -441,8 +441,19 @@ Identity SDFFeatures::ConstructSdfModelImpl(
   if (isNested)
   {
     worldID = this->GetWorldOfModelImpl(_parentID);
-    const auto &skel = this->models.at(_parentID)->model;
+
+    const auto parentModelInfo = this->models.at(_parentID);
+    const auto &skel = parentModelInfo->model;
     modelName = ::sdf::JoinName(skel->getName(), _sdfModel.Name());
+
+    for (const auto &nestedModelID: parentModelInfo->nestedModels)
+    {
+      auto nestedModel = this->models.at(nestedModelID);
+      if (nestedModel->localName == _sdfModel.Name())
+      {
+        return this->GenerateIdentity(nestedModelID, nestedModel);
+      }
+    }
   }
 
   dart::dynamics::Frame *parentFrame = this->frames.at(_parentID);

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -446,7 +446,11 @@ Identity SDFFeatures::ConstructSdfModelImpl(
     const auto &skel = parentModelInfo->model;
     modelName = ::sdf::JoinName(skel->getName(), _sdfModel.Name());
 
-    for (const auto &nestedModelID: parentModelInfo->nestedModels)
+    // Check to see if the nested model has already been constructed.
+    // This can happen in the case that it was recursively created as
+    // part of the parent model.
+    // In this case, return the identity, rather than duplicating.
+    for (const auto &nestedModelID : parentModelInfo->nestedModels)
     {
       auto nestedModel = this->models.at(nestedModelID);
       if (nestedModel->localName == _sdfModel.Name())


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This makes dartsim correctly handle nested models.  The simulation runner may try to construct models twice (First from the root sdf::Model, and then again because the nested model is in the ECM).  This will return the originally constructed model rather than creating a duplicate.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.