### PR TITLE
bullet-featherstone: fix setting angular velocity

### DIFF
--- a/bullet-featherstone/src/FreeGroupFeatures.cc
+++ b/bullet-featherstone/src/FreeGroupFeatures.cc
@@ -68,29 +68,7 @@ void FreeGroupFeatures::SetFreeGroupWorldAngularVelocity(
 
   if (model != nullptr)
   {
-    // Set angular velocity the each one of the joints of the model
-    for (const auto& jointID : model->jointEntityIds)
-    {
-      auto jointInfo = this->joints[jointID];
-      if (!jointInfo->motor)
-      {
-        auto *modelInfo = this->ReferenceInterface<ModelInfo>(jointInfo->model);
-        jointInfo->motor = std::make_shared<btMultiBodyJointMotor>(
-          modelInfo->body.get(),
-          std::get<InternalJoint>(jointInfo->identifier).indexInBtModel,
-          0,
-          static_cast<btScalar>(0),
-          static_cast<btScalar>(jointInfo->effort));
-        auto *world = this->ReferenceInterface<WorldInfo>(modelInfo->world);
-        world->world->addMultiBodyConstraint(jointInfo->motor.get());
-      }
-
-      if (jointInfo->motor)
-      {
-        jointInfo->motor->setVelocityTarget(
-            static_cast<btScalar>(_angularVelocity[2]));
-      }
-    }
+    model->body->setBaseOmega(convertVec(_angularVelocity));
   }
 }
 

--- a/bullet-featherstone/src/KinematicsFeatures.cc
+++ b/bullet-featherstone/src/KinematicsFeatures.cc
@@ -104,7 +104,7 @@ FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
       }
     }
 
-    if (model->body == nullptr)
+    if (!model || model->body == nullptr)
       model = this->FrameInterface<ModelInfo>(_id);
   }
 

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -490,19 +490,35 @@ TYPED_TEST(SimulationFeaturesShapeFeaturesTest, ShapeFeatures)
   }
 }
 
-template <class T>
-class SimulationFeaturesTestBasic :
-  public SimulationFeaturesTest<T>{};
-using SimulationFeaturesTestBasicTypes =
-  ::testing::Types<Features>;
-TYPED_TEST_SUITE(SimulationFeaturesTestBasic,
-                 SimulationFeaturesTestBasicTypes);
+struct FreeGroupFeatures : gz::physics::FeatureList<
+  gz::physics::FindFreeGroupFeature,
+  gz::physics::SetFreeGroupWorldPose,
+  gz::physics::SetFreeGroupWorldVelocity,
 
