### PR TITLE
Unregister collision detectors when the darstim plugin is unloaded

### DIFF
--- a/dartsim/src/plugin.cc
+++ b/dartsim/src/plugin.cc
@@ -64,6 +64,18 @@ class Plugin :
 
 namespace {
 
+// This is done as a partial fix for
+// https://github.com/gazebosim/gz-physics/issues/442. The issue seems like the
+// destructors for the concrete collision detectors get unloaded and deleted
+// from memory before the destructors run. When it's time to actually call the
+// destructors, a segfault is generated.
+//
+// It's not clear why the destructors are deleted prematurely. It might be a
+// compiler optimization in new compiler versions.
+//
+// The solution here is to call the `unregisterAllCreators` function from the
+// plugins translation unit in the hopes that it will force the compiler to keep
+// the destructors.
 struct UnregisterCollisionDetectors
 {
   ~UnregisterCollisionDetectors()

--- a/dartsim/src/plugin.cc
+++ b/dartsim/src/plugin.cc
@@ -62,6 +62,19 @@ class Plugin :
     public virtual SimulationFeatures,
     public virtual WorldFeatures { };
 
+namespace {
+
+struct UnregisterCollisionDetectors
+{
+  ~UnregisterCollisionDetectors()
+  {
+    dart::collision::CollisionDetector::getFactory()->unregisterAllCreators();
+  }
+};
+
+UnregisterCollisionDetectors unregisterAtUnload;
+}
+
 GZ_PHYSICS_ADD_PLUGIN(Plugin, FeaturePolicy3d, DartsimFeatures)
 
 }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Partial fix for #442 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
