### PR TITLE
Fix memory corruption due to faulty refcount tracking

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -633,7 +633,6 @@ Identity SDFFeatures::ConstructSdfLink(
       world->getName(),
       ::sdf::JoinName(modelInfo.model->getName(), bn->getName()));
   const std::size_t linkID = this->AddLink(bn, fullName, _modelID, sdfInertia);
-  this->AddJoint(joint);
 
   auto linkIdentity = this->GenerateIdentity(linkID, this->links.at(linkID));
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The memory corruption seems to occur only on DART 6.9.2 (version that comes with Ubuntu 20.04), but not 6.12 (Ubuntu 22.04), so I'm led to believe it's a bug in dart that has since been fixed. But the patch in this PR seems to avoid the problem by not storing the freejoint created when creating links. My suspicion is that this freejoint is not properly taken into account when removing skeletons.

This is blocking https://github.com/gazebosim/gz-sim/pull/1836 as the test `INTEGRATION_recreate_entities` is reliably failing on CI. Running the test under `valgrind` shows that a memory corruption occurs while trying to decrement a reference count of a skeleton. With this patch, the `valgrind` error goes away.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
