### PR TITLE
Fix windows warnings

### DIFF
--- a/dartsim/src/SimulationFeatures.hh
+++ b/dartsim/src/SimulationFeatures.hh
@@ -44,7 +44,7 @@ namespace dart
 {
 namespace collision
 {
-class Contact;
+struct Contact;
 }
 }
 

--- a/test/integration/DoublePendulum.cc
+++ b/test/integration/DoublePendulum.cc
@@ -113,7 +113,7 @@ void DoublePendulum_TEST(gz::plugin::PluginPtr _plugin)
   gz::math::PID pid0(100, 0, 10);
   gz::math::PID pid1(10, 0, 5);
   const std::chrono::duration<double> settleTime(std::chrono::seconds(4));
-  unsigned int settleSteps = settleTime / dt;
+  unsigned int settleSteps = static_cast<unsigned int>(settleTime / dt);
   for (unsigned int i = 0; i < settleSteps; ++i)
   {
     auto positions = output.Get<JointPositions>();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes windows warnings

## Summary

https://build.osrfoundation.org/job/gz_physics-8-clowin/15/msbuild/

* https://github.com/gazebosim/gz-physics/commit/353811df0ed227bdea3624b5fd7e4b15a3208bef: use `static_cast` to fix a windows type conversion warning
* https://github.com/gazebosim/gz-physics/commit/dd37b50a33954c6e96dab24d40cdaa1a48734845: the `dart::collision::Contact` is [defined as a struct](https://github.com/dartsim/dart/blob/main/dart/collision/Contact.hpp#L46), so fix the forward declaration

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
