### PR TITLE
Merge ign-physics5 ➡️  gz-physics6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Ubuntu CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'ign-physics[0-9]'
+      - 'gz-physics[0-9]?'
+      - 'main'
 
 jobs:
   focal-ci:
@@ -8,7 +14,7 @@ jobs:
     name: Ubuntu Focal CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@focal
@@ -17,7 +23,7 @@ jobs:
     name: Ubuntu Jammy CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,4 +14,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/gazebosim/projects/7
           github-token: ${{ secrets.TRIAGE_TOKEN }}
-

--- a/Changelog.md
+++ b/Changelog.md
@@ -619,6 +619,19 @@
 
 ## Gazebo Physics 2.x
 
+### Gazebo Physics 2.6.2 (2024-01-05)
+
+1. dartsim: fix handling inertia matrix pose rotation
+    * [Pull request #351](https://github.com/gazebosim/gz-physics/pull/351)
+
+1. Fix a crash due to an invalid pointer
+    * [Pull request #486](https://github.com/gazebosim/gz-physics/pull/486)
+
+1. Infrastructure
+    * [Pull request #488](https://github.com/gazebosim/gz-physics/pull/488)
+    * [Pull request #487](https://github.com/gazebosim/gz-physics/pull/487)
+    * [Pull request #572](https://github.com/gazebosim/gz-physics/pull/572)
+
 ### Gazebo Physics 2.6.1 (2023-01-09)
 
 1. Fix build errors and warnings for DART 6.13.0


### PR DESCRIPTION
# ➡️  Forward port

  Port `ign-physics5 ` ➡️  `gz-physics6`

  Branch comparison: https://github.com/gazebosim/gz-physics/compare/gz-physics6...ign-physics5

  **Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)