### PR TITLE
Fix model frame data

### DIFF
--- a/dartsim/src/KinematicsFeatures.cc
+++ b/dartsim/src/KinematicsFeatures.cc
@@ -64,14 +64,6 @@ FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
 const dart::dynamics::Frame *KinematicsFeatures::SelectFrame(
     const FrameID &_id) const
 {
-  const auto model_it = this->models.idToObject.find(_id.ID());
-  if (model_it != this->models.idToObject.end())
-  {
-    // This is a model FreeGroup frame, so we'll use the first root link as the
-    // frame
-    return model_it->second->model->getRootBodyNode();
-  }
-
   auto framesIt = this->frames.find(_id.ID());
   if (framesIt == this->frames.end())
   {

--- a/test/common_test/kinematic_features.cc
+++ b/test/common_test/kinematic_features.cc
@@ -205,11 +205,8 @@ TYPED_TEST(KinematicFeaturesTest, LinkFrameSemanticsPose)
 
     gz::math::Pose3d actualModelPose(1, 0, 0, 0, 0, 0);
     auto modelFrameData = model->FrameDataRelativeToWorld();
-    if (this->PhysicsEngineName(name) == "bullet-featherstone")
-    {
-      EXPECT_EQ(actualModelPose,
-                gz::math::eigen3::convert(modelFrameData.pose));
-    }
+    EXPECT_EQ(actualModelPose,
+              gz::math::eigen3::convert(modelFrameData.pose));
     auto baseLinkFrameData = baseLink->FrameDataRelativeToWorld();
     auto baseLinkPose = gz::math::eigen3::convert(baseLinkFrameData.pose);
     gz::math::Pose3d actualLinkLocalPose(0, 1, 0, 0, 0, 0);
@@ -242,14 +239,11 @@ TYPED_TEST(KinematicFeaturesTest, LinkFrameSemanticsPose)
         linkColPose.Rot().Euler());
 
     gz::math::Pose3d actualNestedModelLocalPose(0, 0, 1, 0, 0, 0.5);
-    if (this->PhysicsEngineName(name) == "bullet-featherstone")
-    {
-      auto nestedModelFrameData = nestedModel->FrameDataRelativeToWorld();
-      gz::math::Pose3d expectedNestedModelWorldPose =
-          actualModelPose * actualNestedModelLocalPose;
-      EXPECT_EQ(expectedNestedModelWorldPose,
-          gz::math::eigen3::convert(nestedModelFrameData.pose));
-    }
+    auto nestedModelFrameData = nestedModel->FrameDataRelativeToWorld();
+    gz::math::Pose3d expectedNestedModelWorldPose =
+        actualModelPose * actualNestedModelLocalPose;
+    EXPECT_EQ(expectedNestedModelWorldPose,
+        gz::math::eigen3::convert(nestedModelFrameData.pose));
 
     auto nestedLinkFrameData = nestedLink->FrameDataRelativeToWorld();
     auto nestedLinkPose = gz::math::eigen3::convert(nestedLinkFrameData.pose);


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

Fix ModelFrameSemantics in dartsim. When a model is added to dartsim, a model [frame](https://github.com/gazebosim/gz-physics/blob/8bcb176e081499d58f230a7df460cffae9e96d11/dartsim/src/SDFFeatures.cc#L568-L571) is also always created. So it looks like we can just look up frames to retrieve model frame data in `KinematicsFeature` instead of using the root body node (which may be at an offset from the model).

Enabled checks for model frame data  in `kinematic_features`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
