### PR TITLE
bullet-featherstone: Improve mesh collision stability

### DIFF
--- a/bullet-featherstone/src/Base.cc
+++ b/bullet-featherstone/src/Base.cc
@@ -43,9 +43,9 @@ WorldInfo::WorldInfo(std::string name_)
   this->world->getSolverInfo().m_jointFeedbackInJointFrame = true;
   this->world->getSolverInfo().m_jointFeedbackInWorldSpace = false;
 
-  // By default a large impulse is is applied when collisions penetrate
+  // By default a large impulse is applied when collisions penetrate
   // which causes unstable behavior. Bullet featherstone does not support
-  // configuring split impulse and penetration threhold parameters. Instead the
+  // configuring split impulse and penetration threshold parameters. Instead the
   // penentration impulse depends on the erp2 parameter so set to a small value
   // (default is 0.2).
   this->world->getSolverInfo().m_erp2 = 0.002;

--- a/bullet-featherstone/src/Base.cc
+++ b/bullet-featherstone/src/Base.cc
@@ -42,6 +42,13 @@ WorldInfo::WorldInfo(std::string name_)
   // Needed for force-torque sensor
   this->world->getSolverInfo().m_jointFeedbackInJointFrame = true;
   this->world->getSolverInfo().m_jointFeedbackInWorldSpace = false;
+
+  // By default a large impulse is is applied when collisions penetrate
+  // which causes unstable behavior. Bullet featherstone does not support
+  // configuring split impulse and penetration threhold parameters. Instead the
+  // penentration impulse depends on the erp2 parameter so set to a small value
+  // (default is 0.2).
+  this->world->getSolverInfo().m_erp2 = 0.002;
 }
 
 }  // namespace bullet_featherstone

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -775,7 +775,7 @@ bool SDFFeatures::AddSdfCollision(
         std::make_unique<btGImpactMeshShape>(
           this->triangleMeshes.back().get()));
       this->meshesGImpact.back()->updateBound();
-      this->meshesGImpact.back()->setMargin(btScalar(0.001));
+      this->meshesGImpact.back()->setMargin(btScalar(0.01));
       compoundShape->addChildShape(btTransform::getIdentity(),
         this->meshesGImpact.back().get());
     }

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -1138,7 +1138,7 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachDetach)
     }
     frameDataModel2Body = model2Body->FrameDataRelativeToWorld();
 
-    EXPECT_NEAR(0.0, frameDataModel2Body.linearVelocity.z(), 1e-3);
+    EXPECT_NEAR(0.0, frameDataModel2Body.linearVelocity.z(), 2e-3);
   }
 }
 
@@ -1266,9 +1266,9 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachMultiple)
           gz::math::eigen3::convert(frameDataModel2Body.linearVelocity);
       gz::math::Vector3d body3LinearVelocity =
           gz::math::eigen3::convert(frameDataModel3Body.linearVelocity);
-      EXPECT_NEAR(0.0, body1LinearVelocity.Z(), 1e-3);
+      EXPECT_NEAR(0.0, body1LinearVelocity.Z(), 3e-3);
       EXPECT_NEAR(0.0, body2LinearVelocity.Z(), 1e-3);
-      EXPECT_NEAR(0.0, body3LinearVelocity.Z(), 1e-3);
+      EXPECT_NEAR(0.0, body3LinearVelocity.Z(), 3e-3);
     }
 
     // Detach the joints. M1 and M3 should fall as there is now nothing stopping
@@ -1296,9 +1296,9 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachMultiple)
       gz::math::Vector3d body3LinearVelocity =
           gz::math::eigen3::convert(frameDataModel3Body.linearVelocity);
 
-      EXPECT_NEAR(dt * (numSteps) * -10, body1LinearVelocity.Z(), 1e-3);
+      EXPECT_NEAR(dt * (numSteps) * -10, body1LinearVelocity.Z(), 3e-3);
       EXPECT_NEAR(0.0, body2LinearVelocity.Z(), 1e-3);
