### PR TITLE
Fix bullet related segfaults on macOS

### DIFF
--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -354,8 +354,10 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: std::unordered_map<std::size_t, CollisionInfoPtr> collisions;
   public: std::unordered_map<std::size_t, JointInfoPtr> joints;
 
-  public: std::vector<std::unique_ptr<btGImpactMeshShape>> meshesGImpact;
+  // Note, the order of triangleMeshes and meshesGImpact is important. Reversing
+  // the order causes segfaults on macOS during destruction.
   public: std::vector<std::unique_ptr<btTriangleMesh>> triangleMeshes;
+  public: std::vector<std::unique_ptr<btGImpactMeshShape>> meshesGImpact;
 };
 
 }  // namespace bullet_featherstone

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -21,7 +21,12 @@ foreach(plugin IN LISTS plugins)
 endforeach()
 
 if (DART_FOUND)
-  target_link_libraries(MockDoublePendulum PUBLIC ${DART_LIBRARIES})
+  # Linking against libdart-collision-bullet causes a segfault on macOS for
+  # some reason. We'll remove it since MockDoublePendulum doesn't use bullet
+  # for collision checking.
+  set(DART_LIBRARIES_NO_BULLET ${DART_LIBRARIES})
+  list(REMOVE_ITEM DART_LIBRARIES_NO_BULLET dart-collision-bullet)
+  target_link_libraries(MockDoublePendulum PUBLIC ${DART_LIBRARIES_NO_BULLET})
   target_compile_definitions(MockDoublePendulum PRIVATE
     "GZ_PHYSICS_RESOURCE_DIR=\"${GZ_PHYSICS_RESOURCE_DIR}\"")
   if (MSVC)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-physics/issues/497

## Summary
This fixes two tests with segfaults on macOS
1. `COMMON_TEST_simulation_features_bullet-featherstone`: The failure appears to be due to the destruction order of the `triangleMeshes` and `meshesGImpact` containers.  Per [this] (https://github.com/bulletphysics/bullet3/issues/567#issuecomment-186248424) comment, memory in bullet is sensitive to order of destruction. `meshesGImpact` objects contain pointers to items contained by`triangleMeshes`, so the solution is to ensure `meshesGImpact` is destructed before `triangleMeshes`.
2. `INTEGRATION_DoublePendulum`: This is a DART test, but the segfault seems to be related to Bullet. I found that even after removing all the code in `DARTDoublePendulum.cc`, the segfault still occurs as long as it's linked with `libdart-collision-bullet`. Since the test doesn't need the bullet collision detector, I've opted to just remove the library from the `DART_LIBRARIES` variable. I still don't know the root cause though, so this might affect the actual dartsim-plugin library.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
