### PR TITLE
dartsim: Add support for joints in worlds

### DIFF
--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -557,17 +557,16 @@ class Base : public Implements3d<FeatureList<Feature>>
 
     // If this is a nested model, remove an entry from the parent models
     // "nestedModels" vector
+    // Note, it is the responsibility of the caller to avoid calling this
+    // function when `_modelID` points to a proxy model to a world.
     auto parentID = this->models.idToContainerID.at(_modelID);
-    if (parentID != _worldID)
-    {
-      auto parentModelInfo = this->models.at(parentID);
-      const std::size_t modelIndex =
-          this->models.idToIndexInContainer.at(_modelID);
-      if (modelIndex >= parentModelInfo->nestedModels.size())
-        return false;
-      parentModelInfo->nestedModels.erase(
-          parentModelInfo->nestedModels.begin() + modelIndex);
-    }
+    const std::size_t modelIndex =
+        this->models.idToIndexInContainer.at(_modelID);
+    auto parentModelInfo = this->GetModelInfo(parentID);
+    if (modelIndex >= parentModelInfo->nestedModels.size())
+      return false;
+    parentModelInfo->nestedModels.erase(parentModelInfo->nestedModels.begin() +
+                                        modelIndex);
     this->models.RemoveEntity(skel);
     world->removeSkeleton(skel);
     return true;

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -161,6 +161,16 @@ struct EntityStorage
     return idToObject.at(_id);
   }
 
+  const std::optional<Value1> MaybeAt(const std::size_t _id) const
+  {
+    auto it = this->idToObject.find(_id);
+    if (it != this->idToObject.end())
+    {
+      return it->second;
+    }
+    return std::nullopt;
+  }
+
   Value1 &at(const Key2 &_key)
   {
     return idToObject.at(objectToID.at(_key));
@@ -189,6 +199,20 @@ struct EntityStorage
   bool HasEntity(const std::size_t _id) const
   {
     return idToObject.find(_id) != idToObject.end();
+  }
+
+  void AddEntity(std::size_t _id, const Value1 &_value1, const Key2 &_key,
+                 std::size_t _containerID)
+  {
+    this->idToObject[_id] = _value1;
+    this->objectToID[_key] = _id;
+    std::vector<std::size_t> &indexInContainerToIDVector =
+        this->indexInContainerToID[_containerID];
+    const std::size_t indexInContainer = indexInContainerToIDVector.size();
+
+    this->idToIndexInContainer[_id] = indexInContainer;
+    indexInContainerToIDVector.push_back(_id);
+    this->idToContainerID[_id] = _containerID;
   }
 
   bool RemoveEntity(const Key2 &_key)
@@ -275,20 +299,16 @@ class Base : public Implements3d<FeatureList<Feature>>
       const DartWorldPtr &_world, const std::string &_name)
   {
     const std::size_t id = this->GetNextEntity();
-
-    this->worlds.idToObject[id] = _world;
-    this->worlds.objectToID[_name] = id;
-
-    std::vector<std::size_t> &indexInContainerToID =
-        this->worlds.indexInContainerToID.at(0);
-
-    this->worlds.idToIndexInContainer[id] = indexInContainerToID.size();
-    indexInContainerToID.push_back(id);
-
-    this->worlds.idToContainerID[id] = 0;
-
     _world->setName(_name);
+    this->worlds.AddEntity(id, _world, _name, 0);
+
     this->frames[id] = dart::dynamics::Frame::World();
+    auto model = dart::dynamics::Skeleton::create("");
+
+    auto modelInfo = std::make_shared<ModelInfo>();
+    modelInfo->model = model;
+    modelInfo->localName = _name;
+    this->modelProxiesToWorld.AddEntity(id, modelInfo, _world, 0);
 
     return id;
   }
