### PR TITLE
Deduplicate common tests part1

### DIFF
--- a/test/common_test/construct_empty_world.cc
+++ b/test/common_test/construct_empty_world.cc
@@ -82,8 +82,7 @@ TYPED_TEST(ConstructEmptyWorldTest, ConstructUpToEmptyWorld)
 }
 
 using FeaturesUpToGetWorldFromEngine = gz::physics::FeatureList<
-  gz::physics::GetEngineInfo,
-  gz::physics::ConstructEmptyWorldFeature,
+  FeaturesUpToEmptyWorld,
   gz::physics::GetWorldFromEngine
 >;
 
@@ -118,9 +117,7 @@ TYPED_TEST(ConstructEmptyWorldTestUpToGetWorldFromEngine,
 }
 
 using FeaturesUpToEmptyModelFeature = gz::physics::FeatureList<
-  gz::physics::GetEngineInfo,
-  gz::physics::ConstructEmptyWorldFeature,
-  gz::physics::GetWorldFromEngine,
+  FeaturesUpToGetWorldFromEngine,
   gz::physics::ConstructEmptyModelFeature
 >;
 
@@ -157,10 +154,7 @@ TYPED_TEST(ConstructEmptyWorldTestUpToEmptyModelFeature,
 }
 
 using FeaturesUpToGetModelFromWorld = gz::physics::FeatureList<
-  gz::physics::GetEngineInfo,
-  gz::physics::ConstructEmptyWorldFeature,
-  gz::physics::GetWorldFromEngine,
-  gz::physics::ConstructEmptyModelFeature,
+  FeaturesUpToEmptyModelFeature,
   gz::physics::GetModelFromWorld
 >;
 
@@ -199,11 +193,7 @@ TYPED_TEST(ConstructEmptyWorldTestUpToGetModelFromWorld,
 }
 
 using FeaturesUpToEmptyNestedModelFeature = gz::physics::FeatureList<
-  gz::physics::GetEngineInfo,
-  gz::physics::ConstructEmptyWorldFeature,
-  gz::physics::GetWorldFromEngine,
-  gz::physics::ConstructEmptyModelFeature,
-  gz::physics::GetModelFromWorld,
+  FeaturesUpToGetModelFromWorld,
   gz::physics::ConstructEmptyNestedModelFeature,
   gz::physics::GetNestedModelFromModel
 >;
@@ -248,10 +238,7 @@ TYPED_TEST(ConstructEmptyWorldTestUpToEmptyNestedModelFeature,
 }
 
 using FeaturesUpToEmptyLink = gz::physics::FeatureList<
-  gz::physics::GetEngineInfo,
-  gz::physics::ConstructEmptyWorldFeature,
-  gz::physics::GetWorldFromEngine,
-  gz::physics::ConstructEmptyModelFeature,
+  FeaturesUpToEmptyModelFeature,
   gz::physics::GetLinkFromModel,
   gz::physics::ConstructEmptyLinkFeature
 >;

--- a/test/common_test/construct_empty_world.cc
+++ b/test/common_test/construct_empty_world.cc
@@ -51,9 +51,28 @@ class ConstructEmptyWorldTest:
     }
   }
 
+  using FeaturePolicy3d = gz::physics::FeaturePolicy3d;
+
+  public: void MakeEmptyWorld(
+              const std::string &_pluginName,
+              gz::physics::EnginePtr<FeaturePolicy3d, T> &_engine,
+              gz::physics::WorldPtr<FeaturePolicy3d, T> &_world)
+  {
+    std::cout << "Testing plugin: " << _pluginName << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(_pluginName);
+
+    _engine = gz::physics::RequestEngine3d<T>::From(plugin);
+    ASSERT_NE(nullptr, _engine);
+
+    _world = _engine->ConstructEmptyWorld("empty world");
+    ASSERT_NE(nullptr, _world);
+  }
+
   public: std::set<std::string> pluginNames;
   public: gz::plugin::Loader loader;
 };
+
+using gz::physics::FeaturePolicy3d;
 
 using FeaturesUpToEmptyWorld = gz::physics::FeatureList<
   gz::physics::GetEngineInfo,
@@ -69,15 +88,10 @@ TYPED_TEST(ConstructEmptyWorldTest, ConstructUpToEmptyWorld)
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
 
-    auto engine =
-      gz::physics::RequestEngine3d<FeaturesUpToEmptyWorld>::From(plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
+    this->MakeEmptyWorld(name, engine, world);
   }
 }
 
@@ -91,7 +105,7 @@ class ConstructEmptyWorldTestUpToGetWorldFromEngine :
   public ConstructEmptyWorldTest<T>{};
 
 using ConstructEmptyWorldTestUpToGetWorldFromEngineTypes =
