### PR TITLE
Disable test failing due to ODE/libccd

### DIFF
--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -966,9 +966,23 @@ TYPED_TEST(JointFeaturesDetachTest, JointDetach)
     // sanity check on velocity values
     EXPECT_LT(1e-5, upperLinkLinearVelocity.Z());
     EXPECT_GT(-0.03, upperLinkAngularVelocity.X());
-    EXPECT_NEAR(0.0, upperLinkLinearVelocity.X(), 1e-6);
+#ifdef __APPLE__
+    // Disable some expectations for dartsim plugin on homebrew,
+    // see https://github.com/gazebosim/gz-physics/issues/620.
+    if (this->PhysicsEngineName(name) != "dartsim")
+#endif
+    {
+      EXPECT_NEAR(0.0, upperLinkLinearVelocity.X(), 1e-6);
+    }
     EXPECT_NEAR(0.0, upperLinkLinearVelocity.Y(), 1e-6);
-    EXPECT_NEAR(0.0, upperLinkAngularVelocity.Y(), 1e-6);
+#ifdef __APPLE__
+    // Disable some expectations for dartsim plugin on homebrew,
+    // see https://github.com/gazebosim/gz-physics/issues/620.
+    if (this->PhysicsEngineName(name) != "dartsim")
+#endif
+    {
+      EXPECT_NEAR(0.0, upperLinkAngularVelocity.Y(), 1e-6);
+    }
     EXPECT_NEAR(0.0, upperLinkAngularVelocity.Z(), 1e-6);
 
     upperJoint->Detach();


### PR DESCRIPTION
# 🦟 Bug fix

Part of #620.

## Summary

As noted in #620, the [JointFeaturesDetachTest/0.JointDetach](https://build.osrfoundation.org/view/gz-harmonic/job/gz_physics-ci-gz-physics7-homebrew-amd64/35/testReport/junit/(root)/JointFeaturesDetachTest_0/JointDetach_2/) test has been failing on macOS since ODE 0.16.5 was merged to homebrew-core in https://github.com/Homebrew/homebrew-core/pull/167158. This disables the failing test expectations while we investigate the cause in #620.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
