### PR TITLE
bullet-featherstone: Fix removing model with joints

### DIFF
--- a/test/common_test/world_features.cc
+++ b/test/common_test/world_features.cc
@@ -358,11 +358,12 @@ TEST_F(WorldModelTest, WorldModelAPI)
 
 struct WorldNestedModelFeatureList : gz::physics::FeatureList<
   GravityFeatures,
-  gz::physics::WorldModelFeature,
-  gz::physics::RemoveEntities,
+  gz::physics::ForwardStep,
   gz::physics::GetNestedModelFromModel,
   gz::physics::sdf::ConstructSdfModel,
-  gz::physics::sdf::ConstructSdfNestedModel
+  gz::physics::sdf::ConstructSdfNestedModel,
+  gz::physics::RemoveEntities,
+  gz::physics::WorldModelFeature
 > { };
 
 
@@ -408,6 +409,10 @@ TEST_F(WorldNestedModelTest, WorldConstructNestedModel)
     ASSERT_NE(nullptr, nestedModel);
     EXPECT_EQ("parent_model", nestedModel->GetName());
 
+    gz::physics::ForwardStep::Input input;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Output output;
+
     // Check that we can remove models via RemoveNestedModel
     EXPECT_TRUE(worldModel->RemoveNestedModel(0));
     EXPECT_TRUE(nestedModel->Removed());
@@ -415,6 +420,15 @@ TEST_F(WorldNestedModelTest, WorldConstructNestedModel)
     EXPECT_EQ(0u, worldModel->GetNestedModelCount());
     EXPECT_EQ(nullptr, worldModel->GetNestedModel(0));
     EXPECT_EQ(nullptr, worldModel->GetNestedModel("parent_model"));
+
+    // verify we can step the world after model removal
+    const size_t numSteps = 1000;
+    for (size_t i = 0; i < numSteps; ++i)
+    {
+      world->Step(output, state, input);
+    }
+    EXPECT_EQ(0u, world->GetModelCount());
+    EXPECT_EQ(0u, worldModel->GetNestedModelCount());
   }
 }
 

--- a/test/common_test/worlds/world_single_nested_model.sdf
+++ b/test/common_test/worlds/world_single_nested_model.sdf
@@ -49,9 +49,12 @@
         </visual>
       </link>
 
-      <joint name="joint1" type="fixed">
-         <parent>link1</parent>
-         <child>nested_model::nested_link1</child>
+      <joint name="joint1" type="revolute">
+        <parent>link1</parent>
+        <child>nested_model::nested_link1</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
       </joint>
     </model>
   </world>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-physics/issues/573

## Summary

When a `btMultiBody` is removed, its joint constraints are never actually removed, causing invalid pointers to be accessed when processing these `btMultiBodyConstraint`s in bullet in the next world step. This PR makes sure all multi body constraints associated with a model are removed properly.

Updated `world_features` test to capture this case. To run the test:

```
ctest -R COMMON_TEST_world_features_bullet-featherstone
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

