### PR TITLE
README: update references from main to gz-physics8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 Build | Status
 -- | --
-Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-physics/branch/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-physics/branch/main)
-Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-noble-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-main-noble-amd64)
-Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-main-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-main-win)](https://build.osrfoundation.org/job/gz_physics-main-win)
+Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-physics/tree/gz-physics8/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-physics/tree/gz-physics8)
+Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-gz-physics8-noble-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-gz-physics8-noble-amd64)
+Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-gz-physics8-homebrew-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-gz-physics8-homebrew-amd64)
+Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-8-win)](https://build.osrfoundation.org/job/gz_physics-8-win)
 
 Gazebo Physics, a component of [Gazebo](https://gazebosim.org), provides an abstract physics interface
 designed to support simulation and rapid development of robot applications.
@@ -73,7 +73,7 @@ See the [installation tutorial](https://gazebosim.org/api/physics/5.0/installati
 
 # Usage
 
-Please refer to the [examples directory](https://github.com/gazebosim/gz-physics/raw/main/examples/).
+Please refer to the [examples directory](https://github.com/gazebosim/gz-physics/raw/gz-physics8/examples/).
 
 # Documentation
 
@@ -90,7 +90,7 @@ You can also generate the documentation from a clone of this repository by follo
 2. Clone the repository
 
     ```
-    git clone https://github.com/gazebosim/gz-physics -b main
+    git clone https://github.com/gazebosim/gz-physics -b gz-physics8
     ```
 
 3. Configure and build the documentation.


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1092

## Summary

Update branch references in the README from `main` to `gz-physics8` including the jenkins badges, an example `git` command, and a markdown links.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
