### PR TITLE
Re-enable AABB tests for ellipsoids

### DIFF
--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -479,19 +479,10 @@ TYPED_TEST(SimulationFeaturesShapeFeaturesTest, ShapeFeatures)
         gz::math::eigen3::convert(cylinderModelAABB).Min());
     EXPECT_EQ(gz::math::Vector3d(3, 1.5, 2.5),
         gz::math::eigen3::convert(cylinderModelAABB).Max());
-    /*
-    /// \TODO(mjcarroll)  The ellipsoid bounding box happens to return a
-    /// FLT_MAX rather than the correct value of 1.2 on the bullet-featherstone
-    /// implementation on Ubuntu Focal.
-    /// Since Focal is a lower-priority platform for featherstone and there
-    /// should be few downstream impacts of this calculation, I am commenting
-    /// it for now.
-    /// Tracked in: https://github.com/gazebosim/gz-physics/issues/440
     EXPECT_TRUE(gz::math::Vector3d(-0.2, -5.3, 0.2).Equal(
     gz::math::eigen3::convert(ellipsoidModelAABB).Min(), 0.1));
     EXPECT_TRUE(gz::math::Vector3d(0.2, -4.7, 1.2).Equal(
     gz::math::eigen3::convert(ellipsoidModelAABB).Max(), 0.1));
-    */
     EXPECT_EQ(gz::math::Vector3d(-0.2, -3.2, 0),
         gz::math::eigen3::convert(capsuleModelAABB).Min());
     EXPECT_EQ(gz::math::Vector3d(0.2, -2.8, 1),


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #440 

## Summary
There were some uninitialized values that were used before #503 , so checking if we can re-enable AABB now that those are fixed.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