-  ::testing::Types<FeaturesUpToEmptyWorld>;
+  ::testing::Types<FeaturesUpToGetWorldFromEngine>;
 TYPED_TEST_SUITE(ConstructEmptyWorldTestUpToGetWorldFromEngine,
                  ConstructEmptyWorldTestUpToGetWorldFromEngineTypes);
 
@@ -101,16 +115,10 @@ TYPED_TEST(ConstructEmptyWorldTestUpToGetWorldFromEngine,
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
+    this->MakeEmptyWorld(name, engine, world);
 
-    auto engine =
-      gz::physics::RequestEngine3d<FeaturesUpToGetWorldFromEngine>::From(
-        plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
     EXPECT_EQ("empty world", world->GetName());
     EXPECT_EQ(engine, world->GetEngine());
   }
@@ -135,15 +143,10 @@ TYPED_TEST(ConstructEmptyWorldTestUpToEmptyModelFeature,
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
+    this->MakeEmptyWorld(name, engine, world);
 
-    auto engine =
-      gz::physics::RequestEngine3d<FeaturesUpToEmptyModelFeature>::From(plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
     EXPECT_EQ("empty world", world->GetName());
     EXPECT_EQ(engine, world->GetEngine());
 
@@ -172,15 +175,10 @@ TYPED_TEST(ConstructEmptyWorldTestUpToGetModelFromWorld,
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
+    this->MakeEmptyWorld(name, engine, world);
 
-    auto engine =
-      gz::physics::RequestEngine3d<FeaturesUpToGetModelFromWorld>::From(plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
     EXPECT_EQ("empty world", world->GetName());
     EXPECT_EQ(engine, world->GetEngine());
 
@@ -212,14 +210,10 @@ TYPED_TEST(ConstructEmptyWorldTestUpToEmptyNestedModelFeature,
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
+    this->MakeEmptyWorld(name, engine, world);
 
-    auto engine = gz::physics::RequestEngine3d<FeaturesUpToEmptyNestedModelFeature>::From(plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
     auto model = world->ConstructEmptyModel("empty model");
 
     auto nestedModel = model->ConstructEmptyNestedModel("empty nested model");
@@ -256,15 +250,10 @@ TYPED_TEST(ConstructEmptyWorldTestUpToEmptyLink, ConstructUpToEmptyWorld)
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
+    this->MakeEmptyWorld(name, engine, world);
 
-    auto engine =
-      gz::physics::RequestEngine3d<FeaturesUpToEmptyLink>::From(plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
     EXPECT_EQ("empty world", world->GetName());
     EXPECT_EQ(engine, world->GetEngine());
 
@@ -307,15 +296,10 @@ TYPED_TEST(ConstructEmptyWorldTestUpToRemove, ConstructUpToEmptyWorld)
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
+    this->MakeEmptyWorld(name, engine, world);
 
-    auto engine =
-      gz::physics::RequestEngine3d<FeaturesUpToRemove>::From(plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
     auto model = world->ConstructEmptyModel("empty model");
     ASSERT_NE(nullptr, model);
     auto modelAlias = world->GetModel(0);
@@ -403,16 +387,10 @@ TYPED_TEST(ConstructEmptyWorldTestUpToEmptyNestedModelFeature2,
 {
   for (const std::string &name : this->pluginNames)
   {
-    std::cout << "Testing plugin: " << name << std::endl;
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+    gz::physics::EnginePtr<FeaturePolicy3d, TypeParam> engine;
+    gz::physics::WorldPtr<FeaturePolicy3d, TypeParam> world;
+    this->MakeEmptyWorld(name, engine, world);
 
-    auto engine =
-      gz::physics::RequestEngine3d<FeaturesUpToEmptyNestedModelFeature2>::From(
-        plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = engine->ConstructEmptyWorld("empty world");
-    ASSERT_NE(nullptr, world);
     auto model1 = world->ConstructEmptyModel("model1");
     ASSERT_NE(nullptr, model1);
     EXPECT_EQ(0ul, model1->GetIndex());


### PR DESCRIPTION
# 🎉 New feature

Deduplicate some code in common tests

## Summary

This is a prototype of some deduplication of code in the common tests:

* https://github.com/gazebosim/gz-physics/commit/adf1147ee53d26318263eddca137bcf8123cd1cb: reference feature lists recursively to avoid repeating feature names
* https://github.com/gazebosim/gz-physics/commit/af8e428f19cf1a84b8fd5fa0bb752fb8e0071839: add templatized helper function for requesting engine and loading an empty world and replace duplicate code in all test cases. Some additional helper functions could be added to further reduce the code duplication.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