@@ -297,23 +317,19 @@ class Base : public Implements3d<FeatureList<Feature>>
       const ModelInfo &_info, const std::size_t _worldID)
   {
     const std::size_t id = this->GetNextEntity();
-    this->models.idToObject[id] = std::make_shared<ModelInfo>(_info);
-    ModelInfo &entry = *this->models.idToObject[id];
-    this->models.objectToID[_info.model] = id;
+    auto entry = std::make_shared<ModelInfo>(_info);
 
     const dart::simulation::WorldPtr &world = worlds[_worldID];
+    world->addSkeleton(entry->model);
+    this->models.AddEntity(id, entry, _info.model, _worldID);
+    if (_info.frame)
+    {
+      this->frames[id] = _info.frame.get();
+    }
+    auto modelProxy = this->modelProxiesToWorld.at(_worldID);
+    modelProxy->nestedModels.push_back(id);
 
-    std::vector<std::size_t> &indexInContainerToID =
-        this->models.indexInContainerToID[_worldID];
-    const std::size_t indexInWorld = indexInContainerToID.size();
-    this->models.idToIndexInContainer[id] = indexInWorld;
-    indexInContainerToID.push_back(id);
-    world->addSkeleton(entry.model);
-
-    this->models.idToContainerID[id] = _worldID;
-    this->frames[id] = _info.frame.get();
-
-    return std::forward_as_tuple(id, entry);
+    return std::forward_as_tuple(id, *entry);
   }
 
   public: inline std::tuple<std::size_t, ModelInfo &> AddNestedModel(
@@ -321,25 +337,17 @@ class Base : public Implements3d<FeatureList<Feature>>
               const std::size_t _worldID)
   {
     const std::size_t id = this->GetNextEntity();
-    this->models.idToObject[id] = std::make_shared<ModelInfo>(_info);
-    ModelInfo &entry = *this->models.idToObject[id];
-    this->models.objectToID[_info.model] = id;
+    auto entry = std::make_shared<ModelInfo>(_info);
 
     const dart::simulation::WorldPtr &world = worlds[_worldID];
+    world->addSkeleton(entry->model);
 
-    auto parentModelInfo = this->models.at(_parentID);
-    const std::size_t indexInModel =
-        parentModelInfo->nestedModels.size();
-    this->models.idToIndexInContainer[id] = indexInModel;
-    std::vector<std::size_t> &indexInContainerToID =
-        this->models.indexInContainerToID[_parentID];
-    indexInContainerToID.push_back(id);
-    world->addSkeleton(entry.model);
-
-    this->models.idToContainerID[id] = _parentID;
+    this->models.AddEntity(id, entry, _info.model, _parentID);
     this->frames[id] = _info.frame.get();
+
+    auto parentModelInfo = this->GetModelInfo(_parentID);
     parentModelInfo->nestedModels.push_back(id);
-    return {id, entry};
+    return {id, *entry};
   }
 
   public: inline std::size_t AddLink(DartBodyNode *_bn,
@@ -348,7 +356,6 @@ class Base : public Implements3d<FeatureList<Feature>>
   {
     const std::size_t id = this->GetNextEntity();
     auto linkInfo = std::make_shared<LinkInfo>();
-    this->links.idToObject[id] = linkInfo;
     linkInfo->link = _bn;
     // The name of the BodyNode during creation is assumed to be the
     // Gazebo-specified name.
@@ -356,21 +363,11 @@ class Base : public Implements3d<FeatureList<Feature>>
     // Inertial properties (if available) used when splitting nodes to close
     // kinematic loops.
     linkInfo->inertial = _inertial;
-    this->links.objectToID[_bn] = id;
+    this->links.AddEntity(id, linkInfo, _bn, _modelID);
     this->frames[id] = _bn;
 
     this->linksByName[_fullName] = _bn;
     this->models.at(_modelID)->links.push_back(linkInfo);
-
-    // Even though DART keeps track of the index of this BodyNode in the
-    // skeleton, the BodyNode may be moved to another skeleton when a joint is
-    // constructed. Thus, we store the original index here.
-    this->links.idToIndexInContainer[id] = _bn->getIndexInSkeleton();
-    std::vector<std::size_t> &indexInContainerToID =
-        this->links.indexInContainerToID[_modelID];
-    indexInContainerToID.push_back(id);
-
-    this->links.idToContainerID[id] = _modelID;
 
     return id;
   }
@@ -494,29 +491,16 @@ class Base : public Implements3d<FeatureList<Feature>>
   {
     const std::size_t id = this->GetNextEntity();
     auto jointInfo = std::make_shared<JointInfo>();
-    this->joints.idToObject[id] = jointInfo;
     jointInfo->joint = _joint;
+    this->joints.AddEntity(id, jointInfo, _joint, _modelID);
 
-    this->joints.idToObject[id]->joint = _joint;
-    this->joints.objectToID[_joint] = id;
     dart::dynamics::SimpleFramePtr jointFrame =
         dart::dynamics::SimpleFrame::createShared(
             _joint->getChildBodyNode(), _joint->getName() + "_frame",
             _joint->getTransformFromChildBodyNode());
 
     this->jointsByName[_fullName] = _joint;
-    this->models.at(_modelID)->joints.push_back(jointInfo);
-
-    // Even though DART keeps track of the index of this joint in the
-    // skeleton, the joint may be moved to another skeleton when a joint is
-    // constructed. Thus, we store the original index here.
-    std::vector<std::size_t> &indexInContainerToID =
-        this->joints.indexInContainerToID[_modelID];
-    this->joints.idToIndexInContainer[id] = indexInContainerToID.size();
-    indexInContainerToID.push_back(id);
-
-    this->joints.idToContainerID[id] = _modelID;
-
+    this->GetModelInfo(_modelID)->joints.push_back(jointInfo);
     this->joints.idToObject[id]->frame = jointFrame;
     this->frames[id] = this->joints.idToObject[id]->frame.get();
 
@@ -592,6 +576,12 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: inline std::size_t GetWorldOfModelImpl(
               const std::size_t &_modelID) const
   {
+    auto worldModelProxy = this->modelProxiesToWorld.MaybeAt(_modelID);
+    if (worldModelProxy.has_value())
+    {
+      return _modelID;
+    }
+
     if (this->models.HasEntity(_modelID))
     {
       auto parentIt = this->models.idToContainerID.find(_modelID);
@@ -620,32 +610,49 @@ class Base : public Implements3d<FeatureList<Feature>>
     }
   };
 
+
   /// \brief Create a fully (world) scoped joint name.
   /// \param _modelID Identity of the parent model of the joint's child link.
   /// \param _name The unscoped joint name.
   /// \return The fully (world) scoped joint name, or an empty string
   /// if a world cannot be resolved.
   public: inline std::string FullyScopedJointName(
-    const Identity &_modelID,
+    const std::size_t &_modelID,
     const std::string &_name) const
   {
-    const auto modelInfo = this->ReferenceInterface<ModelInfo>(_modelID);
-
-    auto worldID = this->GetWorldOfModelImpl(_modelID);
-    if (worldID == INVALID_ENTITY_ID)
+    if (this->modelProxiesToWorld.HasEntity(_modelID))
     {
-      gzerr << "World of model [" << modelInfo->model->getName()
-            << "] could not be found when creating joint [" << _name
-            << "]\n";
-      return "";
+      auto world = this->worlds.at(_modelID);
+      return ::sdf::JoinName(world->getName(), _name);
     }
+    else
+    {
+      const auto modelInfo = this->models.at(_modelID);
 
-    auto world = this->worlds.at(worldID);
-    const std::string fullJointName = ::sdf::JoinName(
-        world->getName(),
-        ::sdf::JoinName(modelInfo->model->getName(), _name));
+      auto worldID = this->GetWorldOfModelImpl(_modelID);
+      if (worldID == INVALID_ENTITY_ID)
+      {
+        gzerr << "World of model [" << modelInfo->model->getName()
+              << "] could not be found when creating the fully scoped name of "
+                 "joint ["
+              << _name << "]\n";
+        return "";
+      }
+      auto world = this->worlds.at(worldID);
+      return ::sdf::JoinName(
+          world->getName(),
+          ::sdf::JoinName(modelInfo->model->getName(), _name));
+    }
+  }
 
-    return fullJointName;
+  public: ModelInfoPtr GetModelInfo(std::size_t _modelID) const
+  {
+    auto modelProxy = this->modelProxiesToWorld.MaybeAt(_modelID);
+    if (modelProxy)
+    {
+      return *modelProxy;
+    }
+    return this->models.at(_modelID);
   }
 
   public: EntityStorage<DartWorldPtr, std::string> worlds;
@@ -654,6 +661,7 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: EntityStorage<JointInfoPtr, const DartJoint*> joints;
   public: EntityStorage<ShapeInfoPtr, const DartShapeNode*> shapes;
   public: std::unordered_map<std::size_t, dart::dynamics::Frame*> frames;
+  public: EntityStorage<ModelInfoPtr, DartWorldPtr> modelProxiesToWorld;
 
   /// \brief Map from the fully qualified link name (including the world name)
   /// to the BodyNode object. This is useful for keeping track of BodyNodes even

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -709,20 +709,16 @@ bool EntityManagementFeatures::RemoveNestedModelByName(const Identity &_modelID,
   const std::string fullName =
       ::sdf::JoinName(modelInfo->model->getName(), _modelName);
 
-  if (this->models.HasEntity(_modelID))
+  auto worldID = this->GetWorldOfModelImpl(_modelID);
+  auto nestedSkel = this->worlds.at(worldID)->getSkeleton(fullName);
+  if (nullptr == nestedSkel || !this->models.HasEntity(nestedSkel))
   {
-    auto worldID = this->GetWorldOfModelImpl(_modelID);
-    auto nestedSkel = this->worlds.at(worldID)->getSkeleton(fullName);
-    if (nullptr == nestedSkel || !this->models.HasEntity(nestedSkel))
-    {
-      return false;
-    }
-    const std::size_t nestedModelID = this->models.IdentityOf(nestedSkel);
-    const auto filterPtr = GetFilterPtr(this, worldID);
-    filterPtr->RemoveSkeletonCollisions(nestedSkel);
-    return this->RemoveModelImpl(worldID, nestedModelID);
+    return false;
   }
-  return false;
+  const std::size_t nestedModelID = this->models.IdentityOf(nestedSkel);
+  const auto filterPtr = GetFilterPtr(this, worldID);
+  filterPtr->RemoveSkeletonCollisions(nestedSkel);
+  return this->RemoveModelImpl(worldID, nestedModelID);
 }
 /////////////////////////////////////////////////
 Identity EntityManagementFeatures::ConstructEmptyWorld(

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -258,6 +258,12 @@ const std::string &EntityManagementFeatures::GetModelName(
 std::size_t EntityManagementFeatures::GetModelIndex(
     const Identity &_modelID) const
 {
+  // If this is a model proxy of a world, we just return 0.
+  auto modelProxy = this->modelProxiesToWorld.MaybeAt(_modelID);
+  if (modelProxy)
+  {
+    return 0;
+  }
   // TODO(anyone) this will throw if the model has been removed. The alternative
   // is to first check if the model exists, but what should we return if it
   // doesn't exist
@@ -317,22 +323,20 @@ Identity EntityManagementFeatures::GetNestedModel(
   const std::string fullName =
       ::sdf::JoinName(modelInfo->model->getName(), _modelName);
 
-  if (this->models.HasEntity(_modelID))
-  {
-    auto worldID = this->GetWorldOfModelImpl(_modelID);
-    auto nestedSkel = this->worlds.at(worldID)->getSkeleton(fullName);
-    if (nullptr == nestedSkel)
-    {
-      return this->GenerateInvalidId();
-    }
-    const std::size_t nestedModelID = this->models.IdentityOf(nestedSkel);
-    return this->GenerateIdentity(nestedModelID,
-                                  this->models.at(nestedModelID));
-  }
-  else
+  auto worldID = this->GetWorldOfModelImpl(_modelID);
+  if (!worldID)
   {
     return this->GenerateInvalidId();
   }
+
+  auto nestedSkel = this->worlds.at(worldID)->getSkeleton(fullName);
+  if (nullptr == nestedSkel)
+  {
+    return this->GenerateInvalidId();
+  }
+  const std::size_t nestedModelID = this->models.IdentityOf(nestedSkel);
+  return this->GenerateIdentity(nestedModelID,
+      this->models.at(nestedModelID));
 }
 
 /////////////////////////////////////////////////
@@ -404,7 +408,7 @@ Identity EntityManagementFeatures::GetLink(
 std::size_t EntityManagementFeatures::GetJointCount(
     const Identity &_modelID) const
 {
-  return this->ReferenceInterface<ModelInfo>(_modelID)->model->getNumJoints();
+  return this->ReferenceInterface<ModelInfo>(_modelID)->joints.size();
 }
 
 /////////////////////////////////////////////////
@@ -566,12 +570,14 @@ Identity EntityManagementFeatures::GetModelOfJoint(
     const Identity &_jointID) const
 {
   const std::size_t modelID = this->joints.idToContainerID.at(_jointID);
+  auto modelInfo = this->GetModelInfo(modelID);
+
 
   // If the model containing the joint doesn't exist in "models", it means this
   // joint belongs to a removed model.
-  if (this->models.HasEntity(modelID))
+  if (modelInfo)
   {
-    return this->GenerateIdentity(modelID, this->models.at(modelID));
+    return this->GenerateIdentity(modelID, modelInfo);
   }
   else
   {
@@ -666,6 +672,11 @@ bool EntityManagementFeatures::RemoveModel(const Identity &_modelID)
 /////////////////////////////////////////////////
 bool EntityManagementFeatures::ModelRemoved(const Identity &_modelID) const
 {
+  auto modelProxy = this->modelProxiesToWorld.MaybeAt(_modelID);
+  if (modelProxy)
+  {
+    return false;
+  }
   return !this->models.HasEntity(_modelID);
 }
 
@@ -755,7 +766,7 @@ Identity EntityManagementFeatures::ConstructEmptyNestedModel(
 {
   // find the world assocated with the model
   auto worldID = this->GetWorldOfModelImpl(_parentModelID);
-  const auto &skel = this->models.at(_parentModelID)->model;
+  const auto &skel = this->GetModelInfo(_parentModelID)->model;
   const std::string modelFullName = ::sdf::JoinName(skel->getName(), _name);
 
   dart::dynamics::SkeletonPtr model =
@@ -776,6 +787,11 @@ Identity EntityManagementFeatures::ConstructEmptyNestedModel(
 Identity EntityManagementFeatures::ConstructEmptyLink(
     const Identity &_modelID, const std::string &_name)
 {
+  // Return early if model is a proxy to the world.
+  if (this->modelProxiesToWorld.MaybeAt(_modelID))
+  {
+    return this->GenerateInvalidId();
+  }
   auto model = this->ReferenceInterface<ModelInfo>(_modelID)->model;
 
   dart::dynamics::FreeJoint::Properties prop_fj;
@@ -833,6 +849,15 @@ void EntityManagementFeatures::RemoveCollisionFilterMask(
   filterPtr->RemoveIgnoredCollision(shapeNode);
 }
 
+Identity EntityManagementFeatures::GetWorldModel(const Identity &_worldID) const
+{
+  auto modelID = this->modelProxiesToWorld.MaybeAt(_worldID);
+  if (modelID)
+  {
+    return this->GenerateIdentity(_worldID, *modelID);
+  }
+  return this->GenerateInvalidId();
 }
+}  // namespace dartsim
 }
 }

--- a/dartsim/src/EntityManagementFeatures.hh
+++ b/dartsim/src/EntityManagementFeatures.hh
@@ -39,7 +39,8 @@ struct EntityManagementFeatureList : FeatureList<
   ConstructEmptyModelFeature,
   ConstructEmptyNestedModelFeature,
   ConstructEmptyLinkFeature,
-  CollisionFilterMaskFeature
+  CollisionFilterMaskFeature,
+  WorldModelFeature
 > { };
 
 class EntityManagementFeatures :
@@ -174,6 +175,9 @@ class EntityManagementFeatures :
       const Identity &_shapeID) const override;
 
   public: void RemoveCollisionFilterMask(const Identity &_shapeID) override;
+
+  // ----- World model feature -----
+  public: Identity GetWorldModel(const Identity &_worldID) const override;
 };
 
 }

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -432,7 +432,11 @@ SDFFeatures::FindParentAndChildOfJoint(std::size_t _worldID,
     return {};
   }
 
-  // Determine the model associated with the joint. This will be the
+  // When calling `FindBodyNode`, we need to check wheter the parent entity
+  // (different from parent link/frame) of the joint is a model or world. If it
+  // is a world, relative name we provide to `FindBodyNode` should *not* be
+  // prefixed by the world name since is that step is done in `FindBodyNode`
+  // itself.
 
   auto *const parent = this->FindBodyNode(
       this->worlds.at(_worldID)->getName(),

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include <dart/constraint/ConstraintSolver.hpp>
 #include <dart/dynamics/BallJoint.hpp>
@@ -377,7 +378,7 @@ static ShapeAndTransform ConstructGeometry(
 /////////////////////////////////////////////////
 dart::dynamics::BodyNode *SDFFeatures::FindBodyNode(
     const std::string &_worldName, const std::string &_jointModelName,
-    const std::string &_linkRelativeName)
+    const std::string &_linkRelativeName) const
 {
   if (_linkRelativeName == "world")
     return nullptr;
@@ -392,6 +393,71 @@ dart::dynamics::BodyNode *SDFFeatures::FindBodyNode(
   gzerr << "Could not find link " << _linkRelativeName << " in model "
          << _jointModelName << std::endl;
   return nullptr;
+}
+
+std::optional<std::pair<dart::dynamics::BodyNode *, dart::dynamics::BodyNode *>>
+SDFFeatures::FindParentAndChildOfJoint(std::size_t _worldID,
+                                       const ::sdf::Joint *_sdfJoint,
+                                       const std::string &_parentName,
+                                       const std::string &_parentType) const
+{
+
+  // Resolve parent and child frames to links
+  std::string parentLinkName;
+  ::sdf::Errors errors = _sdfJoint->ResolveParentLink(parentLinkName);
+  if (!errors.empty())
+  {
+    gzerr << "The link of the parent frame [" << _sdfJoint->ParentName()
+      << "] of joint [" << _sdfJoint->Name() << "] in " << _parentType
+      << " [" << _parentName
+      << "] could not be resolved. The joint will not be constructed\n";
+    for (const auto &error : errors)
+    {
+      gzerr << error << std::endl;
+    }
+    return {};
+  }
+  std::string childLinkName;
+  errors = _sdfJoint->ResolveChildLink(childLinkName);
+  if (!errors.empty())
+  {
+    gzerr << "The link of the child frame [" << _sdfJoint->ChildName()
+      << "] of joint [" << _sdfJoint->Name() << "] in " << _parentType
+      << " [" << _parentName
+      << "] could not be resolved. The joint will not be constructed\n";
+    for (const auto &error : errors)
+    {
+      gzerr << error << std::endl;
+    }
+    return {};
+  }
+
+  // Determine the model associated with the joint. This will be the
+
+  auto *const parent = this->FindBodyNode(
+      this->worlds.at(_worldID)->getName(),
+      _parentType == "model" ? _parentName : "", parentLinkName);
+
+  if (nullptr == parent && parentLinkName != "world")
+  {
+    gzerr << "The parent [" << _sdfJoint->ParentName() << "] of joint ["
+      << _sdfJoint->Name() << "] in " << _parentType << " [" << _parentName
+      << "] was not found. The joint will not be constructed\n";
+    return {};
+  }
+
+  auto *const child = this->FindBodyNode(
+      this->worlds.at(_worldID)->getName(),
+      _parentType == "model" ? _parentName : "", childLinkName);
+  if (nullptr == child)
+  {
+    gzerr << "The child of joint [" << _sdfJoint->Name() << "] in "
+          << _parentType << " [" << _parentName
+          << "] was not found. The joint will not be constructed\n";
+    return {};
+  }
+
+  return std::make_pair(parent, child);
 }
 
 /////////////////////////////////////////////////
@@ -419,6 +485,28 @@ Identity SDFFeatures::ConstructSdfWorld(
     this->ConstructSdfNestedModel(worldID, *model);
   }
 
+  auto modelProxy = this->modelProxiesToWorld.MaybeAt(worldID);
+  if (modelProxy)
+  {
+    for (std::size_t i = 0; i < _sdfWorld.JointCount(); ++i)
+    {
+      const ::sdf::Joint *sdfJoint = _sdfWorld.JointByIndex(i);
+      if (!sdfJoint)
+      {
+        gzerr << "The joint with index [" << i << "] in world ["
+              << _sdfWorld.Name() << "] is a nullptr. It will be skipped.\n";
+        continue;
+      }
+      auto parentAndChild = this->FindParentAndChildOfJoint(
+          worldID, sdfJoint, _sdfWorld.Name(), "world");
+      if (parentAndChild)
+      {
+        auto [parent, child] = *parentAndChild;
+        this->ConstructSdfJoint(this->GetWorldModel(worldID), *sdfJoint, parent,
+                                child);
+      }
+    }
+  }
   return worldID;
 }
 
@@ -521,82 +609,16 @@ Identity SDFFeatures::ConstructSdfModelImpl(
     if (!sdfJoint)
     {
       gzerr << "The joint with index [" << i << "] in model ["
-             << _sdfModel.Name() << "] is a nullptr. It will be skipped.\n";
+        << modelName << "] is a nullptr. It will be skipped.\n";
       continue;
     }
-
-    // Resolve parent and child frames to links
-    std::string parentLinkName;
-    ::sdf::Errors errors = sdfJoint->ResolveParentLink(parentLinkName);
-    if (!errors.empty())
+    auto parentAndChild =
+        this->FindParentAndChildOfJoint(worldID, sdfJoint, modelName, "model");
+    if (parentAndChild)
     {
-      gzerr << "The link of the parent frame [" << sdfJoint->ParentName()
-             << "] of joint [" << sdfJoint->Name() << "] in model ["
-             << modelName
-             << "] could not be resolved. The joint will not be constructed\n";
-      for (const auto &error : errors)
-      {
-        gzerr << error << std::endl;
-      }
-      continue;
+      auto [parent, child] = *parentAndChild;
+      this->ConstructSdfJoint(modelIdentity, *sdfJoint, parent, child);
     }
-    std::string childLinkName;
-    errors = sdfJoint->ResolveChildLink(childLinkName);
-    if (!errors.empty())
-    {
-      gzerr << "The link of the child frame [" << sdfJoint->ChildName()
-             << "] of joint [" << sdfJoint->Name() << "] in model ["
-             << modelName
-             << "] could not be resolved. The joint will not be constructed\n";
-      for (const auto &error : errors)
-      {
-        gzerr << error << std::endl;
-      }
-      continue;
-    }
-
-    const ::sdf::Link *parentSdfLink = _sdfModel.LinkByName(parentLinkName);
-    if (nullptr == parentSdfLink && parentLinkName != "world")
-    {
-      gzerr << "The link [" << parentLinkName << "] of the parent frame ["
-             << sdfJoint->ParentName() << "] of joint [" << sdfJoint->Name()
-             << "] in model [" << modelName
-             << "] could not be resolved. The joint will not be constructed\n";
-      continue;
-    }
-
-    const ::sdf::Link *childSdfLink = _sdfModel.LinkByName(childLinkName);
-    if (nullptr == childSdfLink)
-    {
-      gzerr << "The link [" << childLinkName << "] of the child frame ["
-             << sdfJoint->ChildName() << "] of joint [" << sdfJoint->Name()
-             << "] in model [" << modelName
-             << "] could not be resolved. The joint will not be constructed\n";
-      continue;
-    }
-
-    auto * const parent =
-      FindBodyNode(this->worlds[worldID]->getName(), modelName, parentLinkName);
-
-    if (nullptr == parent && parentLinkName != "world")
-    {
-      gzerr << "The parent [" << sdfJoint->ParentName() << "] of joint ["
-             << sdfJoint->Name() << "] in model [" << modelName
-             << "] was not found. The joint will not be constructed\n";
-      continue;
-    }
-
-    auto * const child =
-      FindBodyNode(worlds[worldID]->getName(), modelName, childLinkName);
-    if (nullptr == child)
-    {
-      gzerr << "The child of joint [" << sdfJoint->Name() << "] in model ["
-             << modelName
-             << "] was not found. The joint will not be constructed\n";
-      continue;
-    }
-
-    this->ConstructSdfJoint(modelInfo, *sdfJoint, parent, child);
   }
 
   return modelIdentity;
@@ -607,6 +629,11 @@ Identity SDFFeatures::ConstructSdfLink(
     const Identity &_modelID,
     const ::sdf::Link &_sdfLink)
 {
+  // Return early if model is a proxy to the world.
+  if (this->modelProxiesToWorld.MaybeAt(_modelID))
+  {
+    return this->GenerateInvalidId();
+  }
   const auto &modelInfo = *this->ReferenceInterface<ModelInfo>(_modelID);
   dart::dynamics::BodyNode::Properties bodyProperties;
   bodyProperties.mName = _sdfLink.Name();
@@ -787,7 +814,7 @@ Identity SDFFeatures::ConstructSdfJoint(
     return this->GenerateInvalidId();
   }
 
-  return ConstructSdfJoint(modelInfo, _sdfJoint, parent, child);
+  return ConstructSdfJoint(_modelID, _sdfJoint, parent, child);
 }
 
 /////////////////////////////////////////////////
@@ -1017,11 +1044,12 @@ dart::dynamics::BodyNode *SDFFeatures::FindOrConstructLink(
 
 /////////////////////////////////////////////////
 Identity SDFFeatures::ConstructSdfJoint(
-    const ModelInfo &_modelInfo,
+    const Identity &_modelID,
     const ::sdf::Joint &_sdfJoint,
     dart::dynamics::BodyNode * const _parent,
     dart::dynamics::BodyNode * const _child)
 {
+  const auto &_modelInfo = *this->ReferenceInterface<ModelInfo>(_modelID);
   // if a specified link is named "world" but cannot be found, we'll assume the
   // joint is connected to the world
   bool worldParent = (!_parent && _sdfJoint.ParentName() == "world");
@@ -1159,22 +1187,10 @@ Identity SDFFeatures::ConstructSdfJoint(
   joint->setTransformFromParentBodyNode(parent_T_prejoint_init);
   joint->setTransformFromChildBodyNode(child_T_postjoint);
 
-  auto modelID = this->models.IdentityOf(_modelInfo.model);
-  auto worldID = this->GetWorldOfModelImpl(modelID);
-  if (worldID == INVALID_ENTITY_ID)
-  {
-    gzerr << "World of model [" << _modelInfo.model->getName()
-           << "] could not be found when creating joint [" << jointName
-           << "]\n";
-    return this->GenerateInvalidId();
-  }
+  const std::string fullJointName =
+      this->FullyScopedJointName(_modelID, jointName);
 
-  auto world = this->worlds.at(worldID);
-  const std::string fullJointName = ::sdf::JoinName(
-      world->getName(),
-      ::sdf::JoinName(_modelInfo.model->getName(), jointName));
-
-  const std::size_t jointID = this->AddJoint(joint, fullJointName, modelID);
+  const std::size_t jointID = this->AddJoint(joint, fullJointName, _modelID);
   // Increment BodyNode version since the child could be moved to a new skeleton
   // when a joint is created.
   // TODO(azeey) Remove incrementVersion once DART has been updated to

--- a/dartsim/src/SDFFeatures.hh
+++ b/dartsim/src/SDFFeatures.hh
@@ -20,6 +20,7 @@
 
 #include <gz/math/Inertial.hh>
 #include <string>
+#include <utility>
 
 #include <gz/physics/sdf/ConstructCollision.hh>
 #include <gz/physics/sdf/ConstructJoint.hh>
@@ -30,6 +31,7 @@
 #include <gz/physics/sdf/ConstructWorld.hh>
 
 #include <gz/physics/Implements.hh>
+#include <sdf/Joint.hh>
 
 #include "Base.hh"
 #include "EntityManagementFeatures.hh"
@@ -93,7 +95,7 @@ class SDFFeatures :
   /// assumed to be world
   /// \param[in] _child Pointer to child link. If nullptr, the child is assumed
   /// to be world
-  private: Identity ConstructSdfJoint(const ModelInfo &_modelInfo,
+  private: Identity ConstructSdfJoint(const Identity &_modelID,
       const ::sdf::Joint &_sdfJoint,
       dart::dynamics::BodyNode * const _parent,
       dart::dynamics::BodyNode * const _child);
@@ -124,7 +126,15 @@ class SDFFeatures :
   private: dart::dynamics::BodyNode *FindBodyNode(
                const std::string &_worldName,
                const std::string &_jointModelName,
-               const std::string &_linkRelativeName);
+               const std::string &_linkRelativeName) const;
+
+  private:
+      std::optional<
+          std::pair<dart::dynamics::BodyNode *, dart::dynamics::BodyNode *>>
+      FindParentAndChildOfJoint(std::size_t _worldID,
+                                const ::sdf::Joint *_sdfJoint,
+                                const std::string &_parentName,
+                                const std::string &_parentType) const;
 };
 
 }

--- a/include/gz/physics/GetEntities.hh
+++ b/include/gz/physics/GetEntities.hh
@@ -505,6 +505,45 @@ namespace gz
       };
     };
 
+    /////////////////////////////////////////////////
+    /// \brief This feature retrieves a model proxy of a world so that model
+    /// APIs can be used on the world, e.g., to access a world joint.
+    ///
+    /// Entities such as joints are only available in a Model. To support world
+    /// joints, instead of creating a new type of entity, we have chosen to
+    /// implement a scheme where the world behaves like a model via this
+    /// feature. Given a world, `w`, we can do `model = w->GetWorldModel()` to
+    /// get the model proxy. We can then use any of the APIs supported by the
+    /// features available in the physics engine, e.g., `model->GetJoint("j1")`.
+    /// where "j1" is a joint directly under `<world>` in the SDFormat.
+    ///
+    /// Note: Certain features available on models, such as
+    /// `RemoveModelFromWorld`, `ConstructEmptyLink`, and `ConstructSdfLink` are
+    /// not valid on the model proxy. Physics engine plugin implementers should
+    /// ensure that calls to APIs from these features fail gracefully.
+    class GZ_PHYSICS_VISIBLE WorldModelFeature : public virtual Feature
+    {
+      public: template <typename PolicyT, typename FeaturesT>
+              class World: public virtual Feature::World<PolicyT, FeaturesT>
+      {
+        public: using ModelPtrType = ModelPtr<PolicyT, FeaturesT>;
+        public: using ConstModelPtrType = ConstModelPtr<PolicyT, FeaturesT>;
+
+        /// \brief Get the model that represents the world.
+        public: ModelPtrType GetWorldModel();
+
+        /// \sa GetWorldModel()
+        public: ConstModelPtrType GetWorldModel() const;
+      };
+
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        public:
+            virtual Identity GetWorldModel(const Identity &_worldID) const = 0;
+      };
+    };
+
     struct GetEntities : FeatureList<
       GetEngineInfo,
       GetWorldFromEngine,

--- a/include/gz/physics/detail/GetEntities.hh
+++ b/include/gz/physics/detail/GetEntities.hh
@@ -521,6 +521,26 @@ namespace gz
             this->template Interface<GetJointFromModel>()
               ->GetModelOfJoint(this->identity));
     }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    auto WorldModelFeature::World<PolicyT, FeaturesT>::GetWorldModel()
+        -> ModelPtrType
+    {
+      return ModelPtrType(this->pimpl,
+            this->template Interface<WorldModelFeature>()
+              ->GetWorldModel(this->identity));
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    auto WorldModelFeature::World<PolicyT, FeaturesT>::GetWorldModel() const
+        -> ConstModelPtrType
+    {
+      return ConstModelPtrType(this->pimpl,
+            this->template Interface<WorldModelFeature>()
+              ->GetWorldModel(this->identity));
+    }
   }
 }
 

--- a/test/common_test/world_features.cc
+++ b/test/common_test/world_features.cc
@@ -235,7 +235,7 @@ TEST_F(WorldModelTest, WorldModelAPI)
     EXPECT_EQ(nullptr, worldModel->GetLink("nonexistent_link"));
     EXPECT_EQ(0, worldModel->GetIndex());
     EXPECT_EQ(world->GetModelCount(), worldModel->GetNestedModelCount());
-    auto nestedModel = worldModel->GetNestedModel(0);
+    const auto nestedModel = worldModel->GetNestedModel(0);
     ASSERT_NE(nullptr, nestedModel);
     EXPECT_EQ("m1", nestedModel->GetName());
     EXPECT_NE(nullptr, worldModel->GetNestedModel("m2"));
@@ -250,6 +250,25 @@ TEST_F(WorldModelTest, WorldModelAPI)
     auto worldModel2 = world->GetWorldModel();
     ASSERT_NE(nullptr, worldModel2);
     EXPECT_EQ(world, worldModel2->GetWorld());
+
+    EXPECT_EQ(2u, world->GetModelCount());
+    EXPECT_EQ(2u, worldModel->GetNestedModelCount());
+
+    // Check that we can remove models via RemoveNestedModel
+    EXPECT_TRUE(worldModel->RemoveNestedModel(0));
+    EXPECT_TRUE(nestedModel->Removed());
+    EXPECT_EQ(1u, world->GetModelCount());
+    EXPECT_EQ(1u, worldModel->GetNestedModelCount());
+    EXPECT_NE(nullptr, worldModel->GetNestedModel(0));
+    EXPECT_EQ(nullptr, worldModel->GetNestedModel("m1"));
+
+    const auto m2 = worldModel->GetNestedModel("m2");
+    ASSERT_NE(nullptr, m2);
+    EXPECT_TRUE(worldModel->RemoveNestedModel("m2"));
+    EXPECT_TRUE(m2->Removed());
+    EXPECT_EQ(0u, world->GetModelCount());
+    EXPECT_EQ(0u, worldModel->GetNestedModelCount());
+    EXPECT_EQ(nullptr, worldModel->GetNestedModel("m2"));
 
     // Check that we can construct nested models and joints, but not links
     auto m3 = worldModel->ConstructEmptyNestedModel("m3");
@@ -277,6 +296,26 @@ TEST_F(WorldModelTest, WorldModelAPI)
     EXPECT_TRUE(worldModel->ConstructNestedModel(sdfModel));
     EXPECT_TRUE(world->GetModel("m4"));
     EXPECT_TRUE(worldModel->GetNestedModel("m4"));
+
+    EXPECT_EQ(2u, world->GetModelCount());
+    EXPECT_EQ(2u, worldModel->GetNestedModelCount());
+    // Check that we can remove created via the World model proxy
+    EXPECT_EQ(m3, worldModel->GetNestedModel(0));
+    EXPECT_TRUE(worldModel->RemoveNestedModel(0));
+    EXPECT_TRUE(m3->Removed());
+    EXPECT_EQ(1u, world->GetModelCount());
+    EXPECT_EQ(1u, worldModel->GetNestedModelCount());
+    EXPECT_EQ(nullptr, worldModel->GetNestedModel("m3"));
+    EXPECT_EQ(nullptr, world->GetModel("m3"));
+
+    const auto m4 = worldModel->GetNestedModel("m4");
+    ASSERT_NE(nullptr, m4);
+    EXPECT_TRUE(worldModel->RemoveNestedModel("m4"));
+    EXPECT_EQ(0u, world->GetModelCount());
+    EXPECT_EQ(0u, worldModel->GetNestedModelCount());
+    EXPECT_TRUE(m4->Removed());
+    EXPECT_EQ(nullptr, worldModel->GetNestedModel("m4"));
+    EXPECT_EQ(nullptr, world->GetModel("m4"));
   }
 }
 

