### PR TITLE
Do not install common tests

### DIFF
--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -15,8 +15,6 @@ set(tests
   world_features
 )
 
-set(TEST_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/)
-
 # Find the Python interpreter for running the
 # check_test_ran.py script
 include(GzPython)
@@ -61,8 +59,6 @@ foreach(test ${tests})
     "TEST_WORLD_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/worlds/\""
     "GZ_PHYSICS_RESOURCE_DIR=\"${GZ_PHYSICS_RESOURCE_DIR}\""
   )
-
-  install(TARGETS ${test_executable} DESTINATION ${TEST_INSTALL_DIR})
 
   if (${BULLET_FOUND})
     configure_common_test("bullet" ${test_executable})


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Nightlies are complaining about the missing installation of some test files that were added to the `gz-phsyisc6` branch. I assume that we don't want to install them but please let me know otherwise.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.