### PR TITLE
Find python directly instead of using GzPython

### DIFF
--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -23,7 +23,7 @@ set(TEST_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_V
 
 # Find the Python interpreter for running the
 # check_test_ran.py script
-include(GzPython)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 function(configure_common_test PHYSICS_ENGINE_NAME test_name)
   if(NOT SKIP_${PHYSICS_ENGINE_NAME} AND NOT INTERNAL_SKIP_${PHYSICS_ENGINE_NAME})


### PR DESCRIPTION
# 🎉 New feature

Part of gazebosim/gz-cmake#350.

## Summary

I suggested in https://github.com/gazebosim/gz-cmake/issues/350#issuecomment-1907453341 that we find python directly so that `GzPython` can be deprecated, and this is a step towards that goal.

## Test it

Compile and run tests and verify that the `check_test_ran.py` script still runs.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
