### PR TITLE
[bullet-featherstone] Ignore collision between static objects and objects with world joint

### DIFF
--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -1213,8 +1213,8 @@ bool SDFFeatures::AddSdfCollision(
       if (model->body->hasFixedBase())
       {
         // check if it's a base link
-        std::size_t linkID = model->body->getUserIndex();
-        isFixed = std::size_t(_linkID) == linkID;
+        isFixed = std::size_t(_linkID) ==
+            static_cast<std::size_t>(model->body->getUserIndex());
         // check if link has zero dofs
         if (!isFixed && linkInfo->indexInModel.has_value())
         {

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -1205,12 +1205,24 @@ bool SDFFeatures::AddSdfCollision(
 
       auto *world = this->ReferenceInterface<WorldInfo>(model->world);
 
-      // Set static filter for collisions in a static model
-      // and collisions in a base link that is fixed to the world
-      std::size_t linkID = model->body->getUserIndex();
-      bool isFixedBaseLink = model->body->hasFixedBase() &&
-                             (std::size_t(_linkID) == linkID);
-      if (isStatic || isFixedBaseLink)
+      // Set static filter for collisions in
+      // 1) a static model
+      // 2) a fixed base link
+      // 3) a (non-base) link with zero dofs
+      bool isFixed = false;
+      if (model->body->hasFixedBase())
+      {
+        // check if it's a base link
+        std::size_t linkID = model->body->getUserIndex();
+        isFixed = std::size_t(_linkID) == linkID;
+        // check if link has zero dofs
+        if (!isFixed && linkInfo->indexInModel.has_value())
+        {
+           isFixed = model->body->getLink(
+              linkInfo->indexInModel.value()).m_dofCount == 0;
+        }
+      }
+      if (isStatic || isFixed)
       {
         world->world->addCollisionObject(
           linkInfo->collider.get(),

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -1205,7 +1205,12 @@ bool SDFFeatures::AddSdfCollision(
 
       auto *world = this->ReferenceInterface<WorldInfo>(model->world);
 
-      if (isStatic)
+      // Set static filter for collisions in a static model
+      // and collisions in a base link that is fixed to the world
+      std::size_t linkID = model->body->getUserIndex();
+      bool isFixedBaseLink = model->body->hasFixedBase() &&
+                             (std::size_t(_linkID) == linkID);
+      if (isStatic || isFixedBaseLink)
       {
         world->world->addCollisionObject(
           linkInfo->collider.get(),

--- a/test/common_test/collisions.cc
+++ b/test/common_test/collisions.cc
@@ -16,6 +16,7 @@
 */
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <string>
 
 #include <gz/common/Console.hh>
@@ -23,6 +24,7 @@
 
 #include "test/Resources.hh"
 #include "test/TestLibLoader.hh"
+#include "Worlds.hh"
 
 #include <gz/physics/FindFeatures.hh>
 #include <gz/physics/RequestEngine.hh>
@@ -30,13 +32,17 @@
 #include <gz/physics/ForwardStep.hh>
 #include <gz/physics/FrameSemantics.hh>
 #include <gz/physics/FreeJoint.hh>
+#include <gz/physics/GetContacts.hh>
 #include <gz/physics/GetEntities.hh>
 #include <gz/physics/mesh/MeshShape.hh>
 #include <gz/physics/PlaneShape.hh>
 #include <gz/physics/FixedJoint.hh>
+#include <gz/physics/sdf/ConstructModel.hh>
 #include <gz/physics/sdf/ConstructWorld.hh>
 
 #include <gz/common/MeshManager.hh>
+
+#include <sdf/Root.hh>
 
 template <class T>
 class CollisionTest:
@@ -138,6 +144,130 @@ TYPED_TEST(CollisionTest, MeshAndPlane)
     // be rocking side-to-side after falling).
     EXPECT_NEAR(
           -1.91, link2->FrameDataRelativeToWorld().pose.translation()[2], 0.05);
+  }
+}
+
+struct CollisionStaticFeaturesList : gz::physics::FeatureList<
+  gz::physics::sdf::ConstructSdfModel,
+  gz::physics::sdf::ConstructSdfWorld,
+  gz::physics::GetContactsFromLastStepFeature,
+  gz::physics::ForwardStep
+> { };
+
+template <class T>
+class CollisionStaticTest :
+  public CollisionTest<T>{};
+using CollisionStaticTestTypes =
+  ::testing::Types<CollisionStaticFeaturesList>;
+TYPED_TEST_SUITE(CollisionStaticTest,
+                 CollisionStaticTestTypes);
+
+TYPED_TEST(CollisionStaticTest, StaticCollisions)
+{
+  auto getBoxStaticStr = [](const std::string &_name,
+                              const gz::math::Pose3d &_pose)
+  {
+    std::stringstream modelStaticStr;
+    modelStaticStr << R"(
+    <sdf version="1.11">
+      <model name=")";
+    modelStaticStr << _name << R"(">
+        <pose>)";
+    modelStaticStr << _pose;
+    modelStaticStr << R"(</pose>
+        <link name="body">
+          <collision name="collision">
+            <geometry>
+              <box><size>1 1 1</size></box>
+            </geometry>
+          </collision>
+        </link>
+        <static>true</static>
+      </model>
+    </sdf>)";
+    return modelStaticStr.str();
+  };
+
+  auto getBoxFixedJointStr = [](const std::string &_name,
+                                const gz::math::Pose3d &_pose)
+  {
+    std::stringstream modelFixedJointStr;
+    modelFixedJointStr << R"(
+    <sdf version="1.11">
+      <model name=")";
+    modelFixedJointStr << _name << R"(">
+        <pose>)";
+    modelFixedJointStr << _pose;
+    modelFixedJointStr << R"(</pose>
+        <link name="body">
+          <collision name="collision">
+            <geometry>
+              <box><size>1 1 1</size></box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="world_fixed" type="fixed">
+          <parent>world</parent>
+          <child>body</child>
+        </joint>
+      </model>
+    </sdf>)";
+    return modelFixedJointStr.str();
+  };
+
+  for (const std::string &name : this->pluginNames)
+  {
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    sdf::Root rootWorld;
+    const sdf::Errors errorsWorld =
+        rootWorld.Load(common_test::worlds::kGroundSdf);
+    ASSERT_TRUE(errorsWorld.empty()) << errorsWorld.front();
+
+    auto engine =
+        gz::physics::RequestEngine3d<CollisionStaticFeaturesList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    auto world = engine->ConstructWorld(*rootWorld.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(getBoxStaticStr(
+        "box_static", gz::math::Pose3d::Zero));
+    ASSERT_TRUE(errors.empty()) << errors.front();
+    ASSERT_NE(nullptr, root.Model());
+    world->ConstructModel(*root.Model());
+
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+    for (std::size_t i = 0; i < 10; ++i)
+    {
+      world->Step(output, state, input);
+    }
+
+    // static box overlaps with ground plane
+    // verify no contacts between static bodies.
+    auto contacts = world->GetContactsFromLastStep();
+    EXPECT_EQ(0u, contacts.size());
+
+    // currently only bullet-featherstone skips collision checking between
+    // static bodies and bodies with world fixed joint
+    if (this->PhysicsEngineName(name) != "bullet-featherstone")
+      continue;
+
+    errors = root.LoadSdfString(getBoxFixedJointStr(
+        "box_fixed_world_joint", gz::math::Pose3d::Zero));
+    ASSERT_TRUE(errors.empty()) << errors.front();
+    ASSERT_NE(nullptr, root.Model());
+    world->ConstructModel(*root.Model());
+
+    world->Step(output, state, input);
+    // box fixed to world overlaps with static box and ground plane
+    // verify there are still no contacts.
+    contacts = world->GetContactsFromLastStep();
+    EXPECT_EQ(0u, contacts.size());
   }
 }
 

--- a/test/common_test/collisions.cc
+++ b/test/common_test/collisions.cc
@@ -147,25 +147,20 @@ TYPED_TEST(CollisionTest, MeshAndPlane)
   }
 }
 
-struct CollisionStaticFeaturesList : gz::physics::FeatureList<
+using CollisionStaticFeaturesList = gz::physics::FeatureList<
   gz::physics::sdf::ConstructSdfModel,
   gz::physics::sdf::ConstructSdfWorld,
   gz::physics::GetContactsFromLastStepFeature,
   gz::physics::ForwardStep
-> { };
+>;
 
-template <class T>
-class CollisionStaticTest :
-  public CollisionTest<T>{};
-using CollisionStaticTestTypes =
-  ::testing::Types<CollisionStaticFeaturesList>;
-TYPED_TEST_SUITE(CollisionStaticTest,
-                 CollisionStaticTestTypes);
+using CollisionStaticTestFeaturesList =
+  CollisionTest<CollisionStaticFeaturesList>;
 
-TYPED_TEST(CollisionStaticTest, StaticCollisions)
+TEST_F(CollisionStaticTestFeaturesList, StaticCollisions)
 {
   auto getBoxStaticStr = [](const std::string &_name,
-                              const gz::math::Pose3d &_pose)
+                            const gz::math::Pose3d &_pose)
   {
     std::stringstream modelStaticStr;
     modelStaticStr << R"(


### PR DESCRIPTION
# 🎉 New feature

## Summary

Skip collision checking between collisions in 1) a static model 2) a fixed base link, and 3) a non base link with zero dofs.

This is done by setting the collision filter mask / flags to use the `StaticFilter`, which is already done for static objects (`<static>true</static>`), i.e. static objects already ignore collisions with each other.

This is for perf optimization. When you have overlapping complex meshes with fixed world joints, they would cause a perf hit and these changes would allow bullet to skip collision checking between them.

Added a test in `collisions.cc` that checks contacts between static objects and objects with fixed world joint.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
