### PR TITLE
Enable 24.04 CI, require cmake 3.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'ign-physics[0-9]'
-      - 'gz-physics[0-9]?'
+      - 'gz-physics[1-9]?[0-9]'
       - 'main'
 
 jobs:
@@ -22,3 +22,12 @@ jobs:
           codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 Build | Status
 -- | --
-Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-physics/tree/gz-physics8/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-physics/tree/gz-physics8)
-Ubuntu Jammy  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-gz-physics8-jammy-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-gz-physics8-jammy-amd64)
-Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-gz-physics8-homebrew-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-gz-physics8-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-8-win)](https://build.osrfoundation.org/job/gz_physics-8-win)
+Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-physics/branch/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-physics/branch/main)
+Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-noble-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-main-noble-amd64)
+Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-main-homebrew-amd64)
+Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-main-win)](https://build.osrfoundation.org/job/gz_physics-main-win)
 
 Gazebo Physics, a component of [Gazebo](https://gazebosim.org), provides an abstract physics interface
 designed to support simulation and rapid development of robot applications.

--- a/examples/hello_world_loader/CMakeLists.txt
+++ b/examples/hello_world_loader/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(gz-physics-hello-world-loader)
 

--- a/examples/hello_world_plugin/CMakeLists.txt
+++ b/examples/hello_world_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(gz-physics-hello-world-plugin)
 

--- a/examples/simple_plugin/CMakeLists.txt
+++ b/examples/simple_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(gz-physics-simple-plugin)
 


### PR DESCRIPTION
# 🎉 New feature

Part of gazebosim/gz-cmake#350.

## Summary

This adds a GitHub workflow using Noble and increases our minimum required cmake version to 3.22.1 since we are already requiring that in gz-cmake4.

It also fixes the push branch regex to support multi-digit versions (copied from https://github.com/gazebosim/sdformat/pull/1445) and fixes the CI badges in the README.


## Test it

Check CI results

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
