### PR TITLE
Fix CTAD compile warnings

### DIFF
--- a/bullet-featherstone/src/JointFeatures.cc
+++ b/bullet-featherstone/src/JointFeatures.cc
@@ -176,9 +176,9 @@ double JointFeatures::GetJointForce(
       // According to the documentation in btMultibodyLink.h,
       // m_axesTop[0] is the joint axis for revolute joints.
       Eigen::Vector3d axis = convert(link.getAxisTop(0));
-      math::Vector3 axis_converted(axis[0], axis[1], axis[2]);
+      math::Vector3d axis_converted(axis[0], axis[1], axis[2]);
       btVector3 angular = feedback->m_reactionForces.getAngular();
-      math::Vector3<double> angularTorque(
+      math::Vector3d angularTorque(
         angular.getX(),
         angular.getY(),
         angular.getZ());
@@ -193,9 +193,9 @@ double JointFeatures::GetJointForce(
     else if (link.m_jointType == btMultibodyLink::ePrismatic)
     {
       auto axis = convert(link.getAxisBottom(0));
-      math::Vector3 axis_converted(axis[0], axis[1], axis[2]);
+      math::Vector3d axis_converted(axis[0], axis[1], axis[2]);
       btVector3 linear = feedback->m_reactionForces.getLinear();
-      math::Vector3<double> linearForce(
+      math::Vector3d linearForce(
         linear.getX(),
         linear.getY(),
         linear.getZ());


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

Fixes the following error when compiling with the `-Wctad-maybe-unsupported` flag

```sh
physics/bullet_featherstone/src/JointFeatures.cc:179:7: error: 'math::Vector3' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

