### PR TITLE
dartsim: make gz-common geospatial component optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,9 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 #--------------------------------------
 # Find gz-common
 gz_find_package(gz-common5
-  COMPONENTS geospatial graphics profiler
-  REQUIRED_BY heightmap mesh dartsim tpe tpelib bullet)
+  COMPONENTS graphics profiler
+  OPTIONAL_COMPONENTS geospatial
+  REQUIRED_BY heightmap mesh dartsim tpe tpelib bullet bullet-featherstone)
 set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
 #--------------------------------------

--- a/dartsim/CMakeLists.txt
+++ b/dartsim/CMakeLists.txt
@@ -16,6 +16,9 @@ install(
   DESTINATION "${GZ_INCLUDE_INSTALL_DIR_FULL}")
 
 gz_get_libsources_and_unittests(sources test_sources)
+if(NOT gz-common${GZ_COMMON_VER}-geospatial_FOUND)
+  list(REMOVE_ITEM sources src/CustomHeightmapShape.cc)
+endif()
 
 # TODO(MXG): Think about a gz_add_plugin(~) macro for gz-cmake
 set(engine_name dartsim-plugin)
@@ -28,15 +31,22 @@ target_link_libraries(${dartsim_plugin}
   PUBLIC
     ${features}
     ${PROJECT_LIBRARY_TARGET_NAME}-sdf
-    ${PROJECT_LIBRARY_TARGET_NAME}-heightmap
     ${PROJECT_LIBRARY_TARGET_NAME}-mesh
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
-    gz-common${GZ_COMMON_VER}::geospatial
     gz-math${GZ_MATH_VER}::eigen3
   PRIVATE
     # We need to link this, even when the profiler isn't used to get headers.
     gz-common${GZ_COMMON_VER}::profiler
 )
+if(gz-common${GZ_COMMON_VER}-geospatial_FOUND)
+  target_link_libraries(${dartsim_plugin}
+    PUBLIC
+      ${PROJECT_LIBRARY_TARGET_NAME}-heightmap
+      gz-common${GZ_COMMON_VER}::geospatial)
+  target_compile_definitions(${dartsim_plugin}
+    PRIVATE
+      GZ_COMMON_GEOSPATIAL_FOUND)
+endif()
 
 # The Gazebo fork of DART contains additional code that allows customizing
 # contact constraints. We check for the presence of "ContactSurface.hpp", which
@@ -86,9 +96,7 @@ gz_build_tests(
     ${dartsim_plugin}
     gz-plugin${GZ_PLUGIN_VER}::loader
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
-    gz-common${GZ_COMMON_VER}::geospatial
     ${PROJECT_LIBRARY_TARGET_NAME}-sdf
-    ${PROJECT_LIBRARY_TARGET_NAME}-heightmap
     ${PROJECT_LIBRARY_TARGET_NAME}-mesh
   TEST_LIST tests)
 

--- a/dartsim/src/EntityManagement_TEST.cc
+++ b/dartsim/src/EntityManagement_TEST.cc
@@ -19,8 +19,10 @@
 
 #include <gz/plugin/Loader.hh>
 
+#ifdef GZ_COMMON_GEOSPATIAL_FOUND
 #include <gz/common/geospatial/Dem.hh>
 #include <gz/common/geospatial/ImageHeightmap.hh>
+#endif
 #include <gz/common/MeshManager.hh>
 #include <gz/common/Filesystem.hh>
 
@@ -208,6 +210,7 @@ TEST(EntityManagement_TEST, ConstructEmptyWorld)
   EXPECT_NEAR(meshShapeScaledSize[1], 0.3831, 1e-4);
   EXPECT_NEAR(meshShapeScaledSize[2], 0.0489, 1e-4);
 
+#ifdef GZ_COMMON_GEOSPATIAL_FOUND
   // image heightmap
   auto heightmapLink = model->ConstructEmptyLink("heightmap_link");
   heightmapLink->AttachFixedJoint(child, "heightmap_joint");
@@ -266,6 +269,7 @@ TEST(EntityManagement_TEST, ConstructEmptyWorld)
   EXPECT_NEAR(sizeDem.X(), demShapeRecast->GetSize()[0], 1e-3);
   EXPECT_NEAR(sizeDem.Y(), demShapeRecast->GetSize()[1], 1e-3);
   EXPECT_NEAR(sizeDem.Z(), demShapeRecast->GetSize()[2], 1e-6);
+#endif
 }
 
 TEST(EntityManagement_TEST, RemoveEntities)

--- a/dartsim/src/ShapeFeatures.cc
+++ b/dartsim/src/ShapeFeatures.cc
@@ -32,7 +32,9 @@
 #include <gz/common/Mesh.hh>
 #include <gz/common/MeshManager.hh>
 
+#ifdef GZ_COMMON_GEOSPATIAL_FOUND
 #include "CustomHeightmapShape.hh"
