### PR TITLE
Add missing algorithm include

### DIFF
--- a/include/gz/physics/detail/InspectFeatures.hh
+++ b/include/gz/physics/detail/InspectFeatures.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_DETAIL_INSPECTFEATURES_HH
 #define GZ_PHYSICS_DETAIL_INSPECTFEATURES_HH
 
+#include <algorithm>
 #include <set>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #644 

## Summary
Adds a missing include (algorithm). Needed due to use of std::find.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers