### PR TITLE
Support setting solver iterations

### DIFF
--- a/bullet-featherstone/src/Base.cc
+++ b/bullet-featherstone/src/Base.cc
@@ -45,10 +45,15 @@ WorldInfo::WorldInfo(std::string name_)
 
   // By default a large impulse is applied when collisions penetrate
   // which causes unstable behavior. Bullet featherstone does not support
-  // configuring split impulse and penetration threshold parameters. Instead the
-  // penentration impulse depends on the erp2 parameter so set to a small value
-  // (default is 0.2).
+  // configuring split impulse and penetration threshold parameters. Instead
+  // the penentration impulse depends on the erp2 parameter so set to a small
+  // value (default in bullet is 0.2).
   this->world->getSolverInfo().m_erp2 = btScalar(0.002);
+
+  // Set solver iterations to the same as the default value in SDF,
+  // //world/physics/solver/bullet/iters
+  // (default in bullet is 10)
+  this->world->getSolverInfo().m_numIterations = 50u;
 }
 
 }  // namespace bullet_featherstone

--- a/bullet-featherstone/src/WorldFeatures.cc
+++ b/bullet-featherstone/src/WorldFeatures.cc
@@ -52,6 +52,51 @@ WorldFeatures::LinearVectorType WorldFeatures::GetWorldGravity(
     return WorldFeatures::LinearVectorType(0, 0, 0);
   }
 }
+
+/////////////////////////////////////////////////
+void WorldFeatures::SetWorldSolver(const Identity &,
+    const std::string &_solver)
+{
+  // bullet-featherstone implementation uses btMultiBodyDynamicsWorld
+  // so currently only supports BT_MULTIBODY_SOLVER
+  if (_solver != "MultiBodySolver")
+  {
+    gzwarn << "bullet-featherstone implementation currently only supports "
+           << "MultiBodySolver (BT_MULTIBODY_SOLVER)" << std::endl;
+  }
+}
+
+/////////////////////////////////////////////////
+const std::string &WorldFeatures::GetWorldSolver(const Identity &) const
+{
+  // bullet-featherstone implementation uses btMultiBodyDynamicsWorld
+  // so currently only supports BT_MULTIBODY_SOLVER
+  static std::string solverType = "MultiBodySolver";
+  return solverType;
+}
+
+/////////////////////////////////////////////////
+void WorldFeatures::SetWorldSolverIterations(const Identity &_id,
+    std::size_t _iterations)
+{
+  const auto worldInfo = this->ReferenceInterface<WorldInfo>(_id);
+  if (worldInfo)
+  {
+    worldInfo->world->getSolverInfo().m_numIterations = _iterations;
+  }
+}
+
+/////////////////////////////////////////////////
+std::size_t WorldFeatures::GetWorldSolverIterations(const Identity &_id) const
+{
+  const auto worldInfo = this->ReferenceInterface<WorldInfo>(_id);
+  if (worldInfo)
+  {
+    return worldInfo->world->getSolverInfo().m_numIterations;
+  }
+  return 0u;
+}
+
 }
 }
 }

--- a/bullet-featherstone/src/WorldFeatures.hh
+++ b/bullet-featherstone/src/WorldFeatures.hh
@@ -29,7 +29,8 @@ namespace physics {
 namespace bullet_featherstone {
 
 struct WorldFeatureList : FeatureList<
-  Gravity
+  Gravity,
+  Solver
 > { };
 
 class WorldFeatures :
@@ -42,6 +43,21 @@ class WorldFeatures :
 
   // Documentation inherited
   public: LinearVectorType GetWorldGravity(const Identity &_id) const override;
+
+  // Documentation inherited
+  public: void SetWorldSolver(const Identity &_id, const std::string &_solver)
+      override;
+
+  // Documentation inherited
+  public: const std::string &GetWorldSolver(const Identity &_id) const override;
+
+  // Documentation inherited
+  public: void SetWorldSolverIterations(const Identity &_id, std::size_t)
+      override;
+
+  // Documentation inherited
+  public: std::size_t GetWorldSolverIterations(const Identity &_id) const
+      override;
 };
 
 }

--- a/bullet-featherstone/src/WorldFeatures.hh
+++ b/bullet-featherstone/src/WorldFeatures.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_BULLET_SRC_WORLDFEATURES_HH_
 #define GZ_PHYSICS_BULLET_SRC_WORLDFEATURES_HH_
 
+#include <cstddef>
 #include <string>
 
 #include <gz/physics/World.hh>

--- a/dartsim/src/WorldFeatures.cc
+++ b/dartsim/src/WorldFeatures.cc
@@ -154,7 +154,6 @@ void WorldFeatures::SetWorldSolver(const Identity &_id,
     return;
   }
 
