### PR TITLE
Fix segmentation fault on exit for macOS tests

### DIFF
--- a/dartsim/CMakeLists.txt
+++ b/dartsim/CMakeLists.txt
@@ -111,5 +111,9 @@ foreach(test UNIT_FindFeatures_TEST UNIT_RequestFeatures_TEST)
   if(TARGET ${test})
     target_compile_definitions(${test} PRIVATE
       "dartsim_plugin_LIB=\"$<TARGET_FILE:${dartsim_plugin}>\"")
+
+    target_link_libraries(${test} ${dartsim_plugin})
+    add_dependencies(${test} ${dartsim_plugin})
+
   endif()
 endforeach()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #442

## Summary

See #442 for details on how to reproduce.

Add a link dependency to `dartsim_plugin` in  the failing test(s). The dependency is present in the tests contained in `gz-physics/dart` but not for those in `gz-physics/src`.

This prevent the segmentation fault on exit, but does not really address the root cause of why the `SingletonFactory` for the `CollisionDetector` has a  segmentation faulting without the explicit link.

As mentioned in the comment, the error occurs in the destruction of the static `Registrar` variable for the `DARTCollisionDetector`. The `std::function` associated with the lambda in the registration entry below is invalid at the point the `Factory` destructor is called.

```c++
DARTCollisionDetector::Registrar<DARTCollisionDetector>
    DARTCollisionDetector::mRegistrar{
        DARTCollisionDetector::getStaticType(),
        []() -> std::shared_ptr<dart::collision::DARTCollisionDetector> {
          return dart::collision::DARTCollisionDetector::create();
        }};
```

It's possible the explicit link prevents the shared library from being unloaded and so the process exits cleanly (the same result occurs if the plugin `LoadLib` call is made with `nodelete=true`).


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
