### PR TITLE
Citadel: backport fix for dartsim segfaults

### DIFF
--- a/dartsim/src/plugin.cc
+++ b/dartsim/src/plugin.cc
@@ -57,6 +57,31 @@ class Plugin :
     public virtual ShapeFeatures,
     public virtual SimulationFeatures { };
 
+namespace {
+
+// This is done as a partial fix for
+// https://github.com/gazebosim/gz-physics/issues/442. The issue seems like the
+// destructors for the concrete collision detectors get unloaded and deleted
+// from memory before the destructors run. When it's time to actually call the
+// destructors, a segfault is generated.
+//
+// It's not clear why the destructors are deleted prematurely. It might be a
+// compiler optimization in new compiler versions.
+//
+// The solution here is to call the `unregisterAllCreators` function from the
+// plugins translation unit in the hopes that it will force the compiler to keep
+// the destructors.
+struct UnregisterCollisionDetectors
+{
+  ~UnregisterCollisionDetectors()
+  {
+    dart::collision::CollisionDetector::getFactory()->unregisterAllCreators();
+  }
+};
+
+UnregisterCollisionDetectors unregisterAtUnload;
+}
+
 IGN_PHYSICS_ADD_PLUGIN(Plugin, FeaturePolicy3d, DartsimFeatures)
 
 }


### PR DESCRIPTION
# 🦟 Bug fix

Backport https://github.com/gazebosim/gz-physics/pull/529 to Citadel to fix https://github.com/gazebosim/gz-physics/issues/442 (gz-sim6 segfaults on macOS) on Citadel and https://github.com/gazebosim/gz-sim/issues/2204

## Summary

See https://github.com/gazebosim/gz-physics/pull/529 and https://github.com/gazebosim/gz-physics/issues/442 for context.

Original commit message:

Unregister collision detectors when the darstim plugin is unloaded (https://github.com/gazebosim/gz-physics/pull/529)

Fixes a segfault that occurs due to destructors being removed from memory before they're called

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-Merge**.
