### PR TITLE
Report skipped test as skipped instead of passing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -20,6 +20,9 @@ function(configure_common_test PHYSICS_ENGINE_NAME test_name)
       ${test_name}
       $<TARGET_FILE:${PROJECT_LIBRARY_TARGET_NAME}-${PHYSICS_ENGINE_NAME}-plugin>
   )
+  set_property(TEST ${test_name}_${PHYSICS_ENGINE_NAME} PROPERTY
+    SKIP_REGULAR_EXPRESSION "\[[ \t]*SKIPPED[ \t]*]"
+  )
 endfunction()
 
 set(GZ_PHYSICS_RESOURCE_DIR "${CMAKE_SOURCE_DIR}/resources")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Currently, running `make test` reports "Passed" even though there might be some tests skipped. This fixes that by checking the output of gtest for the string `[  SKIPPED  ]`. The use of the `SKIP_REGULAR_EXPRESSION` property on tests is only available from cmake 3.16, so I've updated the minimum required version. This version is available in all platforms we support for gz-physics6.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