-
   std::shared_ptr<dart::constraint::BoxedLcpSolver> boxedSolver;
   if (_solver == "dantzig" || _solver == "DantzigBoxedLcpSolver")
   {

--- a/dartsim/src/WorldFeatures.hh
+++ b/dartsim/src/WorldFeatures.hh
@@ -68,6 +68,14 @@ class WorldFeatures :
 
   // Documentation inherited
   public: const std::string &GetWorldSolver(const Identity &_id) const override;
+
+  // Documentation inherited
+  public: void SetWorldSolverIterations(const Identity &_id, std::size_t)
+      override;
+
+  // Documentation inherited
+  public: std::size_t GetWorldSolverIterations(const Identity &_id) const
+      override;
 };
 
 }

--- a/dartsim/src/WorldFeatures.hh
+++ b/dartsim/src/WorldFeatures.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_DARTSIM_SRC_WORLDFEATURES_HH_
 #define GZ_PHYSICS_DARTSIM_SRC_WORLDFEATURES_HH_
 
+#include <cstddef>
 #include <string>
 
 #include <gz/physics/World.hh>

--- a/dartsim/src/WorldFeatures_TEST.cc
+++ b/dartsim/src/WorldFeatures_TEST.cc
@@ -115,6 +115,12 @@ TEST_F(WorldFeaturesFixture, Solver)
   world->SetSolver("dantzig");
   EXPECT_EQ("DantzigBoxedLcpSolver", world->GetSolver());
 
+  world->SetSolverIterations(20u);
+  EXPECT_EQ(0u, world->GetSolverIterations());
+
   world->SetSolver("pgs");
   EXPECT_EQ("PgsBoxedLcpSolver", world->GetSolver());
+
+  world->SetSolverIterations(20u);
+  EXPECT_EQ(20u, world->GetSolverIterations());
 }

--- a/include/gz/physics/World.hh
+++ b/include/gz/physics/World.hh
@@ -184,6 +184,14 @@ namespace gz
         /// \brief Get the name of the solver in use.
         /// \return Name of solver.
         public: const std::string &GetSolver() const;
+
+        /// \brief Set the number of solver iterations per step.
+        /// \param[in] _Iterations Number of solver iterations per step
+        public: void SetSolverIterations(std::size_t _iterations);
+
+        /// \brief Get the number of solver iterations per step.
+        /// \return Number of solver iterations per step.
+        public: std::size_t GetSolverIterations() const;
       };
 
       /// \private The implementation API for the solver.
@@ -200,6 +208,18 @@ namespace gz
         /// \param[in] _id Identity of the world.
         /// \return Name of solver.
         public: virtual const std::string &GetWorldSolver(
+            const Identity &_id) const = 0;
+
+        /// \brief Implementation API for setting the number of solver iterations.
+        /// \param[in] _id Identity of the world.
+        /// \param[in] _solver Number of solver iterations.
+        public: virtual void SetWorldSolverIterations(
+            const Identity &_id, std::size_t _iterations) = 0;
+
+        /// \brief Implementation API for getting the number of solver iterations.
+        /// \param[in] _id Identity of the world.
+        /// \return Number of solver iterations.
+        public: virtual std::size_t GetWorldSolverIterations(
             const Identity &_id) const = 0;
       };
     };

--- a/include/gz/physics/World.hh
+++ b/include/gz/physics/World.hh
@@ -210,13 +210,15 @@ namespace gz
         public: virtual const std::string &GetWorldSolver(
             const Identity &_id) const = 0;
 
-        /// \brief Implementation API for setting the number of solver iterations.
+        /// \brief Implementation API for setting the number of solver
+        /// iterations.
         /// \param[in] _id Identity of the world.
         /// \param[in] _solver Number of solver iterations.
         public: virtual void SetWorldSolverIterations(
             const Identity &_id, std::size_t _iterations) = 0;
 
-        /// \brief Implementation API for getting the number of solver iterations.
+        /// \brief Implementation API for getting the number of solver
+        /// iterations.
         /// \param[in] _id Identity of the world.
         /// \return Number of solver iterations.
         public: virtual std::size_t GetWorldSolverIterations(

--- a/include/gz/physics/World.hh
+++ b/include/gz/physics/World.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_WORLD_HH_
 #define GZ_PHYSICS_WORLD_HH_
 
+#include <cstddef>
 #include <string>
 
 #include <gz/physics/FeatureList.hh>
@@ -186,7 +187,7 @@ namespace gz
         public: const std::string &GetSolver() const;
 
         /// \brief Set the number of solver iterations per step.
-        /// \param[in] _Iterations Number of solver iterations per step
+        /// \param[in] _iterations Number of solver iterations per step
         public: void SetSolverIterations(std::size_t _iterations);
 
         /// \brief Get the number of solver iterations per step.

--- a/include/gz/physics/detail/World.hh
+++ b/include/gz/physics/detail/World.hh
@@ -135,6 +135,24 @@ const std::string &Solver::World<PolicyT, FeaturesT>::
       ->GetWorldSolver(this->identity);
 }
 
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+void Solver::World<PolicyT, FeaturesT>::SetSolverIterations(
+    std::size_t _iterations)
+{
+  this->template Interface<Solver>()
+      ->SetWorldSolverIterations(this->identity, _iterations);
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+std::size_t Solver::World<PolicyT, FeaturesT>::
+    GetSolverIterations() const
+{
+  return this->template Interface<Solver>()
+      ->GetWorldSolverIterations(this->identity);
+}
+
 }  // namespace physics
 }  // namespace gz
 

