### PR TITLE
Define GZ_PHYSICS_VERSION_NAMESPACE in config.hh

### DIFF
--- a/include/gz/physics/config.hh.in
+++ b/include/gz/physics/config.hh.in
@@ -27,6 +27,7 @@
 
 #define GZ_PHYSICS_VERSION "${PROJECT_VERSION}"
 #define GZ_PHYSICS_VERSION_FULL "${PROJECT_VERSION_FULL}"
+#define GZ_PHYSICS_VERSION_NAMESPACE v${PROJECT_VERSION_MAJOR}
 
 #define GZ_PHYSICS_ENGINE_INSTALL_DIR _Pragma ("GCC warning \"'GZ_PHYSICS_ENGINE_INSTALL_DIR' macro is deprecated, use gz::physics::getEngineInstallDir() function instead. \"") "${GZ_PHYSICS_ENGINE_INSTALL_DIR}"
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-cmake/issues/412

## Summary

Ensure that the `GZ_PHYSICS_VERSION_NAMESPACE` macro is defined in `config.hh.in`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
