### PR TITLE
Suppress MSVC warning that is not applicable

### DIFF
--- a/include/gz/physics/FeatureList.hh
+++ b/include/gz/physics/FeatureList.hh
@@ -22,6 +22,14 @@
 
 #include <gz/physics/Feature.hh>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+/// Suppress warnings about "base-class is already a base-class"
+/// Typically, this would indicate a diamond pattern in inheritance,
+/// but this is a false positive for the plugin mechanism.
+#pragma warning(disable: 4584)
+#endif  // defined(_MSC_VER)
+
 namespace gz
 {
   namespace physics
@@ -111,4 +119,7 @@ namespace gz
 
 #include <gz/physics/detail/FeatureList.hh>
 
-#endif
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif  // defined(_MSC_VER)
+#endif  // GZ_PHYSICS_FEATURELIST_HH_

--- a/include/gz/physics/FeatureList.hh
+++ b/include/gz/physics/FeatureList.hh
@@ -26,7 +26,9 @@
 #pragma warning(push)
 /// Suppress warnings about "base-class is already a base-class"
 /// Typically, this would indicate a diamond pattern in inheritance,
-/// but this is a false positive for the plugin mechanism.
+/// but there are uses in the plugin mechanism recursive templates.
+/// The templates have no base classes, so there are no ambiguity
+/// concerns, so we can safely suppress the warning here.
 #pragma warning(disable: 4584)
 #endif  // defined(_MSC_VER)
 


### PR DESCRIPTION
This triggers a warning in downstream libraries such as:

https://build.osrfoundation.org/job/ign_gazebo-pr-win/5195/msbuild/

```
'gz::physics::detail::ComposePlugin::type': base-class 'gz::physics::detail::ComposePlugin::n,void>' is already a base-class of 'gz::physics::detail::ComposePlugin::type'
```
 
After talking with @mxgrey, while this is typically a relevant warning by MSVC, it is not applicable so we can suppress it.

Signed-off-by: Michael Carroll <michael@openrobotics.org>