### PR TITLE
bullet-featherstone: Support convex decomposition for meshes

### DIFF
--- a/bullet-featherstone/src/Base.cc
+++ b/bullet-featherstone/src/Base.cc
@@ -48,7 +48,7 @@ WorldInfo::WorldInfo(std::string name_)
   // configuring split impulse and penetration threshold parameters. Instead the
   // penentration impulse depends on the erp2 parameter so set to a small value
   // (default is 0.2).
-  this->world->getSolverInfo().m_erp2 = btScalar(0.002);
+  this->world->getSolverInfo().m_erp2 = btScalar(0.02);
 }
 
 }  // namespace bullet_featherstone

--- a/bullet-featherstone/src/Base.cc
+++ b/bullet-featherstone/src/Base.cc
@@ -42,13 +42,6 @@ WorldInfo::WorldInfo(std::string name_)
   // Needed for force-torque sensor
   this->world->getSolverInfo().m_jointFeedbackInJointFrame = true;
   this->world->getSolverInfo().m_jointFeedbackInWorldSpace = false;
-
-  // By default a large impulse is applied when collisions penetrate
-  // which causes unstable behavior. Bullet featherstone does not support
-  // configuring split impulse and penetration threshold parameters. Instead the
-  // penentration impulse depends on the erp2 parameter so set to a small value
-  // (default is 0.2).
-  this->world->getSolverInfo().m_erp2 = btScalar(0.02);
 }
 
 }  // namespace bullet_featherstone

--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -487,6 +487,7 @@ class Base : public Implements3d<FeatureList<Feature>>
     // important.
     this->meshesGImpact.clear();
     this->triangleMeshes.clear();
+    this->meshesConvex.clear();
 
     this->joints.clear();
 

--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -520,6 +520,7 @@ class Base : public Implements3d<FeatureList<Feature>>
 
   public: std::vector<std::unique_ptr<btTriangleMesh>> triangleMeshes;
   public: std::vector<std::unique_ptr<btGImpactMeshShape>> meshesGImpact;
+  public: std::vector<std::unique_ptr<btConvexHullShape>> meshesConvex;
 };
 
 }  // namespace bullet_featherstone

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -1034,6 +1034,14 @@ bool SDFFeatures::AddSdfCollision(
   }
   else if (const auto *meshSdf = geom->MeshShape())
   {
+    // By default a large impulse is applied when mesh collisions penetrate
+    // which causes unstable behavior. Bullet featherstone does not support
+    // configuring split impulse and penetration threshold parameters. Instead
+    // the penentration impulse depends on the erp2 parameter so set to a small
+    // value (default is 0.2).
+    auto *world = this->ReferenceInterface<WorldInfo>(model->world);
+    world->world->getSolverInfo().m_erp2 = btScalar(0.02);
+
     auto &meshManager = *gz::common::MeshManager::Instance();
     auto *mesh = meshManager.Load(meshSdf->Uri());
     const btVector3 scale = convertVec(meshSdf->Scale());

--- a/test/common_test/collisions.cc
+++ b/test/common_test/collisions.cc
@@ -237,19 +237,13 @@ TYPED_TEST(CollisionMeshTest, MeshDecomposition)
     gz::physics::ForwardStep::Input input;
     std::size_t stepCount = 1000u;
     for (unsigned int i = 0; i < stepCount; ++i)
-    {
       world->Step(output, state, input);
-//    frameDataModelSimplifiedBody =
-//        modelSimplifiedBody->FrameDataRelativeToWorld();
-//    std::cerr  << frameDataModelSimplifiedBody.pose.translation().z() << std::endl;
-
-    }
 
     frameDataModelSimplifiedBody =
         modelSimplifiedBody->FrameDataRelativeToWorld();
-    EXPECT_NEAR(0.106,
+    EXPECT_NEAR(0.1,
                 frameDataModelSimplifiedBody.pose.translation().z(), 1e-3);
-    EXPECT_NEAR(0.0, frameDataModelSimplifiedBody.linearVelocity.z(), 2e-3);
+    EXPECT_NEAR(0.0, frameDataModelSimplifiedBody.linearVelocity.z(), 1e-3);
   }
 }
 


### PR DESCRIPTION
# 🎉 New feature

Depends on 
* https://github.com/gazebosim/sdformat/pull/1380
* https://github.com/gazebosim/gz-common/pull/583

## Summary

Supports convex decomposition on meshes. Bullet-featherstone implementation will parse the new mesh simplification attribute introduced in https://github.com/gazebosim/sdformat/pull/1380, decompses the mesh into convex meshes, and builds `btConvexHullShape` collision shapes.

Compared to `btGImpactMeshes` (which is currently used for all meshes), the convex hulls seems to be more stable, do not have gaps between meshes (collision margins can be set to 1mm instead of 1cm), and some manual testing shows potentially faster performance (dependent on the number of submeshes generated)

Added test to verify that convex decomposition flag is parsed and valid collisions are generated.

Other changes:
* the `m_erp2` value is now only set when there are meshes in the scene. The param was reduced to improve stability in https://github.com/gazebosim/gz-physics/pull/600. I think we do not need to do it globally when there are no meshes in the world as the instability seems to only come from meshes. The value is also bumped up a little to prevent to much penetration - This will likely need more tuning.

## To Test

Together with https://github.com/gazebosim/gz-sim/pull/2331, you can visualize the decomposed collision meshes. 

Run gz sim with bullet-featherstone plugin and a world that has a model (e.g. [Cordless Drill Simplified](https://app.gazebosim.org/iche033/fuel/models/Cordless%20Drill%20Simplified)) that uses mesh decomposition:

```
gz sim -v 4 your_test_world.sdf --physics-engine gz-physics-bullet-featherstone-plugin
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

