### PR TITLE
Reduce error to debug and add notes

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -306,8 +306,11 @@ static ShapeAndTransform ConstructPlane(
 static ShapeAndTransform ConstructHeightmap(
     const ::sdf::Heightmap & /*_heightmap*/)
 {
-  gzerr << "Heightmap construction from an SDF has not been implemented yet "
-         << "for dartsim.\n";
+  // TODO(mjcarroll) Allow dartsim to construct heightmaps internally rather
+  // than relying on the physics consumer constructing and attaching:
+  // https://github.com/gazebosim/gz-physics/issues/451
+  gzdbg << "Heightmap construction from an SDF has not been implemented yet "
+        << "for dartsim. Use AttachHeightmapShapeFeature to use heightmaps.\n";
   return {nullptr};
 }
 
@@ -317,8 +320,11 @@ static ShapeAndTransform ConstructMesh(
 {
   // TODO(MXG): Look into what kind of mesh URI we get here. Will it just be
   // a local file name, or do we need to resolve the URI?
-  gzerr << "Mesh construction from an SDF has not been implemented yet for "
-         << "dartsim.\n";
+  // TODO(mjcarroll) Allow dartsim to construct meshes internally rather
+  // than relying on the physics consumer constructing and attaching:
+  // https://github.com/gazebosim/gz-physics/issues/451
+  gzdbg << "Mesh construction from an SDF has not been implemented yet for "
+        << "dartsim. Use AttachMeshShapeFeature to use mesh shapes.\n";
   return {nullptr};
 }
 


### PR DESCRIPTION
Partially addresses #450 by reducing the verbosity of the two errors from "error" to "debug".

In reality, these aren't really errors per se, as the dartsim plugin continues to process the SDF and then attaches meshes and heightmaps in a later stage.

The recent addition of https://github.com/gazebosim/gz-sim/pull/1560 allowing SDF to be constructed in a single shot uncovered these unimplemented functions.

The more complete fix is to take advantage of constructing the models in place, which I have opening an issue for at #451.