### PR TITLE
[bullet-featherstone] Fix attaching fixed joint

### DIFF
--- a/bullet-featherstone/src/JointFeatures.cc
+++ b/bullet-featherstone/src/JointFeatures.cc
@@ -368,8 +368,11 @@ void JointFeatures::SetJointTransformFromParent(
 
   if (jointInfo->fixedConstraint)
   {
+      auto tf = convertTf(_pose);
       jointInfo->fixedConstraint->setPivotInA(
-        convertVec(_pose.translation()));
+        tf.getOrigin());
+      jointInfo->fixedConstraint->setFrameInA(
+        tf.getBasis());
   }
 }
 

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -1040,8 +1040,8 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachDetach)
     auto frameDataModel1Body = model1Body->FrameDataRelativeToWorld();
     auto frameDataModel2Body = model2Body->FrameDataRelativeToWorld();
 
-    const gz::math::Pose3d initialModel1Pose(0, 0, 0.25, 0, 0, 0);
-    const gz::math::Pose3d initialModel2Pose(0, 0, 3.0, 0, 0, 0);
+    const gz::math::Pose3d initialModel1Pose(0, 0, 0.25, 0, 0, 0.1);
+    const gz::math::Pose3d initialModel2Pose(0, 0, 3.0, 0, 0, 0.2);
 
     EXPECT_EQ(initialModel1Pose,
               gz::math::eigen3::convert(frameDataModel1Body.pose));
@@ -1133,14 +1133,14 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachDetach)
 
     // After a while, body2 should reach the ground and come to a stop
     std::size_t stepCount = 0u;
-    const std::size_t maxNumSteps = 1000u;
+    const std::size_t maxNumSteps = 2000u;
     while (stepCount++ < maxNumSteps)
     {
       world->Step(output, state, input);
       frameDataModel2Body = model2Body->FrameDataRelativeToWorld();
       // Expected Z height of model2 is 0.75 when both boxes are stacked on top
       // of each other since each is 0.5 high.
-      if (fabs(frameDataModel2Body.pose.translation().z() - 0.75) < 2e-2 &&
+      if (fabs(frameDataModel2Body.pose.translation().z() - 0.75) < 1e-2 &&
           fabs(frameDataModel2Body.linearVelocity.z()) < 1e-3)
       {
         break;

--- a/test/common_test/worlds/joint_across_models.sdf
+++ b/test/common_test/worlds/joint_across_models.sdf
@@ -29,7 +29,7 @@
     </model>
 
     <model name="M1">
-      <pose>0 0 0.25 0 0.0 0</pose>
+      <pose>0 0 0.25 0 0.0 0.1</pose>
       <link name="body">
         <inertial>
           <inertia>
@@ -65,7 +65,7 @@
       </link>
     </model>
     <model name="M2">
-      <pose>0 0 3.0 0 0.0 0</pose>
+      <pose>0 0 3.0 0 0.0 0.2</pose>
       <link name="body">
         <inertial>
           <inertia>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes attaching fixed joint between 2 models.

## Summary

When 2 models are attached by a fixed joint in bullet-featherstone, their rotations are not maintained (only the translation was set). This PR fixes the issue.

## Test it

Before the fix, when you try to create a detachable joint in gz sim (which uses a fixed joint) between two models with rotations, the parent's rotation will be rotated to match the child's, making the models unstable.

I updated the `joint_features` test to use models with rotations.

To test with gz sim: run the [box_attach.sdf](https://gist.github.com/iche033/42731e6cb098d3c79655ac2b70fcbd78) world with bullet-featherstone:

```bash
gz sim -v 4 box_attach.sdf --physics-engine gz-physics-bullet-featherstone-plugin
```

Hit play to create the detachable joint and the boxes become unstable:

![bullet_box_attach](https://github.com/gazebosim/gz-physics/assets/4000684/f4577591-7398-4c6d-ba87-2feab9af226f)

After the fix, the box should remain stable when the joint is created.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

