### PR TITLE
bullet-featherstone: Reset joint motor constraint's velocity target after each step

### DIFF
--- a/bullet-featherstone/src/SimulationFeatures.cc
+++ b/bullet-featherstone/src/SimulationFeatures.cc
@@ -51,6 +51,16 @@ void SimulationFeatures::WorldForwardStep(
   worldInfo->world->stepSimulation(static_cast<btScalar>(stepSize), 1,
                                    static_cast<btScalar>(stepSize));
 
+  // Reset joint velocity target after each step to be consistent with dart's
+  // joint velocity command behavior
+  for (auto & joint : this->joints)
+  {
+    if (joint.second->motor)
+    {
+      joint.second->motor->setVelocityTarget(btScalar(0));
+    }
+  }
+
   this->WriteRequiredData(_h);
   this->Write(_h.Get<ChangedWorldPoses>());
 }

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -174,14 +174,11 @@ TYPED_TEST(JointFeaturesTest, JointSetCommand)
       EXPECT_NEAR(1.0, joint->GetVelocity(0), 1e-2);
     }
 
-    if(this->PhysicsEngineName(name) == "dartsim")
+    for (std::size_t i = 0; i < numSteps; ++i)
     {
-      for (std::size_t i = 0; i < numSteps; ++i)
-      {
-        // expect joint to freeze in subsequent steps without SetVelocityCommand
-        world->Step(output, state, input);
-        EXPECT_NEAR(0.0, joint->GetVelocity(0), 1e-1);
-      }
+      // expect joint to freeze in subsequent steps without SetVelocityCommand
+      world->Step(output, state, input);
+      EXPECT_NEAR(0.0, joint->GetVelocity(0), 1e-1);
     }
 
     // Check that invalid velocity commands don't cause collisions to fail


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2654

## Summary

Reset's the joint velocity cmd after each step to be consistent with dart behavior.

Note: I also tried removing the joint motor constraint after each step but that didn't work (test fails) so opted to reset the joint velocity target to 0.

We have a test for this in `joint_features` but only for dart. This PR enables the test for bullet-featherstone as well. There is also a test in gz-sim in a branch (see instructions in #2654). The test there should now pass with these changes.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
