### PR TITLE
Backport #351 to citadel: fix dartsim inertia matrix rotation

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -417,15 +417,7 @@ Identity SDFFeatures::ConstructSdfLink(
   const math::Inertiald &sdfInertia = _sdfLink.Inertial();
   bodyProperties.mInertia.setMass(sdfInertia.MassMatrix().Mass());
 
-  // TODO(addisu) Resolve the pose of inertials when frame information is
-  // availabile for math::Inertial
-  const Eigen::Matrix3d R_inertial{
-        math::eigen3::convert(sdfInertia.Pose().Rot())};
-
-  const Eigen::Matrix3d I_link =
-      R_inertial
-      * math::eigen3::convert(sdfInertia.Moi())
-      * R_inertial.inverse();
+  const Eigen::Matrix3d I_link = math::eigen3::convert(sdfInertia.Moi());
 
   bodyProperties.mInertia.setMoment(I_link);
 


### PR DESCRIPTION
# 🦟 Bug fix

Backport #351 to citadel, better late than never (https://github.com/gazebosim/gz-physics/pull/351#issuecomment-1201385754)

## Summary

Original commit message:

dartsim: fix handling inertia matrix pose rotation (#351)

When loading a model from SDF, the moment of inertia matrix is currently applying any rotations in the //inertial/pose two times, since the rotations are applied explicitly, but they are already applied in math::Inertial::Moi.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-Merge**.
