### PR TITLE
Disable check in `DetachableJointTest.CorrectAttachmentPoints` test for dartsim plugin on homebrew

### DIFF
--- a/test/common_test/detachable_joint.cc
+++ b/test/common_test/detachable_joint.cc
@@ -187,7 +187,14 @@ TYPED_TEST(DetachableJointTest, CorrectAttachmentPoints)
       // ground.
       auto frameDataC1L1 = cylinder1_link1->FrameDataRelativeToWorld();
       auto frameDataC2L2 = cylinder2_link2->FrameDataRelativeToWorld();
-      EXPECT_NEAR(0.15, frameDataC1L1.pose.translation().z(), 1e-2);
+#ifdef __APPLE__
+      // Disable check for dartsim plugin on homebrew,
+      // see https://github.com/gazebosim/gz-physics/issues/612.
+      if (this->PhysicsEngineName(name) != "dartsim")
+#endif
+      {
+        EXPECT_NEAR(0.15, frameDataC1L1.pose.translation().z(), 1e-2);
+      }
       EXPECT_NEAR(0.05, frameDataC2L2.pose.translation().z(), 1e-2);
     }
   }


### PR DESCRIPTION


# 🦟 Bug fix

Related issue: #612

## Summary

Test started failing recently on hombrew likely due to new ODE 0.6.15 bottle. Disabling check until issue is fixed upstream.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

