### PR TITLE
joint_features test: reduce console spam

### DIFF
--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -143,7 +143,10 @@ TYPED_TEST(JointFeaturesTest, JointSetCommand)
     // Check that invalid velocity commands don't cause collisions to fail
     for (std::size_t i = 0; i < 1000; ++i)
     {
+      // Silence console spam
+      gz::common::Console::SetVerbosity(0);
       joint->SetForce(0, std::numeric_limits<double>::quiet_NaN());
+      gz::common::Console::SetVerbosity(4);
       // expect the position of the pendulum to stay above ground
       world->Step(output, state, input);
       auto frameData = base_link->FrameDataRelativeToWorld();
@@ -178,7 +181,10 @@ TYPED_TEST(JointFeaturesTest, JointSetCommand)
     // Check that invalid velocity commands don't cause collisions to fail
     for (std::size_t i = 0; i < 1000; ++i)
     {
+      // Silence console spam
+      gz::common::Console::SetVerbosity(0);
       joint->SetVelocityCommand(0, std::numeric_limits<double>::quiet_NaN());
+      gz::common::Console::SetVerbosity(4);
       // expect the position of the pendulum to stay above ground
       world->Step(output, state, input);
       auto frameData = base_link->FrameDataRelativeToWorld();


### PR DESCRIPTION
This sets console verbosity to zero when passing NaN commands in the test to reduce console spam.

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Reduces console spam

## Summary

This removes 2000 lines of console output from the `COMMON_TEST_joint_features_*` tests by setting console verbosity to zero when passing NaN commands.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
