### PR TITLE
2.6.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(ignition-cmake2 2.14.0 REQUIRED)
 #============================================================================
 ign_configure_project(
   REPLACE_IGNITION_INCLUDE_PATH gz/physics
-  VERSION_SUFFIX pre1
+  VERSION_SUFFIX
 )
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Gazebo Physics 2.x
 
+### Gazebo Physics 2.6.0 (2022-11-30)
+
+1. Migrate Ignition headers
+    * [Pull request #402](https://github.com/gazebosim/gz-physics/pull/402)
+
 ### Gazebo Physics 2.5.1 (2022-08-16)
 
 1. Remove redundant namespace references


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 2.6.0 release.

Comparison to 2.5.1: https://github.com/gazebosim/gz-physics/compare/ignition-physics2_2.5.1...ign-physics2

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sim/pull/1646

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