-TYPED_TEST(SimulationFeaturesTestBasic, FreeGroup)
+  gz::physics::GetModelFromWorld,
+  gz::physics::GetLinkFromModel,
+
+  gz::physics::FreeGroupFrameSemantics,
+  gz::physics::LinkFrameSemantics,
+
+  gz::physics::sdf::ConstructSdfWorld,
+
+  gz::physics::ForwardStep
+> {};
+
+template <class T>
+class SimulationFeaturesTestFreeGroup :
+  public SimulationFeaturesTest<T>{};
+using SimulationFeaturesTestFreeGroupTypes =
+  ::testing::Types<FreeGroupFeatures>;
+TYPED_TEST_SUITE(SimulationFeaturesTestFreeGroup,
+                 SimulationFeaturesTestFreeGroupTypes);
+
+TYPED_TEST(SimulationFeaturesTestFreeGroup, FreeGroup)
 {
   for (const std::string &name : this->pluginNames)
   {
-    auto world = LoadPluginAndWorld<Features>(
+    auto world = LoadPluginAndWorld<FreeGroupFeatures>(
       this->loader,
       name,
       gz::common::joinPaths(TEST_WORLD_DIR, "shapes.world"));
@@ -520,7 +536,7 @@ TYPED_TEST(SimulationFeaturesTestBasic, FreeGroup)
     auto freeGroupLink = link->FindFreeGroup();
     ASSERT_NE(nullptr, freeGroupLink);
 
-    StepWorld<Features>(world, true);
+    StepWorld<FreeGroupFeatures>(world, true);
 
     freeGroup->SetWorldPose(
       gz::math::eigen3::convert(
@@ -535,7 +551,7 @@ TYPED_TEST(SimulationFeaturesTestBasic, FreeGroup)
               gz::math::eigen3::convert(frameData.pose));
 
     // Step the world
-    StepWorld<Features>(world, false);
+    StepWorld<FreeGroupFeatures>(world, false);
     // Check that the first link's velocities are updated
     frameData = model->GetLink(0)->FrameDataRelativeToWorld();
     EXPECT_TRUE(gz::math::Vector3d(0.1, 0.2, 0.3).Equal(
@@ -544,6 +560,14 @@ TYPED_TEST(SimulationFeaturesTestBasic, FreeGroup)
               gz::math::eigen3::convert(frameData.angularVelocity));
   }
 }
+
+template <class T>
+class SimulationFeaturesTestBasic :
+  public SimulationFeaturesTest<T>{};
+using SimulationFeaturesTestBasicTypes =
+  ::testing::Types<Features>;
+TYPED_TEST_SUITE(SimulationFeaturesTestBasic,
+                 SimulationFeaturesTestBasicTypes);
 
 TYPED_TEST(SimulationFeaturesTestBasic, ShapeBoundingBox)
 {

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -52,7 +52,7 @@
 #include <sdf/Root.hh>
 
 // The features that an engine must have to be loaded by this loader.
-using Features = gz::physics::FeatureList<
+struct Features : gz::physics::FeatureList<
   gz::physics::ConstructEmptyWorldFeature,
 
   gz::physics::FindFreeGroupFeature,
@@ -84,7 +84,7 @@ using Features = gz::physics::FeatureList<
   gz::physics::GetCylinderShapeProperties,
   gz::physics::GetCapsuleShapeProperties,
   gz::physics::GetEllipsoidShapeProperties
->;
+> {};
 
 template <class T>
 class SimulationFeaturesTest:
@@ -184,11 +184,11 @@ std::pair<bool, gz::physics::ForwardStep::Output> StepWorld(
 }
 
 // The features that an engine must have to be loaded by this loader.
-using FeaturesContacts = gz::physics::FeatureList<
+struct FeaturesContacts : gz::physics::FeatureList<
   gz::physics::sdf::ConstructSdfWorld,
   gz::physics::GetContactsFromLastStepFeature,
   gz::physics::ForwardStep
->;
+> {};
 
 template <class T>
 class SimulationFeaturesContactsTest :
@@ -218,10 +218,10 @@ TYPED_TEST(SimulationFeaturesContactsTest, Contacts)
 
 
 // The features that an engine must have to be loaded by this loader.
-using FeaturesStep = gz::physics::FeatureList<
+struct FeaturesStep : gz::physics::FeatureList<
   gz::physics::sdf::ConstructSdfWorld,
   gz::physics::ForwardStep
->;
+> {};
 
 template <class T>
 class SimulationFeaturesStepTest :
@@ -303,7 +303,7 @@ TYPED_TEST(SimulationFeaturesFallingTest, Falling)
 
 
 // The features that an engine must have to be loaded by this loader.
-using FeaturesShapeFeatures = gz::physics::FeatureList<
+struct FeaturesShapeFeatures : gz::physics::FeatureList<
   gz::physics::sdf::ConstructSdfWorld,
   gz::physics::GetModelFromWorld,
   gz::physics::GetLinkFromModel,
@@ -321,7 +321,7 @@ using FeaturesShapeFeatures = gz::physics::FeatureList<
   gz::physics::GetCylinderShapeProperties,
   gz::physics::GetCapsuleShapeProperties,
   gz::physics::GetEllipsoidShapeProperties
->;
+> {};
 
 template <class T>
 class SimulationFeaturesShapeFeaturesTest :
@@ -796,7 +796,7 @@ TYPED_TEST(SimulationFeaturesTestBasic, RetrieveContacts)
   }
 }
 
-using FeaturesContactPropertiesCallback = gz::physics::FeatureList<
+struct FeaturesContactPropertiesCallback : gz::physics::FeatureList<
   gz::physics::ConstructEmptyWorldFeature,
 
   gz::physics::FindFreeGroupFeature,
@@ -833,7 +833,7 @@ using FeaturesContactPropertiesCallback = gz::physics::FeatureList<
   gz::physics::GetCylinderShapeProperties,
   gz::physics::GetCapsuleShapeProperties,
   gz::physics::GetEllipsoidShapeProperties
->;
+> {};
 
 #ifdef DART_HAS_CONTACT_SURFACE
 using ContactSurfaceParams =

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -523,7 +523,7 @@ TYPED_TEST(SimulationFeaturesTestFreeGroup, FreeGroup)
     auto world = LoadPluginAndWorld<FreeGroupFeatures>(
       this->loader,
       name,
-      gz::common::joinPaths(TEST_WORLD_DIR, "falling.world"));
+      gz::common::joinPaths(TEST_WORLD_DIR, "sphere.sdf"));
 
     // model free group test
     auto model = world->GetModel("sphere");
@@ -581,14 +581,11 @@ TYPED_TEST(SimulationFeaturesTestFreeGroup, FreeGroup)
     // Check the velocities again.
     freeGroupFrameData = freeGroup->FrameDataRelativeToWorld();
     linkFrameData = model->GetLink(0)->FrameDataRelativeToWorld();
-
-    // Expect linear velocity to be affected by gravity.
-    const Eigen::Vector3d linearVelocityAfterStep{0.1, 0.2, 0.3 - 9.8 * 0.001};
     EXPECT_PRED_FORMAT2(vectorPredicateVelocity,
-      linearVelocityAfterStep,
+      initialLinearVelocity,
       freeGroupFrameData.linearVelocity);
     EXPECT_PRED_FORMAT2(vectorPredicateVelocity,
-      linearVelocityAfterStep,
+      initialLinearVelocity,
       linkFrameData.linearVelocity);
 
     // Expect angular velocity is unchanged.

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -587,8 +587,6 @@ TYPED_TEST(SimulationFeaturesTestFreeGroup, FreeGroup)
     EXPECT_PRED_FORMAT2(vectorPredicateVelocity,
       initialLinearVelocity,
       linkFrameData.linearVelocity);
-
-    // Expect angular velocity is unchanged.
     EXPECT_PRED_FORMAT2(vectorPredicateVelocity,
       initialAngularVelocity,
       freeGroupFrameData.angularVelocity);


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-physics/issues/545.

## Summary

I've been working on a test for off-diagonal moment of inertia components to support https://github.com/gazebosim/gz-physics/pull/544 based on free rotation of oblong rigid bodies (similar to a [test from gazebo-classic](https://github.com/gazebosim/gazebo-classic/blob/7ccef40e24831eb5cd974b489ee279fc064eacc4/test/integration/physics_link.cc#L315-L388)), and I found that bullet-featherstone's `SetFreeGroupWorldAngularVelocity` API wasn't working quite right. I've updated the FeatureList for the FreeGroup test in `COMMON_TEST_simulation_features` so that it will run with bullet-featherstone (https://github.com/gazebosim/gz-physics/commit/33e12fa800e31f563a6806aa0051c2607ccc1347) and also refactored the test a bit (https://github.com/gazebosim/gz-physics/commit/a4359eff8b3dce704bb10387532d591ee876d4b2: use a world that doesn't start with shapes already in contact, add expectations for FreeGroup APIs, and tighten expected velocity tolerances).

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
