### PR TITLE
Merge ign-physics5  gz-physics6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -224,6 +224,18 @@
 
 ## Gazebo Physics 5.x
 
+### Gazebo Physics 5.3.2 (2023-09-01)
+
+1. Fix a crash due to an invalid pointer
+    * [Pull request #486](https://github.com/gazebosim/gz-physics/pull/486)
+
+1. Infrastructure
+    * [Pull request #490](https://github.com/gazebosim/gz-physics/pull/490)
+    * [Pull request #488](https://github.com/gazebosim/gz-physics/pull/488)
+
+1. Rename COPYING to LICENSE
+    * [Pull request #487](https://github.com/gazebosim/gz-physics/pull/487)
+
 ### Gazebo Physics 5.3.1 (2023-02-16)
 
 1. Fix memory corruption due to faulty refcount tracking


### PR DESCRIPTION
# ➡️  Forward port

Port `ign-physics5 ` ➡️  `gz-physics6`

Branch comparison: https://github.com/gazebosim/gz-physics/compare/gz-physics6...ign-physics5

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)