### PR TITLE
bullet-featherstone: Fix attaching fixed joint between models with inertial pose offset

### DIFF
--- a/bullet-featherstone/src/JointFeatures.cc
+++ b/bullet-featherstone/src/JointFeatures.cc
@@ -509,11 +509,19 @@ void JointFeatures::SetJointTransformFromParent(
 
   if (jointInfo->fixedConstraint)
   {
-      auto tf = convertTf(_pose);
-      jointInfo->fixedConstraint->setPivotInA(
-        tf.getOrigin());
-      jointInfo->fixedConstraint->setFrameInA(
-        tf.getBasis());
+    Eigen::Isometry3d parentInertiaToLinkFrame = Eigen::Isometry3d::Identity();
+    if (jointInfo->parentLinkID.has_value())
+    {
+      auto parentLinkInfo = this->links.at(jointInfo->parentLinkID.value());
+      parentInertiaToLinkFrame = parentLinkInfo->inertiaToLinkFrame;
+    }
+    auto *linkInfo = this->ReferenceInterface<LinkInfo>(jointInfo->childLinkID);
+    auto tf = convertTf(
+      parentInertiaToLinkFrame * _pose * linkInfo->inertiaToLinkFrame.inverse());
+    jointInfo->fixedConstraint->setPivotInA(
+      tf.getOrigin());
+    jointInfo->fixedConstraint->setFrameInA(
+      tf.getBasis());
   }
 }
 

--- a/bullet-featherstone/src/JointFeatures.cc
+++ b/bullet-featherstone/src/JointFeatures.cc
@@ -516,8 +516,8 @@ void JointFeatures::SetJointTransformFromParent(
       parentInertiaToLinkFrame = parentLinkInfo->inertiaToLinkFrame;
     }
     auto *linkInfo = this->ReferenceInterface<LinkInfo>(jointInfo->childLinkID);
-    auto tf = convertTf(
-      parentInertiaToLinkFrame * _pose * linkInfo->inertiaToLinkFrame.inverse());
+    auto tf = convertTf(parentInertiaToLinkFrame * _pose *
+                        linkInfo->inertiaToLinkFrame.inverse());
     jointInfo->fixedConstraint->setPivotInA(
       tf.getOrigin());
     jointInfo->fixedConstraint->setFrameInA(

--- a/test/common_test/worlds/detachable_joint.world
+++ b/test/common_test/worlds/detachable_joint.world
@@ -101,6 +101,7 @@
       <link name="link2">
         <inertial>
           <mass>1.0</mass>
+          <pose>0.0 0 0.3 0 0 0</pose>
           <inertia>
             <ixx>0.0068</ixx>
             <ixy>0</ixy>


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

When creating a fixed constraint between links, the `SetJointTransformFromParent` currently does not take into account the inertial pose. If an inertial pose offset exists, the fixed constraint causes the 2 models to be displaced from their original position. This PR updates the calculation in `SetJointTransformFromParent` to include inertial pose offset. 

The `detachable_joint.world` test world is updated to use a model with inertial pose offset - this world is used by the `CorrectAttachmentPoints` test in `detachable_joint` common test. The test fails without the changes in this PR.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

