### PR TITLE
Remove deprecated function

### DIFF
--- a/include/gz/physics/FreeGroup.hh
+++ b/include/gz/physics/FreeGroup.hh
@@ -85,18 +85,6 @@ namespace gz
 
         /// \brief const version of RootLink()
         public: ConstLinkPtr<PolicyT, FeaturesT> RootLink() const;
-
-        /// \brief The root link of this FreeGroup. This link is the root of one
-        /// of the kinematic trees represented by this FreeGroup. Getting and
-        /// setting properties (like poses and velocities) on the group will be
-        /// done in terms of this link.
-        /// DEPRECATED. Please use RootLink()
-        public: LinkPtr<PolicyT, FeaturesT> GZ_DEPRECATED(4.0) CanonicalLink();
-
-        /// \brief const version of CanonicalLink()
-        /// DEPRECATED. Please use RootLink()
-        public: ConstLinkPtr<PolicyT, FeaturesT> GZ_DEPRECATED(4.0)
-                    CanonicalLink() const;
       };
 
       public: template <typename PolicyT>

--- a/include/gz/physics/detail/FreeGroup.hh
+++ b/include/gz/physics/detail/FreeGroup.hh
@@ -86,22 +86,6 @@ namespace gz
 
     /////////////////////////////////////////////////
     template <typename PolicyT, typename FeaturesT>
-    LinkPtr<PolicyT, FeaturesT>
-    FindFreeGroupFeature::FreeGroup<PolicyT, FeaturesT>::CanonicalLink()
-    {
-      return this->RootLink();
-    }
-
-    /////////////////////////////////////////////////
-    template <typename PolicyT, typename FeaturesT>
-    ConstLinkPtr<PolicyT, FeaturesT>
-    FindFreeGroupFeature::FreeGroup<PolicyT, FeaturesT>::CanonicalLink() const
-    {
-      return this->RootLink();
-    }
-
-    /////////////////////////////////////////////////
-    template <typename PolicyT, typename FeaturesT>
     void SetFreeGroupWorldPose::FreeGroup<PolicyT, FeaturesT>::SetWorldPose(
         const PoseType &_pose)
     {

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -627,9 +627,6 @@ TYPED_TEST(SimulationFeaturesTestFreeGroup, FreeGroup)
     auto model = world->GetModel("sphere");
     auto freeGroup = model->FindFreeGroup();
     ASSERT_NE(nullptr, freeGroup);
-    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-    ASSERT_NE(nullptr, freeGroup->CanonicalLink());
-    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
     ASSERT_NE(nullptr, freeGroup->RootLink());
 
     auto link = model->GetLink("sphere_link");
@@ -1273,10 +1270,7 @@ TYPED_TEST(SimulationFeaturesTestBasic, MultipleCollisions)
     auto model = world->GetModel("box");
     auto freeGroup = model->FindFreeGroup();
     ASSERT_NE(nullptr, freeGroup);
-    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-      ASSERT_NE(nullptr, freeGroup->CanonicalLink());
-    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-      ASSERT_NE(nullptr, freeGroup->RootLink());
+    ASSERT_NE(nullptr, freeGroup->RootLink());
 
     auto link = model->GetLink("box_link");
     auto freeGroupLink = link->FindFreeGroup();

--- a/tpe/plugin/src/SimulationFeatures_TEST.cc
+++ b/tpe/plugin/src/SimulationFeatures_TEST.cc
@@ -447,9 +447,6 @@ TEST_P(SimulationFeatures_TEST, FreeGroup)
     auto model = world->GetModel("sphere");
     auto freeGroup = model->FindFreeGroup();
     ASSERT_NE(nullptr, freeGroup);
-    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-    ASSERT_NE(nullptr, freeGroup->CanonicalLink());
-    GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
     ASSERT_NE(nullptr, freeGroup->RootLink());
 
     auto link = model->GetLink("sphere_link");


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Remove `CanonicalLink()` in `FreeGroup`. It's replaced by `RootLink()`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