--- a/include/gz/physics/detail/World.hh
+++ b/include/gz/physics/detail/World.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_DETAIL_WORLD_HH_
 #define GZ_PHYSICS_DETAIL_WORLD_HH_
 
+#include <cstddef>
 #include <string>
 
 #include <gz/physics/World.hh>

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -1133,7 +1133,7 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachDetach)
 
     // After a while, body2 should reach the ground and come to a stop
     std::size_t stepCount = 0u;
-    const std::size_t maxNumSteps = 1000u;
+    const std::size_t maxNumSteps = 2000u;
     while (stepCount++ < maxNumSteps)
     {
       world->Step(output, state, input);

--- a/test/common_test/world_features.cc
+++ b/test/common_test/world_features.cc
@@ -457,6 +457,56 @@ TEST_F(WorldNestedModelTest, WorldConstructNestedModel)
   }
 }
 
+struct WorldSolverFeatureList : gz::physics::FeatureList<
+  gz::physics::GetEngineInfo,
+  gz::physics::Solver,
+  gz::physics::sdf::ConstructSdfWorld
+> { };
+
+
+class WorldSolverTest : public WorldFeaturesTest<WorldSolverFeatureList>
+{
+  public: gz::physics::World3dPtr<WorldSolverFeatureList> LoadWorld(
+      const std::string &_pluginName)
+  {
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(_pluginName);
+
+    auto engine =
+        gz::physics::RequestEngine3d<WorldSolverFeatureList>::From(plugin);
+
+    sdf::Root root;
+    const sdf::Errors errors = root.Load(
+        common_test::worlds::kEmptySdf);
+    EXPECT_TRUE(errors.empty()) << errors;
+    if (errors.empty())
+    {
+      auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+      return world;
+    }
+    return nullptr;
+  }
+};
+
+TEST_F(WorldSolverTest, WorldSolver)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    auto world = this->LoadWorld(name);
+    ASSERT_NE(nullptr, world);
+
+    EXPECT_FALSE(world->GetSolver().empty());
+    EXPECT_NO_THROW(world->SetSolver("invalid"));
+    EXPECT_NE("invalid", world->GetSolver());
+
+    if (PhysicsEngineName(name) == "bullet-featherstone")
+    {
+      EXPECT_LT(0u, world->GetSolverIterations());
+      world->SetSolverIterations(100u);
+      EXPECT_EQ(100u, world->GetSolverIterations());
+    }
+  }
+}
+
 int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/common_test/world_features.cc
+++ b/test/common_test/world_features.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <gtest/gtest.h>
+#include <string>
 
 #include <gz/common/Console.hh>
 #include <gz/plugin/Loader.hh>
@@ -39,6 +40,7 @@
 #include <gz/physics/sdf/ConstructWorld.hh>
 
 #include <sdf/Root.hh>
+#include <sdf/Types.hh>
 
 using AssertVectorApprox = gz::physics::test::AssertVectorApprox;
 
@@ -462,7 +464,6 @@ struct WorldSolverFeatureList : gz::physics::FeatureList<
   gz::physics::Solver,
   gz::physics::sdf::ConstructSdfWorld
 > { };
-
 
 class WorldSolverTest : public WorldFeaturesTest<WorldSolverFeatureList>
 {


### PR DESCRIPTION
# 🎉 New feature

## Summary
Extends Solver feature to support setting solver iterations per step.

Added support in:
* dart: only applicable if solver type is `PgsBoxedLcpSolver`
* bullet-featherstone: sets solver iteration for `btMultiBodyMCLPConstraintSolver`.  By default it's now set to 50 (same as the default value in [`//world/physics/bullet/solver/iters`](http://sdformat.org/spec?ver=1.11&elem=physics#solver_iters)). Originally it was only [10](https://github.com/bulletphysics/bullet3/blob/master/src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h#L85). Changing to 50 improves stability and prevents objects from drifting.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

