### PR TITLE
EllipsoidShape: use const references in API

### DIFF
--- a/bullet-featherstone/src/ShapeFeatures.cc
+++ b/bullet-featherstone/src/ShapeFeatures.cc
@@ -303,7 +303,7 @@ Vector3d ShapeFeatures::GetEllipsoidShapeRadii(
 Identity ShapeFeatures::AttachEllipsoidShape(
     const Identity &_linkID,
     const std::string &_name,
-    const Vector3d _radii,
+    const Vector3d &_radii,
     const Pose3d &_pose)
 {
   btVector3 positions[1];

--- a/bullet-featherstone/src/ShapeFeatures.hh
+++ b/bullet-featherstone/src/ShapeFeatures.hh
@@ -117,7 +117,7 @@ class ShapeFeatures :
   public: Identity AttachEllipsoidShape(
       const Identity &_linkID,
       const std::string &_name,
-      const Vector3d _radii,
+      const Vector3d &_radii,
       const Pose3d &_pose) override;
 
   // ----- Sphere Features -----

--- a/dartsim/src/ShapeFeatures.cc
+++ b/dartsim/src/ShapeFeatures.cc
@@ -252,7 +252,7 @@ Vector3d ShapeFeatures::GetEllipsoidShapeRadii(
 Identity ShapeFeatures::AttachEllipsoidShape(
     const Identity &_linkID,
     const std::string &_name,
-    const Vector3d _radii,
+    const Vector3d &_radii,
     const Pose3d &_pose)
 {
   common::MeshManager *meshMgr = common::MeshManager::Instance();

--- a/dartsim/src/ShapeFeatures.hh
+++ b/dartsim/src/ShapeFeatures.hh
@@ -148,7 +148,7 @@ class ShapeFeatures :
   public: Identity AttachEllipsoidShape(
       const Identity &_linkID,
       const std::string &_name,
-      const Vector3d _radii,
+      const Vector3d &_radii,
       const Pose3d &_pose) override;
 
   // ----- Sphere Features -----

--- a/include/gz/physics/EllipsoidShape.hh
+++ b/include/gz/physics/EllipsoidShape.hh
@@ -69,7 +69,7 @@ namespace gz
         /// \brief Set the radius of this EllipsoidShape
         /// \param[in] _radii
         ///   The desired radius of this EllipsoidShape
-        public: void SetRadii(Dimensions _radii);
+        public: void SetRadii(const Dimensions &_radii);
       };
 
       public: template <typename PolicyT>
@@ -79,7 +79,7 @@ namespace gz
             typename FromPolicy<PolicyT>::template Use<LinearVector>;
 
         public: virtual void SetEllipsoidShapeRadii(
-            const Identity &_ellipsoidID, Dimensions _radii) = 0;
+            const Identity &_ellipsoidID, const Dimensions &_radii) = 0;
       };
     };
 
@@ -109,7 +109,7 @@ namespace gz
         /// \returns a ShapePtrType to the newly constructed EllipsoidShape
         public: ShapePtrType AttachEllipsoidShape(
             const std::string &_name = "ellipsoid",
-            Dimensions _radii = Dimensions::Constant(1.0),
+            const Dimensions &_radii = Dimensions::Constant(1.0),
             const PoseType &_pose = PoseType::Identity());
       };
 
@@ -125,7 +125,7 @@ namespace gz
         public: virtual Identity AttachEllipsoidShape(
             const Identity &_linkID,
             const std::string &_name,
-            Dimensions _radii,
+            const Dimensions &_radii,
             const PoseType &_pose) = 0;
       };
     };

--- a/include/gz/physics/detail/EllipsoidShape.hh
+++ b/include/gz/physics/detail/EllipsoidShape.hh
@@ -37,7 +37,7 @@ namespace gz
     /////////////////////////////////////////////////
     template <typename PolicyT, typename FeaturesT>
     void SetEllipsoidShapeProperties::EllipsoidShape<PolicyT, FeaturesT>
-    ::SetRadii(Dimensions _radii)
+    ::SetRadii(const Dimensions &_radii)
     {
       this->template Interface<SetEllipsoidShapeProperties>()
           ->SetEllipsoidShapeRadii(this->identity, _radii);
@@ -48,7 +48,7 @@ namespace gz
     auto AttachEllipsoidShapeFeature::Link<PolicyT, FeaturesT>
     ::AttachEllipsoidShape(
         const std::string &_name,
-        Dimensions _radii,
+        const Dimensions &_radii,
         const PoseType &_pose) -> ShapePtrType
     {
       return ShapePtrType(this->pimpl,

--- a/tpe/plugin/src/ShapeFeatures.cc
+++ b/tpe/plugin/src/ShapeFeatures.cc
@@ -272,7 +272,7 @@ Vector3d ShapeFeatures::GetEllipsoidShapeRadii(
 Identity ShapeFeatures::AttachEllipsoidShape(
   const Identity &_linkID,
   const std::string &_name,
-  Vector3d _radii,
+  const Vector3d &_radii,
   const Pose3d &_pose)
 {
   auto it = this->links.find(_linkID);

--- a/tpe/plugin/src/ShapeFeatures.hh
+++ b/tpe/plugin/src/ShapeFeatures.hh
@@ -116,7 +116,7 @@ class ShapeFeatures :
   public: Identity AttachEllipsoidShape(
     const Identity &_linkID,
     const std::string &_name,
-    Vector3d _radii,
+    const Vector3d &_radii,
     const Pose3d &_pose) override;
 
   // ----- Sphere Features -----


### PR DESCRIPTION
# 🦟 Bug fix

Fixes API issue noted in https://github.com/gazebosim/gz-physics/pull/515#discussion_r1227485794

## Summary

Pass the Vector of Ellipsoid radii as a `const` reference to `SetRadii` and `AttachEllipsoidShape`. This is either an API or ABI break, so I've targeted `main`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
