### PR TITLE
dartsim: To not call dart::collision::GzOdeCollisionDetector::create() in ConstructEmptyWorld

### DIFF
--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -28,7 +28,7 @@
 #include <dart/collision/CollisionFilter.hpp>
 #include <dart/collision/CollisionObject.hpp>
 
-#include "GzOdeCollisionDetector.hh"
+#include <dart/collision/dart/DARTCollisionDetector.hpp>
 
 namespace gz {
 namespace physics {
@@ -725,7 +725,7 @@ Identity EntityManagementFeatures::ConstructEmptyWorld(
     const Identity &/*_engineID*/, const std::string &_name)
 {
   const auto &world = std::make_shared<dart::simulation::World>(_name);
-  auto collisionDetector = dart::collision::GzOdeCollisionDetector::create();
+  auto collisionDetector = dart::collision::DARTCollisionDetector::create();
   world->getConstraintSolver()->setCollisionDetector(collisionDetector);
 
   auto &collOpt = world->getConstraintSolver()->getCollisionOption();

--- a/dartsim/src/WorldFeatures.cc
+++ b/dartsim/src/WorldFeatures.cc
@@ -62,6 +62,7 @@ void WorldFeatures::SetWorldCollisionDetector(
   }
   else
   {
+    collisionDetector = dart::collision::GzOdeCollisionDetector::create();
     gzerr << "Collision detector [" << _collisionDetector
            << "] is not supported, defaulting to ["
            << collisionDetector->getType() << "]." << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix
 
Fixes problem described in https://github.com/gazebosim/gz-sim/issues/18#issuecomment-2301643365 .

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