+#endif
 #include "CustomMeshShape.hh"
 
 namespace gz {
@@ -325,6 +327,7 @@ Identity ShapeFeatures::AttachSphereShape(
   return this->GenerateIdentity(shapeID, this->shapes.at(shapeID));
 }
 
+#ifdef GZ_COMMON_GEOSPATIAL_FOUND
 //////////////////////////////////////////////////
 Identity ShapeFeatures::CastToHeightmapShape(
     const Identity &_shapeID) const
@@ -376,6 +379,7 @@ Identity ShapeFeatures::AttachHeightmapShape(
   const std::size_t shapeID = this->AddShape({sn, _name});
   return this->GenerateIdentity(shapeID, this->shapes.at(shapeID));
 }
+#endif
 
 /////////////////////////////////////////////////
 Identity ShapeFeatures::CastToMeshShape(

--- a/dartsim/src/ShapeFeatures.hh
+++ b/dartsim/src/ShapeFeatures.hh
@@ -25,7 +25,9 @@
 #include <gz/physics/CapsuleShape.hh>
 #include <gz/physics/CylinderShape.hh>
 #include <gz/physics/EllipsoidShape.hh>
+#ifdef GZ_COMMON_GEOSPATIAL_FOUND
 #include <gz/physics/heightmap/HeightmapShape.hh>
+#endif
 #include <gz/physics/mesh/MeshShape.hh>
 #include <gz/physics/PlaneShape.hh>
 #include <gz/physics/SphereShape.hh>
@@ -67,9 +69,11 @@ struct ShapeFeatureList : FeatureList<
 //  SetSphereShapeProperties,
   AttachSphereShapeFeature,
 
+#ifdef GZ_COMMON_GEOSPATIAL_FOUND
   heightmap::GetHeightmapShapeProperties,
 //  heightmap::SetHeightmapShapeProperties,
   heightmap::AttachHeightmapShapeFeature,
+#endif
 
   mesh::GetMeshShapeProperties,
 //  mesh::SetMeshShapeProperties,
@@ -165,6 +169,7 @@ class ShapeFeatures :
       const Pose3d &_pose) override;
 
 
+#ifdef GZ_COMMON_GEOSPATIAL_FOUND
   // ----- Heightmap Features -----
   public: Identity CastToHeightmapShape(
       const Identity &_shapeID) const override;
@@ -179,6 +184,7 @@ class ShapeFeatures :
       const Pose3d &_pose,
       const LinearVector3d &_size,
       int _subSampling) override;
+#endif
 
   // ----- Mesh Features -----
   public: Identity CastToMeshShape(

--- a/heightmap/CMakeLists.txt
+++ b/heightmap/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT gz-common${GZ_COMMON_VER}-geospatial_FOUND)
+  # Skip adding this component
+  return()
+endif()
 gz_add_component(heightmap INTERFACE
   GET_TARGET_NAME heightmap)
 

--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -24,21 +24,23 @@ set(TEST_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_V
 include(GzPython)
 
 function(configure_common_test PHYSICS_ENGINE_NAME test_name)
-  set(target_name ${test_name}_${PHYSICS_ENGINE_NAME})
-  add_test(NAME ${target_name}
-    COMMAND
-      ${test_name}
-      $<TARGET_FILE:${PROJECT_LIBRARY_TARGET_NAME}-${PHYSICS_ENGINE_NAME}-plugin>
-      --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${target_name}.xml
-  )
+  if(NOT SKIP_${PHYSICS_ENGINE_NAME} AND NOT INTERNAL_SKIP_${PHYSICS_ENGINE_NAME})
+    set(target_name ${test_name}_${PHYSICS_ENGINE_NAME})
+    add_test(NAME ${target_name}
+      COMMAND
+        ${test_name}
+        $<TARGET_FILE:${PROJECT_LIBRARY_TARGET_NAME}-${PHYSICS_ENGINE_NAME}-plugin>
+        --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${target_name}.xml
+    )
 
-  set_tests_properties(${target_name} PROPERTIES TIMEOUT 240)
+    set_tests_properties(${target_name} PROPERTIES TIMEOUT 240)
 
-  if(Python3_Interpreter_FOUND)
-    # Check that the test produced a result and create a failure if it didn't.
-    # Guards against crashed and timed out tests.
-    add_test(check_${target_name} ${Python3_EXECUTABLE} ${GZ_CMAKE_TOOLS_DIR}/check_test_ran.py
-      ${CMAKE_BINARY_DIR}/test_results/${target_name}.xml)
+    if(Python3_Interpreter_FOUND)
+      # Check that the test produced a result and create a failure if it didn't.
+      # Guards against crashed and timed out tests.
+      add_test(check_${target_name} ${Python3_EXECUTABLE} ${GZ_CMAKE_TOOLS_DIR}/check_test_ran.py
+        ${CMAKE_BINARY_DIR}/test_results/${target_name}.xml)
+    endif()
   endif()
 endfunction()
 
@@ -66,12 +68,8 @@ foreach(test ${tests})
 
   install(TARGETS ${test_executable} DESTINATION ${TEST_INSTALL_DIR})
 
-  if (${BULLET_FOUND})
-    configure_common_test("bullet" ${test_executable})
-    configure_common_test("bullet-featherstone" ${test_executable})
-  endif()
-  if (${DART_FOUND})
-    configure_common_test("dartsim" ${test_executable})
-  endif()
+  configure_common_test("bullet" ${test_executable})
+  configure_common_test("bullet-featherstone" ${test_executable})
+  configure_common_test("dartsim" ${test_executable})
   configure_common_test("tpe" ${test_executable})
 endforeach()


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/osrf/homebrew-simulation/issues/2274.

## Summary

There is currently an issue with `gdal` on macOS homebrew-core that causes multiple incompatible versions of protobuf to be in the dependency chain of formulae that depend on both `gz-msgs9` and `gz-common5`. This currently has most Garden packages broken on macOS.

A temporary workaround is to disable the `gdal` dependency from the `gz-physics6` homebrew formula until `gdal` is fixed. Currently, removing `gdal` from the dependency list of `gz-common5` will prevent compilation of all gz-physics plugins because the `geospatial` component of `gz-common5` is listed as required. This pull request changes the `geospatial` component of `gz-common5` into an optional component.

I also noticed a configuration error when `gdal` could not be found and fixed it in https://github.com/gazebosim/gz-physics/commit/ea8c7cb32d1c64e73d4cdad83dae93ab6829f122.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
