### PR TITLE
Reduce error to debug msg for mesh construction

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -840,8 +840,8 @@ Identity SDFFeatures::ConstructSdfCollision(
   if (!shape)
   {
     // The geometry element was empty, or the shape type is not supported
-    gzerr << "The geometry element of collision [" << _collision.Name() << "] "
-           << "couldn't be created\n";
+    gzdbg << "The geometry element of collision [" << _collision.Name() << "] "
+          << "couldn't be created\n";
     return this->GenerateInvalidId();
   }
 


### PR DESCRIPTION


# 🦟 Bug fix

## Summary
Currently gazebo prints out error messages if the model has a mesh collision. The collision seems to be created fine but gz-physics still prints out an error msg:

```sh
[Err] [SDFFeatures.cc:843] The geometry element of collision [Rock01_Collider_62] couldn't be created
```

When you have lots of mesh collisions in the world like in the [harmonic demo](https://github.com/gazebosim/harmonic_demo), the console is filled with red error msgs.

Taking a similar approach as in https://github.com/gazebosim/gz-physics/pull/452, this PR just downgrades the severity level from error to debug.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

