### PR TITLE
Add sample ctest cmds to tutorials

### DIFF
--- a/tutorials/02_installation.md
+++ b/tutorials/02_installation.md
@@ -227,6 +227,22 @@ Follow these steps to run tests and static code analysis in your clone of this r
   make test
   ```
 
+  Each test is registered with `ctest`. These can then be filtered with the `ctest` command line.
+
+  ```
+  # See a list of all available tests
+  ctest -N
+
+  # Run all tests in dartsim (verbose)
+  ctest -R dartsim -V
+
+  # Run all INTEGRATION tests (verbose)
+  ctest -R INTEGRATION -V
+
+  # Run all COMMON tests (verbose)
+  ctest -R COMMON -V
+  ```
+
 3. You will need Cppcheck in order to run static code checks. On Ubuntu Cppcheck can be installed using
   ```
   sudo apt-get install cppcheck


### PR DESCRIPTION

# 🎉 New feature


## Summary

Added some info on how to run specific tests, similar to [these instructions](https://github.com/gazebosim/gz-rendering/blob/451e34e46622ab7a8f6aa4d521ba0a1565b8fdb7/tutorials/02_install.md?plain=1#L290-L307) in gz-rendering

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

