### PR TITLE
Use relative install paths for plugin shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,7 @@ message(STATUS "-------------------------------------------\n")
 set(GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR
   ${GZ_LIB_INSTALL_DIR}/gz-${GZ_DESIGNATION}-${PROJECT_VERSION_MAJOR}/engine-plugins
 )
-set(GZ_PHYSICS_ENGINE_INSTALL_DIR
-  ${CMAKE_INSTALL_PREFIX}/${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR}
-)
+set(GZ_PHYSICS_ENGINE_INSTALL_DIR ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
 
 #============================================================================
 # Configure the build


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes an error when building https://github.com/gazebo-release/gz_physics_vendor/ in the ROS buildfarm.

Similar to https://github.com/gazebosim/gz-tools/pull/137


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