-      EXPECT_NEAR(dt * (numSteps) * -10, body3LinearVelocity.Z(), 1e-3);
+      EXPECT_NEAR(dt * (numSteps) * -10, body3LinearVelocity.Z(), 3e-3);
     }
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Mesh collisions are quite unstable in our bullet-featherstone implementation. Sometimes they explode and fly away on contact. The bullet-featherstone's multibody constraint solve applies a large impulse (uncapped) when penetration occurs.  To reduce this effect, we tune 2 parameters:
* collision margin - increased from 0.001 to 0.01
    * 0.01 is actually the [default margin](https://github.com/bulletphysics/bullet3/blob/6bb8d1123d8a55d407b19fd3357c724d0f5c9d3c/src/BulletCollision/Gimpact/btGImpactShape.h#L530) for GImpact meshes. The new value is also consistent with gazebo-classic which does not have margin set for GImpact meshes (so uses default value of 0.01)
* [erp2](https://github.com/bulletphysics/bullet3/blob/6bb8d1123d8a55d407b19fd3357c724d0f5c9d3c/src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h#L48) (contact constraint error reduction param) - Reduces from default value of 0.2 to 0.02. This [affects](https://github.com/bulletphysics/bullet3/blob/6bb8d1123d8a55d407b19fd3357c724d0f5c9d3c/src/BulletDynamics/Featherstone/btMultiBodyConstraintSolver.cpp#L803) the contact penetration impulse applied.

Here's original behavior:
erp = 0.2, margin = 0.001
Box meshes explode on contact

![bullet-1mm](https://github.com/gazebosim/gz-physics/assets/4000684/4454c4f4-50e3-4313-93df-370b1ce063ef)

Here's testing with just increasing the margin and leaving the erp untouched:
erp = 0.2, margin = 0.01
Stability improved but there are still small bounces due to penetration

![bullet-1cm](https://github.com/gazebosim/gz-physics/assets/4000684/e8fd498b-5a3a-4b4a-bad9-e776e9927fab)


Here's the new behavior with improved stability even when the top box is dropped from higher z:
erp = 0.002, margin = 0.01

![bullet-002erp-1cm](https://github.com/gazebosim/gz-physics/assets/4000684/9e486bdb-29b6-4c95-8449-6415ef7c1b72)

The downside of having a larger margin is that the mesh collision has a small gap when resting on top of one another.
<img width="231" alt="bullet-1cm_margin" src="https://github.com/gazebosim/gz-physics/assets/4000684/252c9c0b-db16-48e9-bca2-f3246b72e1fd">

This will need to be addressed


## To test

To reproduce the tests above, first you'll need these 2 PRs that allow bullet-featherstone in gz-phsyics to load meshes from relative paths:
* https://github.com/gazebosim/gz-sim/pull/2323
* https://github.com/gazebosim/sdformat/pull/1373
 
You can download the world and model files for testing:

```
mkdir -p box_mesh_test/box
wget https://gist.githubusercontent.com/iche033/9943a9bcf6ed9eede40ee3e9dbb4f8ad/raw/2f837c5221c3d56ee13f6191de4c0a449c36b0db/box_mesh_test.sdf
wget https://gist.githubusercontent.com/iche033/d13a8d8e0c05308f98ce1e5e105500ce/raw/681a2be4a2d53d36c9f0e415640258674ef977e5/model.sdf -O box_mesh_test/box/model.sdf
wget https://gist.githubusercontent.com/iche033/8c57b8882085dbce615419d5d472530c/raw/754f620ab034d218c0cda02453c4664968fe5935/box.obj -O box_mesh_test/box/box.obj
wget https://gist.githubusercontent.com/iche033/e59504e1b67f37f2ad30588d16fadb1b/raw/9a4dd30007345f017ca44f7da671eca6cddb9843/model.config -O box_mesh_test/box/model.config
```

Run gz-sim with bullet-featherstone plugin:

```
gz sim -v 4 box_mesh_test.sdf --physics-engine gz-physics-bullet-featherstone-plugin
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

