### PR TITLE
Consolidate packages.apt files

### DIFF
--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,6 +1,0 @@
-libdart-collision-bullet-dev
-libdart-collision-ode-dev
-libdart-dev
-libdart-external-ikfast-dev
-libdart-external-odelcpsolver-dev
-libdart-utils-urdf-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,4 +1,10 @@
 libbenchmark-dev
+libdart-collision-bullet-dev
+libdart-collision-ode-dev
+libdart-dev
+libdart-external-ikfast-dev
+libdart-external-odelcpsolver-dev
+libdart-utils-urdf-dev
 libeigen3-dev
 libgz-cmake3-dev
 libgz-common5-dev


### PR DESCRIPTION
# 🦟 Bug fix

Small follow-up to https://github.com/gazebosim/gz-physics/pull/526

## Summary

The `packages-focal.apt` file was removed in https://github.com/gazebosim/gz-physics/pull/526, so `packages-jammy.apt` can now be consolidated with `packages.apt`, which is done here.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
