### PR TITLE
CI workflow: use 22.04 for codecheck, coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@focal
-        with:
-          codecov-enabled: true
-          cppcheck-enabled: true
-          cpplint-enabled: true
   jammy-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Jammy CI
@@ -25,3 +21,7 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
+        with:
+          codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true


### PR DESCRIPTION
# 🎉 New feature

Improves coverage with bullet-featherstone

## Summary

In #574, some functionality is being added that depends on a version of bullet that is not available on 20.04 but is available on 22.04, macOS and windows (see https://github.com/gazebosim/gz-physics/pull/574#discussion_r1397703321). Some ifdefs are being added to support compilation on 20.04, but computing code coverage on 20.04 will be incomplete. This changes the code coverage and codecheck platforms from 20.04 to 22.04, and CI is still 🟢, so it seems like a safe change.

## Test it

Observer results of GitHub workflow.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
