### PR TITLE
Disable collisions between attached bodies

### DIFF
--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -112,6 +112,13 @@ struct ModelInfo
   }
 };
 
+class GzMultiBodyLinkCollider: public btMultiBodyLinkCollider {
+  using btMultiBodyLinkCollider::btMultiBodyLinkCollider;
+
+	bool checkCollideWithOverride(const btCollisionObject* co) const override {
+    return btMultiBodyLinkCollider::checkCollideWithOverride(co) && btCollisionObject::checkCollideWithOverride(co);
+  }
+};
 /// Link information is embedded inside the model, so all we need to store here
 /// is a reference to the model and the index of this link inside of it.
 struct LinkInfo
@@ -120,7 +127,7 @@ struct LinkInfo
   std::optional<int> indexInModel;
   Identity model;
   Eigen::Isometry3d inertiaToLinkFrame;
-  std::unique_ptr<btMultiBodyLinkCollider> collider = nullptr;
+  std::unique_ptr<GzMultiBodyLinkCollider> collider = nullptr;
   std::unique_ptr<btCompoundShape> shape = nullptr;
   std::vector<std::size_t> collisionEntityIds = {};
   std::unordered_map<std::string, std::size_t> collisionNameToEntityId = {};

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -1263,7 +1263,7 @@ bool SDFFeatures::AddSdfCollision(
 
       // NOTE: Bullet does not appear to support different surface properties
       // for different shapes attached to the same link.
-      linkInfo->collider = std::make_unique<btMultiBodyLinkCollider>(
+      linkInfo->collider = std::make_unique<GzMultiBodyLinkCollider>(
         model->body.get(), linkIndexInModel);
 
       linkInfo->shape->addChildShape(btInertialToCollision, shape.get());


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Even with #632 , it looks like objects that are attached to each other continue to generate contacts. Even though we've explicitly marked the two objects not to collide, looking at the bullet code (https://github.com/bulletphysics/bullet3/blob/e9c461b0ace140d5c73972760781d94b7b5eee53/src/BulletDynamics/Featherstone/btMultiBodyLinkCollider.h#L79-L80), that is ignored because `checkCollideWithOverride` will always return true if the two objects are not in the same btMultiBody.

@iche033 I haven't checked this thoroughly, but the solution I came up with is to call the base class's `checkCollideWithOverride` as well as `btMultiBodyLinkCollider::checkCollideWithOverride` and return the result of anding the two. This does behave much better. I tried with the SDF below by uncommenting only one of the `<plugin>` tags. Without this PR, the objects fly up or down together even though gravity is 0. Visualizing contacts in gz-sim also shows that they are in contact. With the PR, the boxes stay in place and generate no contacts.

<details><summary>SDF File</summary>

```xml
<?xml version="1.0"?>
<sdf version="1.11">
  <world name="default">

    <gravity>0 0 0</gravity>

    <model name="ground_plane">
      <static>true</static>
      <link name="link">
        <collision name="collision">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
            </plane>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
              <size>100 100</size>
            </plane>
          </geometry>
          <material>
            <ambient>0.8 0.8 0.8 1</ambient>
            <diffuse>0.8 0.8 0.8 1</diffuse>
            <specular>0.8 0.8 0.8 1</specular>
          </material>
        </visual>
      </link>
    </model>
    <model name="M1">
      <pose>0 2 3.0 0 0.0 0.0</pose>
      <link name="body">
        <inertial auto="true"/>
        <collision name="box_collision">
          <geometry>
            <box>
              <size>1 1 0.5</size>
            </box>
          </geometry>
        </collision>

        <visual name="box_visual">
          <geometry>
            <box>
              <size>1 1 0.5</size>
            </box>
          </geometry>
          <material>
            <ambient>1 0 0 1</ambient>
            <diffuse>1 0 0 1</diffuse>
            <specular>1 0 0 1</specular>
          </material>
        </visual>
      </link>
      <plugin filename="gz-sim-detachable-joint-system"
              name="gz::sim::systems::DetachableJoint">
       <parent_link>body</parent_link>
       <child_model>M2</child_model>
       <child_link>body2</child_link>
      </plugin>
    </model>

    <model name="M2">
      <pose>0.3 2 3.0 0 0.0 0</pose>
      <link name="body2">
        <inertial auto="true"/>
        <collision name="box_collision">
          <geometry>
            <box>
              <size>1 1 0.5</size>
            </box>
          </geometry>
        </collision>

        <visual name="box_visual">
          <geometry>
            <box>
              <size>1 1 0.5</size>
            </box>
          </geometry>
          <material>
            <ambient>0 1 0 1</ambient>
            <diffuse>0 1 0 1</diffuse>
            <specular>1 0 0 1</specular>
          </material>
        </visual>
      </link>
      <!-- <plugin filename="gz-sim-detachable-joint-system" -->
      <!--         name="gz::sim::systems::DetachableJoint"> -->
      <!--  <parent_link>body2</parent_link> -->
      <!--  <child_model>M1</child_model> -->
      <!--  <child_link>body</child_link> -->
      <!-- </plugin> -->
    </model>
  </world>
</sdf>

```


</details> 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
