### PR TITLE
Don't install CMakeLists.txt files

### DIFF
--- a/dartsim/include/CMakeLists.txt
+++ b/dartsim/include/CMakeLists.txt
@@ -1,2 +1,0 @@
-add_subdirectory(gz)
-install(DIRECTORY ignition DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL})

--- a/mesh/include/CMakeLists.txt
+++ b/mesh/include/CMakeLists.txt
@@ -1,2 +1,0 @@
-add_subdirectory(gz)
-install(DIRECTORY ignition DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL})

--- a/sdf/include/CMakeLists.txt
+++ b/sdf/include/CMakeLists.txt
@@ -1,2 +1,0 @@
-add_subdirectory(gz)
-install(DIRECTORY ignition DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL})


### PR DESCRIPTION
# 🦟 Bug fix

Fixes unstable debbuilds

## Summary

The debbuilds from 2.6.0 are unstable due to some CMakeLists.txt files being accidentally installed.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-physics2-debbuilder&build=140)](https://build.osrfoundation.org/job/ign-physics2-debbuilder/140/) https://build.osrfoundation.org/job/ign-physics2-debbuilder/140/

This takes an approach similar to gazebosim/gz-common#449 to ensure that they aren't installed.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
