### PR TITLE
Fix joint index used in bookkeeping

### DIFF
--- a/dartsim/CMakeLists.txt
+++ b/dartsim/CMakeLists.txt
@@ -83,6 +83,7 @@ gz_build_tests(
   SOURCES ${test_sources}
   LIB_DEPS
     ${features}
+    ${dartsim_plugin}
     gz-plugin${GZ_PLUGIN_VER}::loader
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
     gz-common${GZ_COMMON_VER}::geospatial

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -510,9 +510,9 @@ class Base : public Implements3d<FeatureList<Feature>>
     // Even though DART keeps track of the index of this joint in the
     // skeleton, the joint may be moved to another skeleton when a joint is
     // constructed. Thus, we store the original index here.
-    this->joints.idToIndexInContainer[id] = _joint->getJointIndexInSkeleton();
     std::vector<std::size_t> &indexInContainerToID =
         this->joints.indexInContainerToID[_modelID];
+    this->joints.idToIndexInContainer[id] = indexInContainerToID.size();
     indexInContainerToID.push_back(id);
 
     this->joints.idToContainerID[id] = _modelID;

--- a/dartsim/src/Base_TEST.cc
+++ b/dartsim/src/Base_TEST.cc
@@ -26,6 +26,9 @@
 #include <gz/physics/sdf/ConstructVisual.hh>
 #include <gz/physics/sdf/ConstructWorld.hh>
 
+#include <sdf/Root.hh>
+#include <sdf/Model.hh>
+
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/FreeJoint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -151,6 +154,49 @@ TEST(BaseClass, RemoveModel)
     checkModelIndices();
   }
   EXPECT_EQ(0u, curSize);
+}
+
+
+TEST(BaseClass, SdfConstructionBookkeeping)
+{
+  dartsim::SDFFeatures sdfFeatures;
+  auto engineId = sdfFeatures.InitiateEngine(0);
+  auto worldID = sdfFeatures.ConstructEmptyWorld(engineId, "default");
+
+  ::sdf::Root root;
+
+  auto errors = root.Load(GZ_PHYSICS_RESOURCE_DIR "/rrbot.xml");
+  ASSERT_TRUE(errors.empty());
+  const ::sdf::Model *sdfModel = root.Model();
+  ASSERT_NE(nullptr, sdfModel);
+
+  auto modelID = sdfFeatures.ConstructSdfModel(worldID, *sdfModel);
+  EXPECT_EQ(1u, sdfFeatures.models.size());
+  EXPECT_EQ(sdfModel->LinkCount(), sdfFeatures.links.size());
+  EXPECT_EQ(sdfModel->LinkCount(), sdfFeatures.linksByName.size());
+  EXPECT_EQ(sdfModel->JointCount(), sdfFeatures.joints.size());
+  EXPECT_EQ(2u, sdfFeatures.shapes.size());
+
+  EXPECT_EQ(sdfModel->LinkCount(), sdfFeatures.GetLinkCount(modelID));
+  EXPECT_EQ(sdfModel->JointCount(), sdfFeatures.GetJointCount(modelID));
+
+  for (uint64_t i = 0; i < sdfModel->LinkCount(); ++i)
+  {
+    EXPECT_EQ(sdfModel->LinkByIndex(i)->CollisionCount(),
+              sdfFeatures.GetShapeCount(sdfFeatures.GetLink(modelID, i)));
+  }
+
+  for (uint64_t i =0; i < sdfModel->JointCount(); ++i)
+  {
+    auto jointID = sdfFeatures.GetJoint(modelID, i);
+    ASSERT_TRUE(jointID);
+    ASSERT_EQ(1u, sdfFeatures.joints.idToIndexInContainer.count(jointID));
+    EXPECT_EQ(sdfFeatures.joints.idToIndexInContainer[jointID], i);
+    EXPECT_EQ(sdfFeatures.joints.idToContainerID[jointID], modelID.id);
+
+    ASSERT_GE(sdfFeatures.joints.indexInContainerToID[modelID].size(), i);
+    EXPECT_EQ(sdfFeatures.joints.indexInContainerToID[modelID][i], jointID.id);
+  }
 }
 
 TEST(BaseClass, AddNestedModel)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The joint index obtained from the skeleton counts the freejoint, which is not in line with joint indexing in gz-physics API where there is no notion of free joints. This fixes the `INTEGRATION_recreate_entities` test in gz-sim which broke due to a forward port of #480 to gz-physics6.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
