### PR TITLE
Check that plugin exists before adding common test

### DIFF
--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -24,21 +24,23 @@ set(TEST_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_V
 include(GzPython)
 
 function(configure_common_test PHYSICS_ENGINE_NAME test_name)
-  set(target_name ${test_name}_${PHYSICS_ENGINE_NAME})
-  add_test(NAME ${target_name}
-    COMMAND
-      ${test_name}
-      $<TARGET_FILE:${PROJECT_LIBRARY_TARGET_NAME}-${PHYSICS_ENGINE_NAME}-plugin>
-      --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${target_name}.xml
-  )
+  if(NOT SKIP_${PHYSICS_ENGINE_NAME} AND NOT INTERNAL_SKIP_${PHYSICS_ENGINE_NAME})
+    set(target_name ${test_name}_${PHYSICS_ENGINE_NAME})
+    add_test(NAME ${target_name}
+      COMMAND
+        ${test_name}
+        $<TARGET_FILE:${PROJECT_LIBRARY_TARGET_NAME}-${PHYSICS_ENGINE_NAME}-plugin>
+        --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${target_name}.xml
+    )
 
-  set_tests_properties(${target_name} PROPERTIES TIMEOUT 240)
+    set_tests_properties(${target_name} PROPERTIES TIMEOUT 240)
 
-  if(Python3_Interpreter_FOUND)
-    # Check that the test produced a result and create a failure if it didn't.
-    # Guards against crashed and timed out tests.
-    add_test(check_${target_name} ${Python3_EXECUTABLE} ${GZ_CMAKE_TOOLS_DIR}/check_test_ran.py
-      ${CMAKE_BINARY_DIR}/test_results/${target_name}.xml)
+    if(Python3_Interpreter_FOUND)
+      # Check that the test produced a result and create a failure if it didn't.
+      # Guards against crashed and timed out tests.
+      add_test(check_${target_name} ${Python3_EXECUTABLE} ${GZ_CMAKE_TOOLS_DIR}/check_test_ran.py
+        ${CMAKE_BINARY_DIR}/test_results/${target_name}.xml)
+    endif()
   endif()
 endfunction()
 
@@ -66,12 +68,8 @@ foreach(test ${tests})
 
   install(TARGETS ${test_executable} DESTINATION ${TEST_INSTALL_DIR})
 
-  if (${BULLET_FOUND})
-    configure_common_test("bullet" ${test_executable})
-    configure_common_test("bullet-featherstone" ${test_executable})
-  endif()
-  if (${DART_FOUND})
-    configure_common_test("dartsim" ${test_executable})
-  endif()
+  configure_common_test("bullet" ${test_executable})
+  configure_common_test("bullet-featherstone" ${test_executable})
+  configure_common_test("dartsim" ${test_executable})
   configure_common_test("tpe" ${test_executable})
 endforeach()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #522

## Summary

As noted in #522, `gz-physics6` will fail to build if certain dependencies required by a component are missing, instead of just skipping those components. I previously noticed this while attempting to make the `gz-common5-geospatial` component optional in #516 but that PR was closed, so I've cherry-picked this build fix on its own.

A question was raised in https://github.com/gazebosim/gz-physics/pull/516/commits/cc9cced8235366fa810493c1fb04311a6a2f4191?w=1#r1242397957 about the use of the `SKIP_*` and `INTERNAL_SKIP_*` variables that are used by `gz-cmake` to indicate whether a component is to be skipped or not. The `INTERNAL_SKIP_*` variables are set by [gz_find_package](https://github.com/gazebosim/gz-cmake/blob/gz-cmake3/cmake/GzFindPackage.cmake#L296) when dependencies required by a component are missing.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
