### PR TITLE
bullet-featherstone: Fix finding free group for a body with fixed base

### DIFF
--- a/bullet-featherstone/src/FreeGroupFeatures.cc
+++ b/bullet-featherstone/src/FreeGroupFeatures.cc
@@ -85,13 +85,24 @@ Identity FreeGroupFeatures::FindFreeGroupForModel(
 {
   const auto *model = this->ReferenceInterface<ModelInfo>(_modelID);
 
-  // Also reject if the model is a child of a fixed constraint
-  // (detachable joint)
+  std::cerr <<  "joints " << this->joints.size() << std::endl;
   for (const auto & joint : this->joints)
   {
+    // Also reject if the model is a child of a fixed constraint
+    // (detachable joint)
     if (joint.second->fixedConstraint)
     {
       if (joint.second->fixedConstraint->getMultiBodyB() == model->body.get())
+      {
+        return this->GenerateInvalidId();
+      }
+    }
+    // Reject if the model has a world joint
+    if (std::size_t(joint.second->model) == std::size_t(_modelID))
+    {
+      const auto *identifier =
+          std::get_if<RootJoint>(&joint.second->identifier);
+      if (identifier)
       {
         return this->GenerateInvalidId();
       }

--- a/bullet-featherstone/src/FreeGroupFeatures.cc
+++ b/bullet-featherstone/src/FreeGroupFeatures.cc
@@ -85,7 +85,6 @@ Identity FreeGroupFeatures::FindFreeGroupForModel(
 {
   const auto *model = this->ReferenceInterface<ModelInfo>(_modelID);
 
-  std::cerr <<  "joints " << this->joints.size() << std::endl;
   for (const auto & joint : this->joints)
   {
     // Also reject if the model is a child of a fixed constraint

--- a/bullet-featherstone/src/FreeGroupFeatures.cc
+++ b/bullet-featherstone/src/FreeGroupFeatures.cc
@@ -107,7 +107,7 @@ Identity FreeGroupFeatures::FindFreeGroupForLink(
 {
   // Free groups in bullet-featherstone are currently represented by ModelInfo
   const auto *link = this->ReferenceInterface<LinkInfo>(_linkID);
-  return FindFreeGroupForModel(link->model)
+  return this->FindFreeGroupForModel(link->model);
 }
 
 /////////////////////////////////////////////////

--- a/bullet-featherstone/src/FreeGroupFeatures.cc
+++ b/bullet-featherstone/src/FreeGroupFeatures.cc
@@ -85,10 +85,6 @@ Identity FreeGroupFeatures::FindFreeGroupForModel(
 {
   const auto *model = this->ReferenceInterface<ModelInfo>(_modelID);
 
-  // Reject if the model has fixed base
-  if (model->body->hasFixedBase())
-    return this->GenerateInvalidId();
-
   // Also reject if the model is a child of a fixed constraint
   // (detachable joint)
   for (const auto & joint : this->joints)
@@ -102,7 +98,6 @@ Identity FreeGroupFeatures::FindFreeGroupForModel(
     }
   }
 
-
   return _modelID;
 }
 
@@ -110,12 +105,9 @@ Identity FreeGroupFeatures::FindFreeGroupForModel(
 Identity FreeGroupFeatures::FindFreeGroupForLink(
     const Identity &_linkID) const
 {
+  // Free groups in bullet-featherstone are currently represented by ModelInfo
   const auto *link = this->ReferenceInterface<LinkInfo>(_linkID);
-  const auto *model = this->ReferenceInterface<ModelInfo>(link->model);
-  if (model->body->hasFixedBase())
-    return this->GenerateInvalidId();
-
-  return link->model;
+  return FindFreeGroupForModel(link->model)
 }
 
 /////////////////////////////////////////////////

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -578,6 +578,7 @@ Identity SDFFeatures::ConstructSdfModelImpl(
   // Add world joint
   if (structure.rootJoint)
   {
+    std::cerr << " adding root joint " << structure.rootJoint->Name() << std::endl;
     const auto &parentInfo = structure.parentOf.at(structure.rootLink);
     this->AddJoint(
           JointInfo{

--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -578,7 +578,6 @@ Identity SDFFeatures::ConstructSdfModelImpl(
   // Add world joint
   if (structure.rootJoint)
   {
-    std::cerr << " adding root joint " << structure.rootJoint->Name() << std::endl;
     const auto &parentInfo = structure.parentOf.at(structure.rootLink);
     this->AddJoint(
           JointInfo{

--- a/test/common_test/free_joint_features.cc
+++ b/test/common_test/free_joint_features.cc
@@ -356,7 +356,6 @@ TEST_F(FreeGroupFeaturesTest, FreeGroupSetWorldPoseStaticAndFixedModel)
       </model>
     </sdf>)";
 
-
   for (const std::string &name : pluginNames)
   {
     std::cout << "Testing plugin: " << name << std::endl;

--- a/test/common_test/free_joint_features.cc
+++ b/test/common_test/free_joint_features.cc
@@ -318,7 +318,7 @@ TEST_F(FreeGroupFeaturesTest, FreeGroupSetWorldPosePrincipalAxesOffset)
 
 TEST_F(FreeGroupFeaturesTest, FreeGroupSetWorldPoseStaticAndFixedModel)
 {
-  const std::string modelStr = R"(
+  const std::string modelStaticStr = R"(
     <sdf version="1.11">
       <model name="sphere">
         <static>true</static>
@@ -377,7 +377,7 @@ TEST_F(FreeGroupFeaturesTest, FreeGroupSetWorldPoseStaticAndFixedModel)
     ASSERT_NE(nullptr, world);
 
     // create the static model
-    errors = root.LoadSdfString(modelStr);
+    errors = root.LoadSdfString(modelStaticStr);
     ASSERT_TRUE(errors.empty()) << errors;
     ASSERT_NE(nullptr, root.Model());
     world->ConstructModel(*root.Model());


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2663

## Summary

Finding free group for a body that has a fixed base results an invalid ID, which causes set world pose from gz-sim to fail, see https://github.com/gazebosim/gz-sim/issues/2663. This PR removes the fixed base body check and I verified that set world pose works for a body with fixed base.  

Another minor change - I noticed that finding free group for links has the same check. Currently free groups only works for models in bullet-featherstone so I updated the function to just call `FindFreeGroupForModel`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

