### PR TITLE
Use libdart6.13 packages in CI from packages.o.o

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,10 +1,10 @@
 libbenchmark-dev
-libdart-collision-bullet-dev
-libdart-collision-ode-dev
-libdart-dev
-libdart-external-ikfast-dev
-libdart-external-odelcpsolver-dev
-libdart-utils-urdf-dev
+libdart6.13-collision-bullet-dev
+libdart6.13-collision-ode-dev
+libdart6.13-dev
+libdart6.13-external-ikfast-dev
+libdart6.13-external-odelcpsolver-dev
+libdart6.13-utils-urdf-dev
 libeigen3-dev
 libgz-cmake3-dev
 libgz-common5-dev


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-physics/issues/541

## Summary

Use libdart-6.13 packages in CI instead of libdart-6.12

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.