### PR TITLE
bullet-featherstone: Fix bounding box for collisions with pose offset

### DIFF
--- a/bullet-featherstone/src/KinematicsFeatures.hh
+++ b/bullet-featherstone/src/KinematicsFeatures.hh
@@ -30,7 +30,8 @@ namespace bullet_featherstone {
 struct KinematicsFeatureList : gz::physics::FeatureList<
   LinkFrameSemantics,
   ModelFrameSemantics,
-  FreeGroupFrameSemantics
+  FreeGroupFrameSemantics,
+  ShapeFrameSemantics
 > { };
 
 class KinematicsFeatures :

--- a/bullet-featherstone/src/ShapeFeatures.cc
+++ b/bullet-featherstone/src/ShapeFeatures.cc
@@ -37,8 +37,6 @@ AlignedBox3d ShapeFeatures::GetShapeAxisAlignedBoundingBox(
     t.setIdentity();
     btVector3 minBox(0, 0, 0);
     btVector3 maxBox(0, 0, 0);
-    btVector3 minBox2(0, 0, 0);
-    btVector3 maxBox2(0, 0, 0);
     collider->collider->getAabb(t, minBox, maxBox);
     return math::eigen3::convert(math::AxisAlignedBox(
       math::Vector3d(minBox[0], minBox[1], minBox[2]),

--- a/test/common_test/Worlds.hh
+++ b/test/common_test/Worlds.hh
@@ -47,6 +47,7 @@ const auto kMimicUniversalWorld = CommonTestWorld("mimic_universal_world.sdf");
 const auto kMultipleCollisionsSdf = CommonTestWorld("multiple_collisions.sdf");
 const auto kPendulumJointWrenchSdf =
   CommonTestWorld("pendulum_joint_wrench.sdf");
+const auto kPoseOffsetSdf = CommonTestWorld("pose_offset.sdf");
 const auto kShapesWorld = CommonTestWorld("shapes.world");
 const auto kShapesBitmaskWorld = CommonTestWorld("shapes_bitmask.sdf");
 const auto kSlipComplianceSdf = CommonTestWorld("slip_compliance.sdf");

--- a/test/common_test/link_features.cc
+++ b/test/common_test/link_features.cc
@@ -293,14 +293,26 @@ TYPED_TEST(LinkFeaturesTest, JointSetCommand)
   }
 }
 
-TYPED_TEST(LinkFeaturesTest, AxisAlignedBoundingBox)
+using LinkBoundingBoxFeaturesList = gz::physics::FeatureList<
+    gz::physics::ForwardStep,
+    gz::physics::sdf::ConstructSdfWorld,
+    gz::physics::GetEntities,
+    gz::physics::GetLinkBoundingBox,
+    gz::physics::GetModelBoundingBox
+>;
+
+using LinkBoundingBoxFeaturesTestTypes =
+  LinkFeaturesTest<LinkBoundingBoxFeaturesList>;
+
+TEST_F(LinkBoundingBoxFeaturesTestTypes, AxisAlignedBoundingBox)
 {
   for (const std::string &name : this->pluginNames)
   {
     std::cout << "Testing plugin: " << name << std::endl;
     gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
 
-    auto engine = gz::physics::RequestEngine3d<LinkFeaturesList>::From(plugin);
+    auto engine =
+        gz::physics::RequestEngine3d<LinkBoundingBoxFeaturesList>::From(plugin);
     ASSERT_NE(nullptr, engine);
 
     sdf::Root root;
@@ -312,9 +324,6 @@ TYPED_TEST(LinkFeaturesTest, AxisAlignedBoundingBox)
 
     auto world = engine->ConstructWorld(*root.WorldByIndex(0));
     EXPECT_NE(nullptr, world);
-
-    EXPECT_NE(nullptr, world);
-    world->SetGravity(Eigen::Vector3d{0, 0, -9.8});
 
     auto model = world->GetModel("double_pendulum_with_base");
     auto baseLink = model->GetLink("base");
@@ -363,9 +372,6 @@ TYPED_TEST(LinkFeaturesTest, ModelAxisAlignedBoundingBox)
 
     auto world = engine->ConstructWorld(*root.WorldByIndex(0));
     EXPECT_NE(nullptr, world);
-
-    EXPECT_NE(nullptr, world);
-    world->SetGravity(Eigen::Vector3d{0, 0, -9.8});
 
     auto model = world->GetModel("sphere");
     auto bbox = model->GetAxisAlignedBoundingBox();

--- a/test/common_test/worlds/pose_offset.sdf
+++ b/test/common_test/worlds/pose_offset.sdf
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="pose_offset">
+    <model name="model">
+      <pose>1 0 0 0 0 0</pose>
+      <link name="base">
+        <pose>0 1 0 0 0 0</pose>
+        <inertial>
+          <mass>100</mass>
+        </inertial>
+        <collision name="base_collision">
+          <pose>0 0 0.01 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+      <link name="link">
+        <pose>0 0 2.1 -1.5708 0 0</pose>
+        <self_collide>0</self_collide>
+        <inertial>
+          <pose>0 0 0.5 0 0 0</pose>
+        </inertial>
+        <collision name="link_collision">
+          <pose>-0.05 0 0 0 1.5708 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="joint" type="fixed">
+        <parent>base</parent>
+        <child>link</child>
+        <axis>
+          <xyz>1.0 0 0</xyz>
+        </axis>
+      </joint>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

hide whitespace changes for better diff:
https://github.com/gazebosim/gz-physics/pull/647/files?w=1

## Summary

Currently if a collision has a pose offset, the bullet-featherstone plugin return an incorrect axis aligned bounding box for the link containing the collision. This is found to be caused by incorrect frame data pose computed for collisions - It currently ignores the collision pose offset. 

This PR makes a few changes to `KinematicsFeatures::FrameDataRelativeToWorld` in bullet-featherstone plugin:
* fixed getting collision pose relative to world
* fixed getting model pose relative to world
* minor refactoring

The link_features's bounding box test was previously skipped for bullet-featherstone plugin. This PR enables this test for bullet-featherstone by requiring only a minimal set of features needed to run the test.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

