### PR TITLE
bullet-featherstone: Fix convex hull shape's AABB

### DIFF
--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -1124,6 +1124,8 @@ bool SDFFeatures::AddSdfCollision(
               &(vertices[0].getX()), vertices.size()));
           auto *convexShape = this->meshesConvex.back().get();
           convexShape->setMargin(collisionMargin);
+          convexShape->recalcLocalAabb();
+          convexShape->optimizeConvexHull();
 
           btTransform trans;
           trans.setIdentity();


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

After setting a btConvexHullShape's collision margin, the AABBs need to be explicitly recalculated.

This has performance implications. When AABBs overlap, More computation is done in terms of building islands, solving constraints, etc. Non overlapping objects at rest can also be deactivated. So this fix helps improve performance when many objects are located close to each other.

For reference, the same calls are done in the bullet examples, e.g. [here](https://github.com/bulletphysics/bullet3/blob/272c7099d3ba8ac9e8c142e361e8d4cf5d91b8f2/examples/SharedMemory/PhysicsServerCommandProcessor.cpp#L5356-L5357)

The difference in broadphase AABBs is visualized below:

<img width="496" alt="bullet_convex_aabb" src="https://github.com/gazebosim/gz-physics/assets/4000684/4f4e0e53-c730-40fe-a2d7-7a4b850150dd">

Left: No recalculation (before the changes)
Right: AABB recalculated

The AABB size difference is roughly `[0.1 0.1 0.1]`

Note that there is still some obvious padding in the updated broadphase AABB

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

