### PR TITLE
Prepare for 7.0.0~pre3 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake3 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX pre3)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,38 @@
 
 ### Gazebo Physics 7.x.x (202X-XX-XX)
 
+1. Make dartsim/World.hh header private
+    * [Pull request #551](https://github.com/gazebosim/gz-physics/pull/551)
+
+1. Documentation fixes
+    * [Pull request #542](https://github.com/gazebosim/gz-physics/pull/542)
+
+1. Mimic constraint feature using bullet-featherstone
+    * [Pull request #517](https://github.com/gazebosim/gz-physics/pull/517)
+
+1. ign -> gz
+    * [Pull request #524](https://github.com/gazebosim/gz-physics/pull/524)
+
+1. Reduce error to debug messsage for mesh construction
+    * [Pull request #531](https://github.com/gazebosim/gz-physics/pull/531)
+
+1. Infrastructure
+    * [Pull request #528](https://github.com/gazebosim/gz-physics/pull/528)
+    * [Pull request #553](https://github.com/gazebosim/gz-physics/pull/553)
+
+1. Bumps in harmonic : sdformat14
+    * [Pull request #526](https://github.com/gazebosim/gz-physics/pull/526)
+
+1. EllipsoidShape: use const references in API
+    * [Pull request #521](https://github.com/gazebosim/gz-physics/pull/521)
+
+1. Fixed Dartsim SDFFeatures_TEST
+    * [Pull request #405](https://github.com/gazebosim/gz-physics/pull/405)
+
+1. ⬆️  Bump main to 7.0.0~pre1
+    * [Pull request #399](https://github.com/gazebosim/gz-physics/pull/399)
+
+
 ## Gazebo Physics 6.x
 
 ### Gazebo Physics 6.5.1 (2023-09-26)


### PR DESCRIPTION
# 🎈 Release

Preparation for 7.0.0~pre3 release.

Comparison to 6.5.1: https://github.com/gazebosim/gz-physics/compare/gz-physics6_6.5.1...gz-physics7

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.