### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,6 @@ set(GZ_PHYSICS_ENGINE_INSTALL_DIR
 # Configure the build
 #============================================================================
 gz_configure_build(QUIT_IF_BUILD_ERRORS
-  HIDE_SYMBOLS_BY_DEFAULT
   COMPONENTS sdf heightmap mesh dartsim tpe bullet bullet-featherstone)
 
 


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166