### PR TITLE
Prepare for 8.0.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake4 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,19 @@
 ## Gazebo Physics 8.x
 
-### Gazebo Physics 8.0.0 (2024-09-XX)
+### Gazebo Physics 8.0.0 (2024-09-25)
 
 1. **Baseline:** this includes all changes from 7.3.0 and earlier.
+
+1. Miscellaneous documentation fixes
+    * [Pull request #691](https://github.com/gazebosim/gz-physics/pull/691)
+    * [Pull request #689](https://github.com/gazebosim/gz-physics/pull/689)
+    * [Pull request #690](https://github.com/gazebosim/gz-physics/pull/690)
+    * [Pull request #688](https://github.com/gazebosim/gz-physics/pull/688)
+    * [Pull request #686](https://github.com/gazebosim/gz-physics/pull/686)
+    * [Pull request #684](https://github.com/gazebosim/gz-physics/pull/684)
+    * [Pull request #683](https://github.com/gazebosim/gz-physics/pull/683)
+    * [Pull request #682](https://github.com/gazebosim/gz-physics/pull/682)
+    * [Pull request #681](https://github.com/gazebosim/gz-physics/pull/681)
 
 1. Remove deprecated functions
     * [Pull request #673](https://github.com/gazebosim/gz-physics/pull/673)


### PR DESCRIPTION
# 🎈 Release

Preparation for 8.0.0 release.

Comparison to 8.0.0-pre2: https://github.com/gazebosim/gz-physics/compare/gz-physics8_8.0.0-pre2...gz-physics8

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.