### PR TITLE
Get bullet version from cmake instead of API

### DIFF
--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(TEST_TYPE "COMMON_TEST")
-include_directories(${BULLET_INCLUDE_DIRS})
 
 set(tests
   added_mass
@@ -47,6 +46,10 @@ endfunction()
 
 set(GZ_PHYSICS_RESOURCE_DIR "${CMAKE_SOURCE_DIR}/resources")
 
+# Get bullet version using pkg_check_modules as it is not available
+# through the cmake module
+gz_pkg_check_modules_quiet(bullet_version_check "bullet")
+
 foreach(test ${tests})
   set(test_executable "${TEST_TYPE}_${test}")
   add_executable(${test_executable} ${test}.cc)
@@ -66,6 +69,13 @@ foreach(test ${tests})
     "TEST_WORLD_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/worlds/\""
     "GZ_PHYSICS_RESOURCE_DIR=\"${GZ_PHYSICS_RESOURCE_DIR}\""
   )
+
+  if (bullet_version_check_VERSION VERSION_LESS_EQUAL 3.25)
+    target_compile_definitions(${test_executable} PRIVATE
+      "BT_BULLET_VERSION_LE_325"
+    )
+  endif()
+
 
   install(TARGETS ${test_executable} DESTINATION ${TEST_INSTALL_DIR})
 

--- a/test/common_test/joint_transmitted_wrench_features.cc
+++ b/test/common_test/joint_transmitted_wrench_features.cc
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <LinearMath/btScalar.h>
 
 #include <gz/common/Console.hh>
 #include <gz/plugin/Loader.hh>
@@ -225,12 +224,10 @@ TYPED_TEST(JointTransmittedWrenchFixture, PendulumAtZeroAngle)
 TYPED_TEST(JointTransmittedWrenchFixture, PendulumInMotion)
 {
   // This test requires https://github.com/bulletphysics/bullet3/pull/4462
-  // When removing this check, also remove
-  // `#include <LinearMath/btScalar.h>` at the top of this file, and
-  // `include_directories(${BULLET_INCLUDE_DIRS})` from
-  // test/common_test/CMakeLists.txt
-  if (this->engineName == "bullet-featherstone" && btGetVersion() <= 325)
+#ifdef BT_BULLET_VERSION_LE_325
+  if (this->engineName == "bullet-featherstone")
     GTEST_SKIP();
+#endif
 
   // Start pendulum at 90° (parallel to the ground) and stop at about 40°
   // so that we have non-trivial test expectations.
@@ -418,12 +415,10 @@ TYPED_TEST(JointTransmittedWrenchFixture, JointLosses)
 TYPED_TEST(JointTransmittedWrenchFixture, ContactForces)
 {
   // This test requires https://github.com/bulletphysics/bullet3/pull/4462
-  // When removing this check, also remove
-  // `#include <LinearMath/btScalar.h>` at the top of this file, and
-  // `include_directories(${BULLET_INCLUDE_DIRS})` from
-  // test/common_test/CMakeLists.txt
-  if (this->engineName == "bullet-featherstone" && btGetVersion() <= 325)
+#if BT_BULLET_VERSION_LE_325
+  if (this->engineName == "bullet-featherstone")
     GTEST_SKIP();
+#endif
 
   auto box = this->world->GetModel("box");
   ASSERT_NE(nullptr, box);


### PR DESCRIPTION
# 🦟 Bug fix

Split out from #574 with acknowledgement to @iche033

## Summary

Currently the bullet API is called from a common test to get the bullet version in order to disable portions of a test that require new features of bullet. This moves the version checking to cmake with `VERSION_*` comparison operators and replaces the bullet API call with a macro defined based on that cmake version comparison.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