--- a/test/common_test/worlds/world_joint_test.sdf
+++ b/test/common_test/worlds/world_joint_test.sdf
@@ -1,0 +1,38 @@
+<sdf version="1.10">
+  <world name="default">
+    <joint name="j1" type="fixed">
+      <parent>world</parent>
+      <child>m1</child>
+    </joint>
+
+    <model name="m1">
+      <link name="link1">
+        <inertial>
+          <mass>1</mass>
+        </inertial>
+      </link>
+    </model>
+
+    <joint name="j2" type="revolute">
+      <parent>m1</parent>
+      <child>m2</child>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>-0.5</lower>
+          <upper>0.5</upper>
+          <effort>100</effort>
+        </limit>
+      </axis>
+    </joint>
+
+    <model name="m2">
+      <link name="link2">
+        <inertial>
+          <mass>1</mass>
+        </inertial>
+      </link>
+    </model>
+  </world>
+</sdf>
+


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/gz-physics/issues/457

## Summary
As of https://github.com/gazebosim/sdformat/pull/1117, SDFormat supports joints under world (`//world/joint` in xpath). But in gz-physics, Entities such as joints are only available in a Model. To support world joints, instead of creating a new type of entity, we have chosen to implement a scheme where the world behaves like a model via the `WorldModelFeature` feature. Given a world, `w`, we can do `model = w->GetWorldModel()` to get the model proxy. We can then use any of the APIs supported by the features available in the physics engine, e.g., `model->GetJoint("j1")` where "j1" is a joint directly under `<world>` in the SDFormat.

Some refactoring of `Base.hh` has already been split out into #500, so that should be merged first.

## Test it
Tests have been added to tests `test/common_test/joint_features.cc` and  `test/common_test/world_features.cc`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
