### PR TITLE
Add main function to joint transmitted wrench test

### DIFF
--- a/test/common_test/joint_transmitted_wrench_features.cc
+++ b/test/common_test/joint_transmitted_wrench_features.cc
@@ -432,4 +432,11 @@ TYPED_TEST(JointTransmittedWrenchFixture, ContactForces)
                                        wrenchAtMotorJointInJoint, 1e-4));
 }
 
-
+int main(int argc, char *argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  if (!JointTransmittedWrenchFeaturesTest<
+      JointTransmittedWrenchFeatureList>::init(argc, argv))
+    return -1;
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# 🦟 Bug fix

Fixes test coverage reduced in #495 

## Summary

I quickly approved and merged #495 that moved a test to a new file without realizing that it was missing the custom `main` function that is required for our common tests that allows passing the plugin library to the test from the CLI. There was reduced test coverage in #495 and I didn't realize why. This should fix it.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
