### PR TITLE
GzOdeCollisionDetector: Use static mutex in create

### DIFF
--- a/dartsim/src/GzOdeCollisionDetector.cc
+++ b/dartsim/src/GzOdeCollisionDetector.cc
@@ -16,6 +16,7 @@
 */
 
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <utility>
 
@@ -43,6 +44,13 @@ GzOdeCollisionDetector::Registrar<GzOdeCollisionDetector>
 /////////////////////////////////////////////////
 std::shared_ptr<GzOdeCollisionDetector> GzOdeCollisionDetector::create()
 {
+  // GzOdeCollisionDetector constructor calls the OdeCollisionDetector
+  // constructor, that calls the non-thread safe dInitODE2(0).
+  // To mitigate this problem, we use a static mutex to ensure that
+  // each GzOdeCollisionDetector constructor is called not at the same time.
+  // See https://github.com/gazebosim/gz-sim/issues/18 for more info.
+  static std::mutex odeInitMutex;
+  std::unique_lock<std::mutex> lock(odeInitMutex);
   return std::shared_ptr<GzOdeCollisionDetector>(new GzOdeCollisionDetector());
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This is done to avoid that non-thread-safe ODE functions are called at the same time, causing errors such as 
> ODE INTERNAL ERROR 1: assertion "!colliders_initialized" failed in dInitColliders() [collision_kernel.cpp:168]

Why this happens? As the `GzOdeCollisionDetector` constructor calls the DART's `OdeCollisionDetector` constructor, that instead calls the non-thread-safe `dInitODE2(0)` ode function. If `dInitODE2(0)` is called at different times, everything seems to be working fine, so we enforce this by adding a static std::mutex in the `GzOdeCollisionDetector::create`.

This fixes part of https://github.com/gazebosim/gz-sim/issues/18 . Note that this does not solve all the ODE-related multi-threading problems, but at least allows to set a different collision manager without having errors such as:

> ODE INTERNAL ERROR 1: assertion "!colliders_initialized" failed in dInitColliders() [collision_kernel.cpp:168]

That happens as `GzOdeCollisionDetector` is allocated before the requested collision detector is set by `WorldFeatures::SetWorldCollisionDetector`, so it is not possible to avoid to construct ``GzOdeCollisionDetector` by specifying a custom collision detector in the SDF, unless we want to change the default collision detector, that is something we want to avoid (at least at the moment) as discussed in https://github.com/gazebosim/gz-sim/issues/18 .


<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
