### PR TITLE
Prepare for 2.6.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-physics2 VERSION 2.6.0)
+project(ignition-physics2 VERSION 2.6.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## Gazebo Physics 2.x
 
+### Gazebo Physics 2.6.1 (2023-01-09)
+
+1. Fix build errors and warnings for DART 6.13.0
+    * [Pull request #465](https://github.com/gazebosim/gz-physics/pull/465)
+
+1. Don't install CMakeLists.txt files
+    * [Pull request #456](https://github.com/gazebosim/gz-physics/pull/456)
+
 ### Gazebo Physics 2.6.0 (2022-11-30)
 
 1. Migrate Ignition headers


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.6.1 release.

Comparison to 2.6.0: https://github.com/ignitionrobotics/ign-physics/compare/ignition-physics2_2.6.0...ign-physics2

<!-- Add links to PRs that require this release (if needed) -->
Needed to fix homebrew binaries

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.