### PR TITLE
bullet-featherstone: Remove joint motor constraint on joint force cmd

### DIFF
--- a/bullet-featherstone/src/JointFeatures.cc
+++ b/bullet-featherstone/src/JointFeatures.cc
@@ -271,7 +271,6 @@ void JointFeatures::SetJointVelocity(
     return;
 
   const auto *model = this->ReferenceInterface<ModelInfo>(joint->model);
-
   model->body->getJointVelMultiDof(identifier->indexInBtModel)[_dof] =
       static_cast<btScalar>(_value);
   model->body->wakeUp();
@@ -302,7 +301,7 @@ void JointFeatures::SetJointForce(
   if (!identifier)
     return;
 
-  auto *model = this->ReferenceInterface<ModelInfo>(joint->model);
+  const auto *model = this->ReferenceInterface<ModelInfo>(joint->model);
   auto *world = this->ReferenceInterface<WorldInfo>(model->world);
 
   // Disable velocity control by removing joint motor constraint

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -146,7 +146,7 @@ TYPED_TEST(JointFeaturesTest, JointSetCommand)
     auto base_link = model->GetLink("base");
     ASSERT_NE(nullptr, base_link);
 
-    // Check that invalid velocity commands don't cause collisions to fail
+    // Check that invalid force commands don't cause collisions to fail
     for (std::size_t i = 0; i < 1000; ++i)
     {
       // Silence console spam
@@ -179,6 +179,15 @@ TYPED_TEST(JointFeaturesTest, JointSetCommand)
       // expect joint to freeze in subsequent steps without SetVelocityCommand
       world->Step(output, state, input);
       EXPECT_NEAR(0.0, joint->GetVelocity(0), 1e-1);
+    }
+
+    // Set joint force to 0 and expect that the velocity command is no
+    // longer enforced, i.e. joint should not freeze in subsequent steps
+    joint->SetForce(0, 0.0);
+    for (std::size_t i = 0; i < numSteps; ++i)
+    {
+      world->Step(output, state, input);
+      EXPECT_LT(0.0, std::fabs(joint->GetVelocity(0)));
     }
 
     // Check that invalid velocity commands don't cause collisions to fail


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2729

## Summary

Currently the joint motor responsible for enforcing a joint vel cmd does not disengage when a force command is received. This PR fixes the issue by removing the joint motor constraint whenever a joint force cmd is received.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
