### PR TITLE
[bullet]: Fix how changed link poses are computed

### DIFF
--- a/bullet-featherstone/src/SimulationFeatures.hh
+++ b/bullet-featherstone/src/SimulationFeatures.hh
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <gz/physics/CanWriteData.hh>
 #include <gz/physics/ForwardStep.hh>
 #include <gz/physics/GetContacts.hh>
 
@@ -36,6 +37,8 @@ struct SimulationFeatureList : gz::physics::FeatureList<
 > { };
 
 class SimulationFeatures :
+    public CanWriteExpectedData<SimulationFeatures,
+      ExpectData<ChangedWorldPoses>>,
     public virtual Base,
     public virtual Implements3d<SimulationFeatureList>
 {

--- a/bullet/src/Base.hh
+++ b/bullet/src/Base.hh
@@ -143,6 +143,25 @@ inline Eigen::Vector3d convert(btVector3 vec)
   return val;
 }
 
+inline math::Vector3d convertToGz(const btVector3 &_vec)
+{
+  return math::Vector3d(_vec[0], _vec[1], _vec[2]);
+}
+
+inline math::Quaterniond convertToGz(const btMatrix3x3 &_mat)
+{
+  return math::Quaterniond(math::Matrix3d(_mat[0][0], _mat[0][1], _mat[0][2],
+                                          _mat[1][0], _mat[1][1], _mat[1][2],
+                                          _mat[2][0], _mat[2][1], _mat[2][2]));
+}
+
+inline math::Pose3d convertToGz(const btTransform &_pose)
+{
+  return math::Pose3d(convertToGz(_pose.getOrigin()),
+                      convertToGz(_pose.getBasis()));
+}
+
+
 class Base : public Implements3d<FeatureList<Feature>>
 {
   public: std::size_t entityCount = 0;
@@ -156,6 +175,7 @@ class Base : public Implements3d<FeatureList<Feature>>
   {
     const auto id = this->GetNextEntity();
     assert(id == 0);
+    (void)id;
 
     return this->GenerateIdentity(0);
   }

--- a/bullet/src/SimulationFeatures.cc
+++ b/bullet/src/SimulationFeatures.cc
@@ -60,7 +60,8 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
     if (info)
     {
       WorldPose wp;
-      wp.pose = info->pose;
+      wp.pose = convertToGz(info->link->getCenterOfMassTransform()) *
+                info->inertialPose.Inverse();
       wp.body = id;
 
       auto iter = this->prevLinkPoses.find(id);

--- a/bullet/src/SimulationFeatures.hh
+++ b/bullet/src/SimulationFeatures.hh
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <gz/physics/CanWriteData.hh>
 #include <gz/physics/ForwardStep.hh>
 
 #include "Base.hh"
@@ -34,6 +35,8 @@ struct SimulationFeatureList : gz::physics::FeatureList<
 > { };
 
 class SimulationFeatures :
+    public CanWriteExpectedData<SimulationFeatures,
+      ExpectData<ChangedWorldPoses>>,
     public virtual Base,
     public virtual Implements3d<SimulationFeatureList>
 {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The existing pose computation used pose data that was never updated by the physics engine. This causes gz-sim to skip updating the poses of links. To test, run `gz sim -v 4 --physics-engine gz-physics-bullet-plugin rolling_shapes.sdf -r`. Without this PR, the shapes do not move.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
