### PR TITLE
Fix build errors and warnings for DART 6.13.0

### DIFF
--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -339,10 +339,17 @@ class Base : public Implements3d<FeatureList<Feature>>
     }
     for (auto &bn : skel->getBodyNodes())
     {
+#if DART_VERSION_AT_LEAST(6, 13, 0)
+      bn->eachShapeNode([this](dart::dynamics::ShapeNode *_sn)
+      {
+        this->shapes.RemoveEntity(_sn);
+      });
+#else
       for (auto &sn : bn->getShapeNodes())
       {
         this->shapes.RemoveEntity(sn);
       }
+#endif
       this->links.RemoveEntity(bn);
     }
     this->models.RemoveEntity(skel);

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -33,6 +33,13 @@
 #include <gz/common/Console.hh>
 #include <gz/physics/Implements.hh>
 
+#if DART_VERSION_AT_LEAST(6, 13, 0)
+// The BodyNode::getShapeNodes method was deprecated in dart 6.13.0
+// in favor of an iterator approach with BodyNode::eachShapeNode
+// See https://github.com/dartsim/dart/pull/1644 for more info
+#define DART_HAS_EACH_SHAPE_NODE_API
+#endif
+
 namespace ignition {
 namespace physics {
 namespace dartsim {
@@ -339,7 +346,7 @@ class Base : public Implements3d<FeatureList<Feature>>
     }
     for (auto &bn : skel->getBodyNodes())
     {
-#if DART_VERSION_AT_LEAST(6, 13, 0)
+#ifdef DART_HAS_EACH_SHAPE_NODE_API
       bn->eachShapeNode([this](dart::dynamics::ShapeNode *_sn)
       {
         this->shapes.RemoveEntity(_sn);

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -170,9 +170,17 @@ dart::constraint::ContactSurfaceParams IgnContactSurfaceHandler::createParams(
   typedef FeaturePolicy3d P;
   typename F::ContactSurfaceParams<P> pIgn;
 
+#if DART_VERSION_AT_LEAST(6, 13, 0)
+  pIgn.frictionCoeff = pDart.mPrimaryFrictionCoeff;
+#else
   pIgn.frictionCoeff = pDart.mFrictionCoeff;
+#endif
   pIgn.secondaryFrictionCoeff = pDart.mSecondaryFrictionCoeff;
+#if DART_VERSION_AT_LEAST(6, 13, 0)
+  pIgn.slipCompliance = pDart.mPrimarySlipCompliance;
+#else
   pIgn.slipCompliance = pDart.mSlipCompliance;
+#endif
   pIgn.secondarySlipCompliance = pDart.mSecondarySlipCompliance;
   pIgn.restitutionCoeff = pDart.mRestitutionCoeff;
   pIgn.firstFrictionalDirection = pDart.mFirstFrictionalDirection;
@@ -185,11 +193,23 @@ dart::constraint::ContactSurfaceParams IgnContactSurfaceHandler::createParams(
                                 _numContactsOnCollisionObject, pIgn);
 
     if (pIgn.frictionCoeff)
+    {
+#if DART_VERSION_AT_LEAST(6, 13, 0)
+      pDart.mPrimaryFrictionCoeff = pIgn.frictionCoeff.value();
+#else
       pDart.mFrictionCoeff = pIgn.frictionCoeff.value();
+#endif
+    }
     if (pIgn.secondaryFrictionCoeff)
       pDart.mSecondaryFrictionCoeff = pIgn.secondaryFrictionCoeff.value();
     if (pIgn.slipCompliance)
+    {
+#if DART_VERSION_AT_LEAST(6, 13, 0)
+      pDart.mPrimarySlipCompliance = pIgn.slipCompliance.value();
+#else
       pDart.mSlipCompliance = pIgn.slipCompliance.value();
+#endif
+    }
     if (pIgn.secondarySlipCompliance)
       pDart.mSecondarySlipCompliance = pIgn.secondarySlipCompliance.value();
     if (pIgn.restitutionCoeff)

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -32,6 +32,15 @@
 #include "gz/common/Profiler.hh"
 #include "gz/physics/GetContacts.hh"
 
+#if DART_VERSION_AT_LEAST(6, 13, 0)
+// The ContactSurfaceParams class was first added to version 6.10 of our fork
+// of dart, and then merged upstream and released in version 6.13.0 with
+// different public member variable names.
+// See https://github.com/dartsim/dart/pull/1626 and
+// https://github.com/gazebo-forks/dart/pull/22 for more info.
+#define DART_HAS_UPSTREAM_FRICTION_VARIABLE_NAMES
+#endif
+
 namespace ignition {
 namespace physics {
 namespace dartsim {
@@ -170,13 +179,13 @@ dart::constraint::ContactSurfaceParams IgnContactSurfaceHandler::createParams(
   typedef FeaturePolicy3d P;
   typename F::ContactSurfaceParams<P> pIgn;
 
-#if DART_VERSION_AT_LEAST(6, 13, 0)
+#ifdef DART_HAS_UPSTREAM_FRICTION_VARIABLE_NAMES
   pIgn.frictionCoeff = pDart.mPrimaryFrictionCoeff;
 #else
   pIgn.frictionCoeff = pDart.mFrictionCoeff;
 #endif
   pIgn.secondaryFrictionCoeff = pDart.mSecondaryFrictionCoeff;
-#if DART_VERSION_AT_LEAST(6, 13, 0)
+#ifdef DART_HAS_UPSTREAM_FRICTION_VARIABLE_NAMES
   pIgn.slipCompliance = pDart.mPrimarySlipCompliance;
 #else
   pIgn.slipCompliance = pDart.mSlipCompliance;
@@ -194,7 +203,7 @@ dart::constraint::ContactSurfaceParams IgnContactSurfaceHandler::createParams(
 
     if (pIgn.frictionCoeff)
     {
-#if DART_VERSION_AT_LEAST(6, 13, 0)
+#ifdef DART_HAS_UPSTREAM_FRICTION_VARIABLE_NAMES
       pDart.mPrimaryFrictionCoeff = pIgn.frictionCoeff.value();
 #else
       pDart.mFrictionCoeff = pIgn.frictionCoeff.value();
@@ -204,7 +213,7 @@ dart::constraint::ContactSurfaceParams IgnContactSurfaceHandler::createParams(
       pDart.mSecondaryFrictionCoeff = pIgn.secondaryFrictionCoeff.value();
     if (pIgn.slipCompliance)
     {
-#if DART_VERSION_AT_LEAST(6, 13, 0)
+#ifdef DART_HAS_UPSTREAM_FRICTION_VARIABLE_NAMES
       pDart.mPrimarySlipCompliance = pIgn.slipCompliance.value();
 #else
       pDart.mSlipCompliance = pIgn.slipCompliance.value();


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
DART 6.13.0 was tagged yesterday and is already available on homebrew. This PR fixes a compilation errors related to `ContactSurfaceParams`, which was a feature added in our fork first and upstreamed. Variable names were changed during the upstreaming process, which now has to be resolved. 

This also fixes a compilation warning with using `BodyNode::getShapeNodes` which is now deprecated and as been replaced by `BodyNode::eachShapeNode`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
