### PR TITLE
Add no gravity link support

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -600,6 +600,11 @@ Identity SDFFeatures::ConstructSdfLink(
 
   bodyProperties.mInertia.setLocalCOM(localCom);
 
+  // ignmsg << "SDF gravity status = " << _sdfLink.EnableGravity() << std::endl;
+
+  bodyProperties.mGravityMode = _sdfLink.EnableGravity();
+  // ignmsg << "gravity in dart set to: " << bodyProperties.mGravityMode << std::endl;
+
   dart::dynamics::FreeJoint::Properties jointProperties;
   jointProperties.mName = bodyProperties.mName + "_FreeJoint";
   // TODO(MXG): Consider adding a UUID to this joint name in order to avoid any

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -600,10 +600,7 @@ Identity SDFFeatures::ConstructSdfLink(
 
   bodyProperties.mInertia.setLocalCOM(localCom);
 
-  // ignmsg << "SDF gravity status = " << _sdfLink.EnableGravity() << std::endl;
-
   bodyProperties.mGravityMode = _sdfLink.EnableGravity();
-  // ignmsg << "gravity in dart set to: " << bodyProperties.mGravityMode << std::endl;
 
   dart::dynamics::FreeJoint::Properties jointProperties;
   jointProperties.mName = bodyProperties.mName + "_FreeJoint";

--- a/dartsim/src/WorldFeatures_TEST.cc
+++ b/dartsim/src/WorldFeatures_TEST.cc
@@ -201,7 +201,7 @@ TEST_F(WorldFeaturesFixture, Gravity)
                         .pose.translation();
     EXPECT_PRED_FORMAT2(vectorPredicate3,
                         Eigen::Vector3d(10, 10, 10),
-                        pos);
+                        posNoGravity);
   }
 }
 

--- a/dartsim/src/WorldFeatures_TEST.cc
+++ b/dartsim/src/WorldFeatures_TEST.cc
@@ -140,6 +140,12 @@ TEST_F(WorldFeaturesFixture, Gravity)
   auto link = model->GetLink(0);
   ASSERT_NE(nullptr, link);
 
+  auto modelNoGravity = world->GetModel("sphere_no_gravity");
+  ASSERT_NE(nullptr, modelNoGravity);
+
+  auto linkNoGravity = modelNoGravity->GetLink(0);
+  ASSERT_NE(nullptr, linkNoGravity);
+
   // initial link pose
   const Eigen::Vector3d initialLinkPosition(0, 0, 2);
   {
@@ -189,6 +195,12 @@ TEST_F(WorldFeaturesFixture, Gravity)
     Eigen::Vector3d pos = link->FrameDataRelativeToWorld().pose.translation();
     EXPECT_PRED_FORMAT2(vectorPredicate3,
                         Eigen::Vector3d(0.5, 0, 2.5),
+                        pos);
+    // pose for link without gravity should not change
+    Eigen::Vector3d posNoGravity = linkNoGravity->FrameDataRelativeToWorld()
+                        .pose.translation();
+    EXPECT_PRED_FORMAT2(vectorPredicate3,
+                        Eigen::Vector3d(10, 10, 10),
                         pos);
   }
 }

--- a/dartsim/worlds/falling.world
+++ b/dartsim/worlds/falling.world
@@ -71,5 +71,17 @@
         </visual>
       </link>
     </model>
+    <model name='sphere_no_gravity'>
+      <link name='link'>
+        <gravity>false</gravity>
+        <pose>10 10 10 0 0 0</pose>
+        <visual name='visual'>
+          <geometry><sphere><radius>1</radius></sphere></geometry>
+        </visual>
+        <collision name='collision'>
+          <geometry><sphere><radius>1</radius></sphere></geometry>
+        </collision>
+      </link>
+    </model>
   </world>
 </sdf>


### PR DESCRIPTION
# 🎉 New feature

Original issue: gazebosim/gz-sim#504

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add parsing and support for no gravity link when using DartSim engine

For implementation and test details, see gazebosim/gz-sim#2398

Changes in other repo:
gz-physics: gazebosim/gz-physics#633
sdformat: gazebosim/sdformat#1410

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.