### PR TITLE
dartsim: Fix sign convention error with contact surface motion velocities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake3 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre3)
+gz_configure_project(VERSION_SUFFIX pre4)
 
 #============================================================================
 # Set project-specific options

--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -67,6 +67,10 @@ foreach(test ${tests})
     "GZ_PHYSICS_RESOURCE_DIR=\"${GZ_PHYSICS_RESOURCE_DIR}\""
   )
 
+  if (DART_HAS_CONTACT_SURFACE_HEADER)
+    target_compile_definitions(${test_executable} PRIVATE DART_HAS_CONTACT_SURFACE)
+  endif()
+
   install(TARGETS ${test_executable} DESTINATION ${TEST_INSTALL_DIR})
 
   configure_common_test("bullet" ${test_executable})

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -36,6 +36,7 @@
 
 #include "gz/physics/BoxShape.hh"
 #include <gz/physics/GetContacts.hh>
+#include "gz/physics/ContactProperties.hh"
 #include "gz/physics/CylinderShape.hh"
 #include "gz/physics/CapsuleShape.hh"
 #include "gz/physics/EllipsoidShape.hh"


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2008

Needed by https://github.com/gazebosim/gz-sim/pull/2178

## Summary
The implementation of contact constraints in the upstream version of dart uses a different sign due to the order of operands in a cross product. See [dart 6.10 fork](https://github.com/gazebo-forks/dart/blob/f1821780e93f34cdd4c138c1a2b3e558e0e72cbe/dart/constraint/ContactConstraint.cpp#L797) vs [dart 6.13 upstream](
https://github.com/dartsim/dart/blob/9f2d6073b32d7de27b6e1ed29fe6f03bf56043a9/dart/constraint/ContactConstraint.cpp#L782). This PR inverts the sign for velocities in the first and second friction directions if it detects that the upstream version of DART is being used. See also https://github.com/gazebo-forks/dart/pull/33

This also enables a test that was accidentally disabled when we transitioned to common tests. The `DART_HAS_CONTACT_SURFACE` define is necessary to run the surface velocity tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
