### PR TITLE
Fix installation tutorial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Gazebo Physics provides the following functionality:
 
 # Install
 
-See the [installation tutorial](https://gazebosim.org/api/physics/5.0/installation.html).
+See the [installation tutorial](https://gazebosim.org/api/physics/8/installation.html).
 
 # Usage
 


### PR DESCRIPTION


# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

The installation tutorial link in README is broken. This updates the link to point to the latest installation tutorial page.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

