### PR TITLE
Disable test failing due to ODE/libccd (backport #621)

### DIFF
--- a/dartsim/src/JointFeatures_TEST.cc
+++ b/dartsim/src/JointFeatures_TEST.cc
@@ -734,9 +734,17 @@ TEST_F(JointFeaturesFixture, JointDetach)
   // sanity check on velocity values
   EXPECT_LT(1e-5, upperLinkLinearVelocity.Z());
   EXPECT_GT(-0.03, upperLinkAngularVelocity.X());
+#ifndef __APPLE__
+  // Disable some expectations for dartsim plugin on homebrew,
+  // see https://github.com/gazebosim/gz-physics/issues/620.
   EXPECT_NEAR(0.0, upperLinkLinearVelocity.X(), 1e-6);
+#endif
   EXPECT_NEAR(0.0, upperLinkLinearVelocity.Y(), 1e-6);
+#ifndef __APPLE__
+  // Disable some expectations for dartsim plugin on homebrew,
+  // see https://github.com/gazebosim/gz-physics/issues/620.
   EXPECT_NEAR(0.0, upperLinkAngularVelocity.Y(), 1e-6);
+#endif
   EXPECT_NEAR(0.0, upperLinkAngularVelocity.Z(), 1e-6);
 
   upperJoint->Detach();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes CI on physics2 + Homebew, 
Reference: https://build.osrfoundation.org/job/gz_physics-ci-ign-physics2-homebrew-amd64/43/testReport/

Backports: https://github.com/gazebosim/gz-physics/commit/13bf7f50ce0c66d942884b502294014360190e82
It is not a direct backport, because the file was different, and I changed the logic because the tested code is directly in a dartsim folder.

## Summary
Disable test failing on homebrew and tag issue tracking it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.