### PR TITLE
Add Cone as a primitive parametric shape.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Gazebo Physics provides the following functionality:
   at runtime.
 * Features for common aspects of rigid body dynamic simulation
     - Construct model from [SDFormat](http://sdformat.org/) file.
-    - Collision shapes (such as box, sphere, cylinder, capsule, ellipsoid, mesh, heightmap).
+    - Collision shapes (such as box, sphere, cylinder, cone, capsule, ellipsoid, mesh, heightmap).
     - Joint types (such as revolute, prismatic, fixed, ball, screw, universal).
     - Step simulation, get/set state, apply inputs.
 * Reference implementation of physics plugin using

--- a/bullet-featherstone/README.md
+++ b/bullet-featherstone/README.md
@@ -65,6 +65,8 @@ These are the specific physics API features implemented.
   * AttachBoxShapeFeature
   * GetCapsuleShapeProperties
   * AttachCapsuleShapeFeature
+  * GetConeShapeProperties
+  * AttachConeShapeFeature
   * GetCylinderShapeProperties
   * AttachCylinderShapeFeature
   * GetEllipsoidShapeProperties

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -25,6 +25,7 @@
 
 #include <sdf/Box.hh>
 #include <sdf/Capsule.hh>
+#include <sdf/Cone.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Ellipsoid.hh>
 #include <sdf/Geometry.hh>
@@ -962,6 +963,14 @@ bool SDFFeatures::AddSdfCollision(
   {
     const auto radius = sphere->Radius();
     shape = std::make_unique<btSphereShape>(static_cast<btScalar>(radius));
+  }
+  else if (const auto *cone = geom->ConeShape())
+  {
+    const auto radius = static_cast<btScalar>(cone->Radius());
+    const auto height = static_cast<btScalar>(cone->Length());
+    shape =
+      std::make_unique<btConeShapeZ>(radius, height);
+    shape->setMargin(0.0);
   }
   else if (const auto *cylinder = geom->CylinderShape())
   {

--- a/bullet-featherstone/src/ShapeFeatures.cc
+++ b/bullet-featherstone/src/ShapeFeatures.cc
@@ -178,6 +178,86 @@ Identity ShapeFeatures::AttachCapsuleShape(
 }
 
 /////////////////////////////////////////////////
+Identity ShapeFeatures::CastToConeShape(const Identity &_shapeID) const
+{
+  const auto *shapeInfo = this->ReferenceInterface<CollisionInfo>(_shapeID);
+  if (shapeInfo != nullptr)
+  {
+    const auto &shape = shapeInfo->collider;
+    if (dynamic_cast<btConeShape*>(shape.get()))
+      return this->GenerateIdentity(_shapeID, this->Reference(_shapeID));
+  }
+
+  return this->GenerateInvalidId();
+}
+
+/////////////////////////////////////////////////
+double ShapeFeatures::GetConeShapeRadius(
+    const Identity &_coneID) const
+{
+  auto it = this->collisions.find(_coneID);
+  if (it != this->collisions.end() && it->second != nullptr)
+  {
+    if (it->second->collider != nullptr)
+    {
+      auto *cone = static_cast<btConeShape*>(
+        it->second->collider.get());
+      if (cone)
+      {
+        return cone->getRadius();
+      }
+    }
+  }
+
+  return -1;
+}
+
+/////////////////////////////////////////////////
+double ShapeFeatures::GetConeShapeHeight(
+    const Identity &_coneID) const
+{
+  auto it = this->collisions.find(_coneID);
+  if (it != this->collisions.end() && it->second != nullptr)
+  {
+    if (it->second->collider != nullptr)
+    {
+      auto *cone = static_cast<btConeShape*>(
+        it->second->collider.get());
+      if (cone)
+      {
+        return cone->getHeight();
+      }
+    }
+  }
+
+  return -1;
+}
+
+/////////////////////////////////////////////////
+Identity ShapeFeatures::AttachConeShape(
+    const Identity &_linkID,
+    const std::string &_name,
+    const double _radius,
+    const double _height,
+    const Pose3d &_pose)
+{
+  const auto radius = static_cast<btScalar>(_radius);
+  const auto height = static_cast<btScalar>(_height);
+  auto shape =
+    std::make_unique<btConeShapeZ>(radius, height);
+  shape->setMargin(0.0);
+
+  auto identity = this->AddCollision(
+    CollisionInfo{
+      _name,
+      std::move(shape),
+      _linkID,
+      _pose});
+
+  return identity;
+}
+
+/////////////////////////////////////////////////
 Identity ShapeFeatures::CastToCylinderShape(const Identity &_shapeID) const
 {
   const auto *shapeInfo = this->ReferenceInterface<CollisionInfo>(_shapeID);

--- a/bullet-featherstone/src/ShapeFeatures.hh
+++ b/bullet-featherstone/src/ShapeFeatures.hh
@@ -21,6 +21,7 @@
 #include <gz/physics/Shape.hh>
 #include <gz/physics/BoxShape.hh>
 #include <gz/physics/CapsuleShape.hh>
+#include <gz/physics/ConeShape.hh>
 #include <gz/physics/CylinderShape.hh>
 #include <gz/physics/EllipsoidShape.hh>
 #include <gz/physics/SphereShape.hh>
@@ -41,6 +42,9 @@ struct ShapeFeatureList : FeatureList<
 
   GetCapsuleShapeProperties,
   AttachCapsuleShapeFeature,
+
+  GetConeShapeProperties,
+  AttachConeShapeFeature,
 
   GetCylinderShapeProperties,
   AttachCylinderShapeFeature,
@@ -88,6 +92,23 @@ class ShapeFeatures :
       const std::string &_name,
       double _radius,
       double _length,
+      const Pose3d &_pose) override;
+
+  // ----- Cone Features -----
+  public: Identity CastToConeShape(
+      const Identity &_shapeID) const override;
+
+  public: double GetConeShapeRadius(
+      const Identity &_coneID) const override;
+
+  public: double GetConeShapeHeight(
+      const Identity &_coneID) const override;
+
+  public: Identity AttachConeShape(
+      const Identity &_linkID,
+      const std::string &_name,
+      double _radius,
+      double _height,
       const Pose3d &_pose) override;
 
   // ----- Cylinder Features -----

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -22,9 +22,10 @@
 #include <sdf/Geometry.hh>
 #include <sdf/Box.hh>
 #include <sdf/Capsule.hh>
+#include <sdf/Cone.hh>
+#include <sdf/Cylinder.hh>
 #include <sdf/Ellipsoid.hh>
 #include <sdf/Sphere.hh>
-#include <sdf/Cylinder.hh>
 #include <sdf/Plane.hh>
 #include <sdf/JointAxis.hh>
 
@@ -227,6 +228,14 @@ Identity SDFFeatures::ConstructSdfCollision(
     const auto sphere = geom->SphereShape();
     const auto radius = static_cast<btScalar>(sphere->Radius());
     shape = std::make_shared<btSphereShape>(radius);
+  }
+  else if (geom->ConeShape())
+  {
+    const auto cone = geom->ConeShape();
+    const auto radius = static_cast<btScalar>(cone->Radius());
+    const auto height = static_cast<btScalar>(cone->Length());
+    shape =
+      std::make_shared<btConeShapeZ>(radius, height);
   }
   else if (geom->CylinderShape())
   {

--- a/dartsim/src/CustomConeMeshShape.cc
+++ b/dartsim/src/CustomConeMeshShape.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "CustomConeMeshShape.hh"
+
+#include <memory>
+#include <string>
+
+#include <gz/common/Console.hh>
+#include <gz/common/MeshManager.hh>
+#include <gz/math/Cone.hh>
+
+namespace gz {
+namespace physics {
+namespace dartsim {
+
+/////////////////////////////////////////////////
+const gz::common::Mesh* MakeCustomConeMesh(
+    const gz::math::Coned &_cone,
+    int _meshRings,
+    int _meshSegments)
+{
+  common::MeshManager *meshMgr = common::MeshManager::Instance();
+  std::string coneMeshName = std::string("cone_mesh")
+    + "_" + std::to_string(_cone.Radius())
+    + "_" + std::to_string(_cone.Length());
+  meshMgr->CreateCone(
+    coneMeshName,
+    _cone.Radius(),
+    _cone.Length(),
+    _meshRings, _meshSegments);
+  return meshMgr->MeshByName(coneMeshName);
+}
+
+/////////////////////////////////////////////////
+CustomConeMeshShape::CustomConeMeshShape(
+    const gz::math::Coned &_cone,
+    int _meshRings,
+    int _meshSegments)
+  : CustomMeshShape(*MakeCustomConeMesh(_cone, _meshRings, _meshSegments),
+                    Eigen::Vector3d(1, 1, 1)),
+    cone(_cone)
+{
+}
+
+}
+}
+}

--- a/dartsim/src/CustomConeMeshShape.hh
+++ b/dartsim/src/CustomConeMeshShape.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_DARTSIM_SRC_CUSTOMCONEMESHSHAPE_HH_
+#define GZ_PHYSICS_DARTSIM_SRC_CUSTOMCONEMESHSHAPE_HH_
+
+#include <gz/math/Cone.hh>
+#include "CustomMeshShape.hh"
+
+namespace gz {
+namespace physics {
+namespace dartsim {
+
+/// \brief This class creates a custom derivative of the CustomMeshShape to
+/// allow casting to a Cone shape.
+class CustomConeMeshShape : public CustomMeshShape
+{
+  public: CustomConeMeshShape(
+      const gz::math::Coned &_cone,
+      int _meshRings = 1,
+      int _meshSegments = 36);
+
+  public: gz::math::Coned cone;
+};
+
+}
+}
+}
+
+#endif  // GZ_PHYSICS_DARTSIM_SRC_CUSTOMMESHSHAPE_HH_

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -20,12 +20,14 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <dart/constraint/ConstraintSolver.hpp>
 #include <dart/dynamics/BallJoint.hpp>
 #include <dart/dynamics/BoxShape.hpp>
 #include <dart/dynamics/CapsuleShape.hpp>
+#include <dart/dynamics/ConeShape.hpp>
 #include <dart/dynamics/CylinderShape.hpp>
 #include <dart/dynamics/EllipsoidShape.hpp>
 #include <dart/dynamics/FreeJoint.hpp>
@@ -49,6 +51,7 @@
 #include <sdf/Box.hh>
 #include <sdf/Collision.hh>
 #include <sdf/Capsule.hh>
+#include <sdf/Cone.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Ellipsoid.hh>
 #include <sdf/Geometry.hh>
@@ -65,6 +68,7 @@
 #include <sdf/World.hh>
 
 #include "AddedMassFeatures.hh"
+#include "CustomConeMeshShape.hh"
 #include "CustomMeshShape.hh"
 
 namespace gz {
@@ -340,11 +344,27 @@ static ShapeAndTransform ConstructGeometry(
   {
     return ConstructCapsule(*_geometry.CapsuleShape());
   }
+  else if (_geometry.ConeShape())
+  {
+    // TODO(anyone): Replace this code when Cone is supported by DART
+    gzwarn << "DART: Cone is not a supported collision geomerty"
+           << " primitive, using generated mesh of a cone instead"
+           << std::endl;
+    auto mesh =
+      std::make_shared<CustomConeMeshShape>(_geometry.ConeShape()->Shape());
+    auto mesh2 = std::dynamic_pointer_cast<dart::dynamics::MeshShape>(mesh);
+    return {mesh2};
+  }
   else if (_geometry.CylinderShape())
+  {
     return ConstructCylinder(*_geometry.CylinderShape());
+  }
   else if (_geometry.EllipsoidShape())
   {
     // TODO(anyone): Replace this code when Ellipsoid is supported by DART
+    gzwarn << "DART: Ellipsoid is not a supported collision geomerty"
+           << " primitive, using generated mesh of an ellipsoid instead"
+           << std::endl;
     common::MeshManager *meshMgr = common::MeshManager::Instance();
     std::string ellipsoidMeshName = std::string("ellipsoid_mesh")
       + "_" + std::to_string(_geometry.EllipsoidShape()->Radii().X())

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -972,10 +972,11 @@ TEST_P(SDFFeatures_TEST, Shapes)
   auto dartWorld = world->GetDartsimWorld();
   ASSERT_NE(nullptr, dartWorld);
 
-  ASSERT_EQ(5u, dartWorld->getNumSkeletons());
+  ASSERT_EQ(6u, dartWorld->getNumSkeletons());
 
   int count{0};
-  for (auto name : {"sphere", "box", "cylinder", "capsule", "ellipsoid"})
+  for (auto name : {"sphere", "box", "cylinder", "capsule", "ellipsoid",
+                    "cone"})
   {
     const auto skeleton = dartWorld->getSkeleton(count++);
     ASSERT_NE(nullptr, skeleton);

--- a/dartsim/src/ShapeFeatures.hh
+++ b/dartsim/src/ShapeFeatures.hh
@@ -23,6 +23,7 @@
 #include <gz/physics/Shape.hh>
 #include <gz/physics/BoxShape.hh>
 #include <gz/physics/CapsuleShape.hh>
+#include <gz/physics/ConeShape.hh>
 #include <gz/physics/CylinderShape.hh>
 #include <gz/physics/EllipsoidShape.hh>
 #include <gz/physics/heightmap/HeightmapShape.hh>
@@ -54,6 +55,10 @@ struct ShapeFeatureList : FeatureList<
   GetCapsuleShapeProperties,
   //  SetCapsulerShapeProperties,
   AttachCapsuleShapeFeature,
+
+  GetConeShapeProperties,
+//  SetConeShapeProperties,
+  AttachConeShapeFeature,
 
   GetCylinderShapeProperties,
 //  SetCylinderShapeProperties,
@@ -119,6 +124,23 @@ class ShapeFeatures :
       const std::string &_name,
       double _radius,
       double _length,
+      const Pose3d &_pose) override;
+
+  // ----- Cone Features -----
+  public: Identity CastToConeShape(
+      const Identity &_shapeID) const override;
+
+  public: double GetConeShapeRadius(
+      const Identity &_coneID) const override;
+
+  public: double GetConeShapeHeight(
+      const Identity &_coneID) const override;
+
+  public: Identity AttachConeShape(
+      const Identity &_linkID,
+      const std::string &_name,
+      double _radius,
+      double _height,
       const Pose3d &_pose) override;
 
   // ----- Cylinder Features -----

--- a/include/gz/physics/ConeShape.hh
+++ b/include/gz/physics/ConeShape.hh
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 CogniPilot Foundation
+ * Copyright 2024 Open Source Robotics Foundation
+ * Copyright 2024 Rudis Laboratories
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_CONESHAPE_HH_
+#define GZ_PHYSICS_CONESHAPE_HH_
+
+#include <string>
+
+#include <gz/physics/DeclareShapeType.hh>
+#include <gz/physics/Geometry.hh>
+
+namespace gz
+{
+  namespace physics
+  {
+    GZ_PHYSICS_DECLARE_SHAPE_TYPE(ConeShape)
+
+    class GZ_PHYSICS_VISIBLE GetConeShapeProperties
+        : public virtual FeatureWithRequirements<ConeShapeCast>
+    {
+      public: template <typename PolicyT, typename FeaturesT>
+      class ConeShape : public virtual Entity<PolicyT, FeaturesT>
+      {
+        public: using Scalar = typename PolicyT::Scalar;
+
+        /// \brief Get the radius of this ConeShape
+        /// \return the radius of this ConeShape
+        public: Scalar GetRadius() const;
+
+        /// \brief Get the height (length along the local z-axis) of this
+        /// ConeShape.
+        /// \return the height of this ConeShape
+        public: Scalar GetHeight() const;
+      };
+
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        public: using Scalar = typename PolicyT::Scalar;
+
+        public: virtual Scalar GetConeShapeRadius(
+            const Identity &_coneID) const = 0;
+
+        public: virtual Scalar GetConeShapeHeight(
+            const Identity &_coneID) const = 0;
+      };
+    };
+
+    /////////////////////////////////////////////////
+    /// \brief This feature sets the ConeShape properties such as
+    /// the cone radius and height.
+    class GZ_PHYSICS_VISIBLE SetConeShapeProperties
+        : public virtual FeatureWithRequirements<ConeShapeCast>
+    {
+      public: template <typename PolicyT, typename FeaturesT>
+      class ConeShape : public virtual Entity<PolicyT, FeaturesT>
+      {
+        public: using Scalar = typename PolicyT::Scalar;
+
+        /// \brief Set the radius of this ConeShape
+        /// \param[in] _radius
+        ///   The desired radius of this ConeShape
+        public: void SetRadius(Scalar _radius);
+
+        /// \brief Set the height of this ConeShape
+        /// \param[in] _height
+        ///   The desired height of this ConeShape
+        public: void SetHeight(Scalar _height);
+      };
+
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        public: using Scalar = typename PolicyT::Scalar;
+
+        public: virtual void SetConeShapeRadius(
+            const Identity &_coneID, Scalar _radius) = 0;
+
+        public: virtual void SetConeShapeHeight(
+            const Identity &_coneID, Scalar _height) = 0;
+      };
+    };
+
+    /////////////////////////////////////////////////
+    /// \brief This feature constructs a new cone shape and attaches the
+    /// desired pose in the link frame. The pose could be defined to be the
+    /// cone center point in actual implementation.
+    class GZ_PHYSICS_VISIBLE AttachConeShapeFeature
+        : public virtual FeatureWithRequirements<ConeShapeCast>
+    {
+      public: template <typename PolicyT, typename FeaturesT>
+      class Link : public virtual Feature::Link<PolicyT, FeaturesT>
+      {
+        public: using Scalar = typename PolicyT::Scalar;
+
+        public: using PoseType =
+            typename FromPolicy<PolicyT>::template Use<Pose>;
+
+        public: using ShapePtrType = ConeShapePtr<PolicyT, FeaturesT>;
+
+        /// \brief Rigidly attach a ConeShape to this link.
+        /// \param[in] _name
+        /// \param[in] _radius
+        ///   The radius of the cone.
+        /// \param[in] _height
+        ///   The height of the cone.
+        /// \param[in] _pose
+        ///   The desired pose of the ConeShape relative to the Link frame.
+        /// \returns a ShapePtrType to the newly constructed ConeShape
+        public: ShapePtrType AttachConeShape(
+            const std::string &_name = "cone",
+            Scalar _radius = 1.0,
+            Scalar _height = 1.0,
+            const PoseType &_pose = PoseType::Identity());
+      };
+
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        public: using Scalar = typename PolicyT::Scalar;
+
+        public: using PoseType =
+            typename FromPolicy<PolicyT>::template Use<Pose>;
+
+        public: virtual Identity AttachConeShape(
+            const Identity &_linkID,
+            const std::string &_name,
+            Scalar _radius,
+            Scalar _height,
+            const PoseType &_pose) = 0;
+      };
+    };
+  }
+}
+
+#include <gz/physics/detail/ConeShape.hh>
+
+#endif

--- a/include/gz/physics/detail/ConeShape.hh
+++ b/include/gz/physics/detail/ConeShape.hh
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 CogniPilot Foundation
+ * Copyright 2024 Open Source Robotics Foundation
+ * Copyright 2024 Rudis Laboratories
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_DETAIL_CONESHAPE_HH_
+#define GZ_PHYSICS_DETAIL_CONESHAPE_HH_
+
+#include <string>
+
+#include <gz/physics/ConeShape.hh>
+
+namespace gz
+{
+  namespace physics
+  {
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    auto GetConeShapeProperties::ConeShape<PolicyT, FeaturesT>
+    ::GetRadius() const -> Scalar
+    {
+      return this->template Interface<GetConeShapeProperties>()
+          ->GetConeShapeRadius(this->identity);
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    auto GetConeShapeProperties::ConeShape<PolicyT, FeaturesT>
+    ::GetHeight() const -> Scalar
+    {
+      return this->template Interface<GetConeShapeProperties>()
+          ->GetConeShapeHeight(this->identity);
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    void SetConeShapeProperties::ConeShape<PolicyT, FeaturesT>
+    ::SetRadius(Scalar _radius)
+    {
+      this->template Interface<SetConeShapeProperties>()
+          ->SetConeShapeRadius(this->identity, _radius);
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    void SetConeShapeProperties::ConeShape<PolicyT, FeaturesT>
+    ::SetHeight(Scalar _height)
+    {
+      this->template Interface<SetConeShapeProperties>()
+          ->SetConeShapeHeight(this->identity, _height);
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    auto AttachConeShapeFeature::Link<PolicyT, FeaturesT>
+    ::AttachConeShape(
+        const std::string &_name,
+        Scalar _radius,
+        Scalar _height,
+        const PoseType &_pose) -> ShapePtrType
+    {
+      return ShapePtrType(this->pimpl,
+            this->template Interface<AttachConeShapeFeature>()
+                ->AttachConeShape(
+                            this->identity, _name, _radius, _height, _pose));
+    }
+  }
+}
+
+#endif

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -1292,17 +1292,16 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachDetachFixedToWorld)
       EXPECT_GT(0.0, body2LinearVelocity.Z());
       // bullet-featherstone and dartsim has different behavior
       // when detaching a joint between overlapping bodies
-      // dartsim: body falls after joint is detached
       // bullet-featherstone: pushes bodies apart
       // So here we just check for non-zero velocity
-#ifdef __APPLE__
-      // Disable check for dartsim plugin on homebrew.
-      // model3 has zero velocity in dartsim on macOS. It could be a
-      // change in behavior between dartsim versions. model3 overlaps
-      // with model1 so could be stuck together
+      // \todo(iche033) Investigate behavior differences in dartsim.
+      // Locally, model3 falls after joint is detached.
+      // On CI, model3 has zero velocity which could mean model3 and model1 are
+      // stuck together since they overlap with each other
       if (this->PhysicsEngineName(name) != "dartsim")
-#endif
-      EXPECT_NE(gz::math::Vector3d::Zero, body3LinearVelocity);
+      {
+        EXPECT_NE(gz::math::Vector3d::Zero, body3LinearVelocity);
+      }
     }
 
     // Test attaching fixed joint with reverse the parent and child

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -44,6 +44,7 @@
 #include <gz/physics/FreeGroup.hh>
 #include <gz/physics/GetBoundingBox.hh>
 #include <gz/physics/GetContacts.hh>
+#include <gz/physics/GetRayIntersection.hh>
 #include "gz/physics/SphereShape.hh"
 
 #include <gz/physics/ConstructEmpty.hh>

--- a/test/common_test/worlds/shapes.world
+++ b/test/common_test/worlds/shapes.world
@@ -165,5 +165,39 @@
         </visual>
       </link>
     </model>
+
+    <model name="cone">
+      <pose>0 -6.5 0.5 0 0 0</pose>
+      <link name="cone_link">
+        <inertial>
+          <inertia>
+            <ixx>2</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2</iyy>
+            <iyz>0</iyz>
+            <izz>2</izz>
+          </inertia>
+          <mass>2.0</mass>
+          <pose>0 0 -0.275 0 0 0</pose>
+        </inertial>
+        <collision name="cone_collision">
+          <geometry>
+            <cone>
+              <radius>0.5</radius>
+              <length>1.1</length>
+            </cone>
+          </geometry>
+        </collision>
+        <visual name="cone_visual">
+          <geometry>
+            <cone>
+              <radius>0.5</radius>
+              <length>1.1</length>
+            </cone>
+          </geometry>
+        </visual>
+      </link>
+    </model>
   </world>
 </sdf>

--- a/tpe/lib/src/Collision.cc
+++ b/tpe/lib/src/Collision.cc
@@ -81,6 +81,12 @@ void Collision::SetShape(const Shape &_shape)
       static_cast<const CapsuleShape *>(&_shape);
     this->dataPtr->shape.reset(new CapsuleShape(*typedShape));
   }
+  else if (_shape.GetType() == ShapeType::CONE)
+  {
+    const ConeShape *typedShape =
+      static_cast<const ConeShape *>(&_shape);
+    this->dataPtr->shape.reset(new ConeShape(*typedShape));
+  }
   else if (_shape.GetType() == ShapeType::CYLINDER)
   {
     const CylinderShape *typedShape =

--- a/tpe/lib/src/Shape.cc
+++ b/tpe/lib/src/Shape.cc
@@ -116,6 +116,45 @@ void CapsuleShape::UpdateBoundingBox()
 }
 
 //////////////////////////////////////////////////
+ConeShape::ConeShape() : Shape()
+{
+  this->type = ShapeType::CONE;
+}
+
+//////////////////////////////////////////////////
+double ConeShape::GetRadius() const
+{
+  return this->radius;
+}
+
+//////////////////////////////////////////////////
+void ConeShape::SetRadius(double _radius)
+{
+  this->radius = _radius;
+  this->dirty = true;
+}
+
+//////////////////////////////////////////////////
+double ConeShape::GetLength() const
+{
+  return this->length;
+}
+
+//////////////////////////////////////////////////
+void ConeShape::SetLength(double _length)
+{
+  this->length = _length;
+  this->dirty = true;
+}
+
+//////////////////////////////////////////////////
+void ConeShape::UpdateBoundingBox()
+{
+  math::Vector3d halfSize(this->radius, this->radius, this->length*0.5);
+  this->bbox = math::AxisAlignedBox(-halfSize, halfSize);
+}
+
+//////////////////////////////////////////////////
 CylinderShape::CylinderShape() : Shape()
 {
   this->type = ShapeType::CYLINDER;

--- a/tpe/lib/src/Shape.hh
+++ b/tpe/lib/src/Shape.hh
@@ -59,6 +59,9 @@ enum class GZ_PHYSICS_TPELIB_VISIBLE ShapeType
 
   /// \brief A ellipsoid shape.
   ELLIPSOID = 7,
+
+  /// \brief A cone shape.
+  CONE = 10,
 };
 
 
@@ -152,6 +155,42 @@ class GZ_PHYSICS_TPELIB_VISIBLE CapsuleShape : public Shape
   /// \brief Capsule length
   private: double length = 0.0;
 };
+
+/// \brief Cone geometry
+class GZ_PHYSICS_TPELIB_VISIBLE ConeShape : public Shape
+{
+  /// \brief Constructor
+  public: ConeShape();
+
+  /// \brief Destructor
+  public: virtual ~ConeShape() = default;
+
+  /// \brief Get cone radius
+  /// \return cone radius
+  public: double GetRadius() const;
+
+  /// \brief Set cone radius
+  /// \param[in] _radius Cone radius
+  public: void SetRadius(double _radius);
+
+  /// \brief Get cone length
+  /// \return Cone length
+  public: double GetLength() const;
+
+  /// \brief Set cone length
+  /// \param[in] _length Cone length
+  public: void SetLength(double _length);
+
+  // Documentation inherited
+  protected: virtual void UpdateBoundingBox() override;
+
+  /// \brief Cone radius
+  private: double radius = 0.0;
+
+  /// \brief Cone length
+  private: double length = 0.0;
+};
+
 
 /// \brief Cylinder geometry
 class GZ_PHYSICS_TPELIB_VISIBLE CylinderShape : public Shape

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -19,6 +19,7 @@
 
 #include <sdf/Box.hh>
 #include <sdf/Capsule.hh>
+#include <sdf/Cone.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Ellipsoid.hh>
 #include <sdf/Sphere.hh>
@@ -290,6 +291,14 @@ Identity SDFFeatures::ConstructSdfCollision(
     tpelib::CapsuleShape shape;
     shape.SetRadius(capsuleSdf->Radius());
     shape.SetLength(capsuleSdf->Length());
+    collision->SetShape(shape);
+  }
+  else if (geom->Type() == ::sdf::GeometryType::CONE)
+  {
+    const auto coneSdf = geom->ConeShape();
+    tpelib::ConeShape shape;
+    shape.SetRadius(coneSdf->Radius());
+    shape.SetLength(coneSdf->Length());
     collision->SetShape(shape);
   }
   else if (geom->Type() == ::sdf::GeometryType::CYLINDER)

--- a/tpe/plugin/src/ShapeFeatures.cc
+++ b/tpe/plugin/src/ShapeFeatures.cc
@@ -83,19 +83,6 @@ Identity ShapeFeatures::AttachBoxShape(
 }
 
 /////////////////////////////////////////////////
-Identity ShapeFeatures::CastToCylinderShape(const Identity &_shapeID) const
-{
-  auto it = this->collisions.find(_shapeID);
-  if (it != this->collisions.end() && it->second != nullptr)
-  {
-    auto *shape = it->second->collision->GetShape();
-    if (shape != nullptr && dynamic_cast<tpelib::CylinderShape*>(shape))
-      return this->GenerateIdentity(_shapeID, it->second);
-  }
-  return this->GenerateInvalidId();
-}
-
-/////////////////////////////////////////////////
 Identity ShapeFeatures::CastToCapsuleShape(const Identity &_shapeID) const
 {
   auto it = this->collisions.find(_shapeID);
@@ -168,6 +155,96 @@ Identity ShapeFeatures::AttachCapsuleShape(
     collision.SetShape(capsuleshape);
 
     return this->AddCollision(_linkID, collision);
+  }
+  return this->GenerateInvalidId();
+}
+
+/////////////////////////////////////////////////
+Identity ShapeFeatures::CastToConeShape(const Identity &_shapeID) const
+{
+  auto it = this->collisions.find(_shapeID);
+  if (it != this->collisions.end() && it->second != nullptr)
+  {
+    auto *shape = it->second->collision->GetShape();
+    if (shape != nullptr && dynamic_cast<tpelib::ConeShape*>(shape))
+      return this->GenerateIdentity(_shapeID, it->second);
+  }
+  return this->GenerateInvalidId();
+}
+
+/////////////////////////////////////////////////
+double ShapeFeatures::GetConeShapeRadius(
+  const Identity &_coneID) const
+{
+  // assume _coneID ~= _collisionID
+  auto it = this->collisions.find(_coneID);
+  if (it != this->collisions.end() && it->second != nullptr)
+  {
+    auto *shape = it->second->collision->GetShape();
+    if (shape != nullptr)
+    {
+      auto *cone = static_cast<tpelib::ConeShape*>(shape);
+      return cone->GetRadius();
+    }
+  }
+  // return invalid radius if no collision found
+  return -1.0;
+}
+
+/////////////////////////////////////////////////
+double ShapeFeatures::GetConeShapeHeight(
+  const Identity &_coneID) const
+{
+  // assume _coneID ~= _collisionID
+  auto it = this->collisions.find(_coneID);
+  if (it != this->collisions.end() && it->second != nullptr)
+  {
+    auto *shape = it->second->collision->GetShape();
+    if (shape != nullptr)
+    {
+      auto *cone = static_cast<tpelib::ConeShape*>(shape);
+      return cone->GetLength();
+    }
+  }
+  // return invalid height if no collision found
+  return -1.0;
+}
+
+/////////////////////////////////////////////////
+Identity ShapeFeatures::AttachConeShape(
+  const Identity &_linkID,
+  const std::string &_name,
+  const double _radius,
+  const double _height,
+  const Pose3d &_pose)
+{
+  auto it = this->links.find(_linkID);
+  if (it != this->links.end() && it->second != nullptr)
+  {
+    auto &collision = static_cast<tpelib::Collision&>(
+      it->second->link->AddCollision());
+    collision.SetName(_name);
+    collision.SetPose(math::eigen3::convert(_pose));
+
+    tpelib::ConeShape coneshape;
+    coneshape.SetRadius(_radius);
+    coneshape.SetLength(_height);
+    collision.SetShape(coneshape);
+
+    return this->AddCollision(_linkID, collision);
+  }
+  return this->GenerateInvalidId();
+}
+
+/////////////////////////////////////////////////
+Identity ShapeFeatures::CastToCylinderShape(const Identity &_shapeID) const
+{
+  auto it = this->collisions.find(_shapeID);
+  if (it != this->collisions.end() && it->second != nullptr)
+  {
+    auto *shape = it->second->collision->GetShape();
+    if (shape != nullptr && dynamic_cast<tpelib::CylinderShape*>(shape))
+      return this->GenerateIdentity(_shapeID, it->second);
   }
   return this->GenerateInvalidId();
 }

--- a/tpe/plugin/src/ShapeFeatures.hh
+++ b/tpe/plugin/src/ShapeFeatures.hh
@@ -23,6 +23,7 @@
 #include <gz/physics/Shape.hh>
 #include <gz/physics/BoxShape.hh>
 #include <gz/physics/CapsuleShape.hh>
+#include <gz/physics/ConeShape.hh>
 #include <gz/physics/CylinderShape.hh>
 #include <gz/physics/EllipsoidShape.hh>
 #include <gz/physics/mesh/MeshShape.hh>
@@ -41,6 +42,9 @@ struct ShapeFeatureList : FeatureList<
 
   GetCapsuleShapeProperties,
   AttachCapsuleShapeFeature,
+
+  GetConeShapeProperties,
+  AttachConeShapeFeature,
 
   GetCylinderShapeProperties,
   AttachCylinderShapeFeature,
@@ -89,6 +93,23 @@ class ShapeFeatures :
     double _length,
     const Pose3d &_pose) override;
 
+  // ----- Cone Features -----
+  public: Identity CastToConeShape(
+    const Identity &_shapeID) const override;
+
+  public: double GetConeShapeRadius(
+    const Identity &_coneID) const override;
+
+  public: double GetConeShapeHeight(
+    const Identity &_coneID) const override;
+
+  public: Identity AttachConeShape(
+    const Identity &_linkID,
+    const std::string &_name,
+    double _radius,
+    double _height,
+    const Pose3d &_pose) override;
+
   // ----- Cylinder Features -----
   public: Identity CastToCylinderShape(
     const Identity &_shapeID) const override;
@@ -106,7 +127,7 @@ class ShapeFeatures :
     double _height,
     const Pose3d &_pose) override;
 
-  // ----- Capsule Features -----
+  // ----- Ellipsoid Features -----
   public: Identity CastToEllipsoidShape(
     const Identity &_shapeID) const override;
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This helps add the missing cone geometry for primitive/basic parametric shapes:

![conetopple](https://github.com/gazebosim/gz-math/assets/10233412/5fd8f1a1-3a77-4e61-95d5-f053389cd908)
![cone](https://github.com/gazebosim/gz-math/assets/10233412/1c516775-7adb-4318-9c6a-0c09a746a3b0)

And is also valuable for visualizations of emitters/source that typically have conic-based spread as seen in this acoustic attack on an IMU by showing the affected area:

![drone_attack](https://github.com/gazebosim/gz-rendering/assets/10233412/7a6b0dfa-8ad6-42c1-83bc-8385ccc4c81a)

Associated PRs:

- https://github.com/gazebosim/gz-gui/pull/620
- https://github.com/gazebosim/gz-math/pull/593
- https://github.com/gazebosim/gz-msgs/pull/441
- https://github.com/gazebosim/gz-physics/pull/638
- https://github.com/gazebosim/gz-rendering/pull/1001
- https://github.com/gazebosim/gz-sim/pull/2404
- https://github.com/gazebosim/sdformat/pull/1415

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
