### PR TITLE
Fix collision checking issues in bullet-featherstone

### DIFF
--- a/bullet-featherstone/src/Base.cc
+++ b/bullet-featherstone/src/Base.cc
@@ -87,7 +87,8 @@ void GzMultiBody::SetBaseWorldTransform(const btTransform &_pose)
 
 void GzMultiBody::UpdateCollisionTransformsIfNeeded()
 {
-  if (this->needsCollisionTransformsUpdate) {
+  if (this->needsCollisionTransformsUpdate)
+  {
     btAlignedObjectArray<btQuaternion> scratchWorldToLocal;
     btAlignedObjectArray<btVector3> scratchLocalOrigin;
     this->updateCollisionObjectWorldTransforms(

--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -81,13 +81,50 @@ struct WorldInfo
   explicit WorldInfo(std::string name);
 };
 
+class GzMultiBody: public btMultiBody {
+  using btMultiBody::btMultiBody;
+
+  // Set position for a particular joint dof and set a flag that the collision
+  // world transforms need to be updated before performing collision queries.
+  // Use this method to set a joint dof position instead of the base class
+  // methods `setJointPos`/ `setJointPosMultiDof`/
+  // (non-const)`getJointPosMultiDof` to ensure that collision queries after
+  // setting joint positions are accurate.
+  public: void SetJointPosForDof(
+    int _jointIndex,
+    std::size_t _dof,
+    btScalar _value);
+  private: using btMultiBody::setJointPos;
+  private: using btMultiBody::setJointPosMultiDof;
+  private: using btMultiBody::getJointPosMultiDof;
+
+  // Get the position of a particular joint dof.
+  // This method is needed because the private using-declaration above hides
+  // both the const and non-const overloads of
+  // `btMultiBody::getJointPosMultiDof`.
+  public: btScalar GetJointPosForDof(int _jointIndex, std::size_t _dof) const;
+
+  // Set base transform in world.
+  // Use this method to set the transform for a moving base model instead of
+  // the base class method `setBaseWorldTransform` to ensure that collision
+  // queries after setting the transform are accurate.
+  public: void SetBaseWorldTransform(const btTransform &_pose);
+  private: using btMultiBody::setBaseWorldTransform;
+
+  // Update collision transforms if `needsCollisionTransformsUpdate` is set and
+  // reset the flag.
+  public: void UpdateCollisionTransformsIfNeeded();
+
+  private: bool needsCollisionTransformsUpdate = false;
+};
+
 struct ModelInfo
 {
   std::string name;
   Identity world;
   int indexInWorld;
   Eigen::Isometry3d baseInertiaToLinkFrame;
-  std::shared_ptr<btMultiBody> body;
+  std::shared_ptr<GzMultiBody> body;
 
   std::vector<std::size_t> linkEntityIds;
   std::vector<std::size_t> jointEntityIds;
@@ -104,7 +141,7 @@ struct ModelInfo
     std::string _name,
     Identity _world,
     Eigen::Isometry3d _baseInertiaToLinkFrame,
-    std::shared_ptr<btMultiBody> _body)
+    std::shared_ptr<GzMultiBody> _body)
     : name(std::move(_name)),
       world(std::move(_world)),
       baseInertiaToLinkFrame(_baseInertiaToLinkFrame),
@@ -324,7 +361,7 @@ class Base : public Implements3d<FeatureList<Feature>>
     std::string _name,
     Identity _worldID,
     Eigen::Isometry3d _baseInertialToLinkFrame,
-    std::shared_ptr<btMultiBody> _body)
+    std::shared_ptr<GzMultiBody> _body)
   {
     const auto id = this->GetNextEntity();
     auto model = std::make_shared<ModelInfo>(
@@ -349,7 +386,7 @@ class Base : public Implements3d<FeatureList<Feature>>
     Identity _parentID,
     Identity _worldID,
     Eigen::Isometry3d _baseInertialToLinkFrame,
-    std::shared_ptr<btMultiBody> _body)
+    std::shared_ptr<GzMultiBody> _body)
   {
     const auto id = this->GetNextEntity();
     auto model = std::make_shared<ModelInfo>(

--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -81,15 +81,19 @@ struct WorldInfo
   explicit WorldInfo(std::string name);
 };
 
-class GzMultiBody: public btMultiBody {
+/// \brief Custom `GzMultiBody` wrapper for `btMultiBody` to ensure that a flag
+/// is set whenever joint position is set or base transform is set indicating
+/// that collision transforms need to be updated.
+class GzMultiBody: public btMultiBody
+{
   using btMultiBody::btMultiBody;
 
-  // Set position for a particular joint dof and set a flag that the collision
-  // world transforms need to be updated before performing collision queries.
-  // Use this method to set a joint dof position instead of the base class
-  // methods `setJointPos`/ `setJointPosMultiDof`/
-  // (non-const)`getJointPosMultiDof` to ensure that collision queries after
-  // setting joint positions are accurate.
+  /// \brief Set position for a particular joint dof and set a flag that the
+  /// collision world transforms need to be updated before performing collision
+  /// queries. Use this method to set a joint dof position instead of the base
+  /// class methods `setJointPos`/ `setJointPosMultiDof`/
+  /// (non-const)`getJointPosMultiDof` to ensure that collision queries after
+  /// setting joint positions are accurate.
   public: void SetJointPosForDof(
     int _jointIndex,
     std::size_t _dof,
@@ -98,21 +102,21 @@ class GzMultiBody: public btMultiBody {
   private: using btMultiBody::setJointPosMultiDof;
   private: using btMultiBody::getJointPosMultiDof;
 
-  // Get the position of a particular joint dof.
-  // This method is needed because the private using-declaration above hides
-  // both the const and non-const overloads of
-  // `btMultiBody::getJointPosMultiDof`.
+  /// \brief Get the position of a particular joint dof.
+  /// This method is needed because the private using-declaration above hides
+  /// both the const and non-const overloads of
+  /// `btMultiBody::getJointPosMultiDof`.
   public: btScalar GetJointPosForDof(int _jointIndex, std::size_t _dof) const;
 
-  // Set base transform in world.
-  // Use this method to set the transform for a moving base model instead of
-  // the base class method `setBaseWorldTransform` to ensure that collision
-  // queries after setting the transform are accurate.
+  /// \brief Set base transform in world.
+  /// Use this method to set the transform for a moving base model instead of
+  /// the base class method `setBaseWorldTransform` to ensure that collision
+  /// queries after setting the transform are accurate.
   public: void SetBaseWorldTransform(const btTransform &_pose);
   private: using btMultiBody::setBaseWorldTransform;
 
-  // Update collision transforms if `needsCollisionTransformsUpdate` is set and
-  // reset the flag.
+  /// \brief Update collision transforms if `needsCollisionTransformsUpdate` is
+  /// set and reset the flag.
   public: void UpdateCollisionTransformsIfNeeded();
 
   private: bool needsCollisionTransformsUpdate = false;

--- a/bullet-featherstone/src/FreeGroupFeatures.cc
+++ b/bullet-featherstone/src/FreeGroupFeatures.cc
@@ -167,8 +167,8 @@ void FreeGroupFeatures::SetFreeGroupWorldPose(
   const auto *model = this->ReferenceInterface<ModelInfo>(_groupID);
   if (model)
   {
-    model->body->setBaseWorldTransform(
-        convertTf(_pose * model->baseInertiaToLinkFrame.inverse()));
+    model->body->SetBaseWorldTransform(
+      convertTf(_pose * model->baseInertiaToLinkFrame.inverse()));
 
     model->body->wakeUp();
 

--- a/bullet-featherstone/src/JointFeatures.cc
+++ b/bullet-featherstone/src/JointFeatures.cc
@@ -141,7 +141,7 @@ double JointFeatures::GetJointPosition(
   if (identifier)
   {
     const auto *model = this->ReferenceInterface<ModelInfo>(joint->model);
-    return model->body->getJointPosMultiDof(identifier->indexInBtModel)[_dof];
+    return model->body->GetJointPosForDof(identifier->indexInBtModel, _dof);
   }
 
   // The base joint never really has a position. It is either a Free Joint or
@@ -256,8 +256,7 @@ void JointFeatures::SetJointPosition(
     return;
 
   const auto *model = this->ReferenceInterface<ModelInfo>(joint->model);
-  model->body->getJointPosMultiDof(identifier->indexInBtModel)[_dof] =
-      static_cast<btScalar>(_value);
+  model->body->SetJointPosForDof(identifier->indexInBtModel, _dof, _value);
   model->body->wakeUp();
 }
 

--- a/bullet-featherstone/src/SimulationFeatures.cc
+++ b/bullet-featherstone/src/SimulationFeatures.cc
@@ -44,6 +44,17 @@ void SimulationFeatures::WorldForwardStep(
     stepSize = dt.count();
   }
 
+  // Bullet updates collision transforms *after* forward integration. But in
+  // some case (e.g. if joint positions were updated), collision transforms may
+  // need to be manually updated before stepping the Bullet simulation.
+  for (auto & model: this->models)
+  {
+    if (model.second->body)
+    {
+      model.second->body->UpdateCollisionTransformsIfNeeded();
+    }
+  }
+
   // \todo(iche033) Stepping sim with varying dt may not work properly.
   // One example is the motor constraint that's created in
   // JointFeatures::SetJointVelocityCommand which assumes a fixed step

--- a/bullet-featherstone/src/SimulationFeatures.cc
+++ b/bullet-featherstone/src/SimulationFeatures.cc
@@ -47,7 +47,7 @@ void SimulationFeatures::WorldForwardStep(
   // Bullet updates collision transforms *after* forward integration. But in
   // some case (e.g. if joint positions were updated), collision transforms may
   // need to be manually updated before stepping the Bullet simulation.
-  for (auto & model: this->models)
+  for (auto & model : this->models)
   {
     if (model.second->body)
     {

--- a/test/common_test/collisions.cc
+++ b/test/common_test/collisions.cc
@@ -455,6 +455,9 @@ TEST_F(CollisionStaticTestFeaturesList, StaticCollisions)
 
   for (const std::string &name : this->pluginNames)
   {
+    // TPE does not support collision checking with plane shapes.
+    if (this->PhysicsEngineName(name) == "tpe") continue;
+
     std::cout << "Testing plugin: " << name << std::endl;
     gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
 
@@ -506,6 +509,104 @@ TEST_F(CollisionStaticTestFeaturesList, StaticCollisions)
     // verify there are still no contacts.
     contacts = world->GetContactsFromLastStep();
     EXPECT_EQ(0u, contacts.size());
+  }
+}
+
+TEST_F(CollisionStaticTestFeaturesList, StaticCollisionsWithFixedBaseMovingLink)
+{
+  auto getBoxStr = [](const std::string &_name,
+    const gz::math::Pose3d &_pose)
+  {
+    std::stringstream modelStr;
+    modelStr << R"(
+    <sdf version="1.11">
+      <model name=")";
+    modelStr << _name << R"(">
+        <pose>)";
+    modelStr << _pose;
+    modelStr << R"(</pose>
+        <link name="body" />
+        <joint name="world_fixed" type="fixed">
+          <parent>world</parent>
+          <child>body</child>
+        </joint>
+        <link name="moving1">
+          <collision name="collision">
+            <geometry>
+              <box><size>1 1 1</size></box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="slider" type="prismatic">
+          <parent>body</parent>
+          <child>moving1</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+        <link name="moving2">
+          <pose>2 0 0 0 0 0</pose>
+          <collision name="collision">
+            <geometry>
+              <box><size>1 1 1</size></box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="moving1_fixed" type="fixed">
+          <parent>moving1</parent>
+          <child>moving2</child>
+        </joint>
+      </model>
+    </sdf>)";
+    return modelStr.str();
+  };
+
+  for (const std::string &name : this->pluginNames)
+  {
+    // TPE does not support collision checking with plane shapes.
+    if (this->PhysicsEngineName(name) == "tpe") continue;
+
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    sdf::Root rootWorld;
+    const sdf::Errors errorsWorld =
+        rootWorld.Load(common_test::worlds::kGroundSdf);
+    ASSERT_TRUE(errorsWorld.empty()) << errorsWorld.front();
+
+    auto engine =
+        gz::physics::RequestEngine3d<CollisionStaticFeaturesList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    auto world = engine->ConstructWorld(*rootWorld.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(getBoxStr(
+        "box_fixed_base_moving_links", gz::math::Pose3d::Zero));
+    ASSERT_TRUE(errors.empty()) << errors.front();
+    ASSERT_NE(nullptr, root.Model());
+    world->ConstructModel(*root.Model());
+
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+    world->Step(output, state, input);
+
+    // box_fixed_base_moving_links overlaps with ground plane on both moving1
+    // and moving2 links, verify that contacts are present on both links.
+    auto contacts = world->GetContactsFromLastStep();
+    EXPECT_LE(2u, contacts.size());
+
+    std::unordered_set<std::size_t> collisionIds;
+    using WorldShapeType = gz::physics::World<
+        gz::physics::FeaturePolicy3d, CollisionStaticFeaturesList>;
+    for (const auto &contact: contacts) {
+      const auto &contactPoint = contact.Get<WorldShapeType::ContactPoint>();
+      collisionIds.insert(contactPoint.collision1->EntityID());
+      collisionIds.insert(contactPoint.collision2->EntityID());
+    }
+    EXPECT_EQ(3u, collisionIds.size());
   }
 }
 

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -39,6 +39,7 @@
 #include <gz/physics/ForwardStep.hh>
 #include <gz/physics/FreeGroup.hh>
 #include <gz/physics/FreeJoint.hh>
+#include <gz/physics/GetContacts.hh>
 #include <gz/physics/GetEntities.hh>
 #include <gz/physics/Joint.hh>
 #include <gz/physics/RemoveEntities.hh>
@@ -86,15 +87,18 @@ class JointFeaturesTest:
 };
 
 struct JointFeatureList : gz::physics::FeatureList<
+    gz::physics::FindFreeGroupFeature,
     gz::physics::ForwardStep,
     gz::physics::GetBasicJointProperties,
     gz::physics::GetBasicJointState,
+    gz::physics::GetContactsFromLastStepFeature,
     gz::physics::GetEngineInfo,
     gz::physics::GetJointFromModel,
     gz::physics::GetLinkFromModel,
     gz::physics::GetModelFromWorld,
     gz::physics::LinkFrameSemantics,
     gz::physics::SetBasicJointState,
+    gz::physics::SetFreeGroupWorldPose,
     gz::physics::SetJointVelocityCommandFeature,
     gz::physics::sdf::ConstructSdfWorld
 > { };
@@ -202,6 +206,71 @@ TYPED_TEST(JointFeaturesTest, JointSetCommand)
       auto frameData = base_link->FrameDataRelativeToWorld();
       EXPECT_NEAR(0.0, frameData.pose.translation().z(), 1e-3);
     }
+  }
+}
+
+TYPED_TEST(JointFeaturesTest, JointSetPositionWithContact)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine = gz::physics::RequestEngine3d<JointFeatureList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    sdf::Root root;
+    const sdf::Errors errors = root.Load(
+        common_test::worlds::kPendulumJointWrenchSdf);
+    ASSERT_TRUE(errors.empty()) << errors.front();
+
+    auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    auto model = world->GetModel("pendulum");
+    ASSERT_NE(nullptr, model);
+    auto motorJoint = model->GetJoint("motor_joint");
+    ASSERT_NE(nullptr, motorJoint);
+
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+
+    world->Step(output, state, input);
+    auto contacts = world->GetContactsFromLastStep();
+    const std::size_t numInitialContacts = contacts.size();
+
+    // Place box such that it is in collision with the pendulum arm at joint
+    // position 0.
+    auto box = world->GetModel("box");
+    ASSERT_NE(nullptr, box);
+    auto boxFreeGroup = box->FindFreeGroup();
+    ASSERT_NE(nullptr, boxFreeGroup);
+    gz::physics::Pose3d X_WB(Eigen::Translation3d(0.5, 0, 0.65));
+    boxFreeGroup->SetWorldPose(X_WB);
+
+    world->Step(output, state, input);
+    contacts = world->GetContactsFromLastStep();
+    EXPECT_LT(numInitialContacts, contacts.size());
+
+    // Move pendulum away from box.
+    motorJoint->SetPosition(0, GZ_DTOR(90.0));
+
+    world->Step(output, state, input);
+    contacts = world->GetContactsFromLastStep();
+    EXPECT_EQ(numInitialContacts, contacts.size());
+
+    // Step until pendulum falls and rests again on the box.
+    for (int i = 0; i < 1000; ++i)
+    {
+      world->Step(output, state, input);
+    }
+
+    // Sanity check that the pendulum is at rest
+    EXPECT_NEAR(0.0, motorJoint->GetVelocity(0), 1e-3);
+
+    contacts = world->GetContactsFromLastStep();
+    EXPECT_LT(numInitialContacts, contacts.size());
   }
 }
 

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -266,8 +266,9 @@ TYPED_TEST(JointFeaturesTest, JointSetPositionWithContact)
       world->Step(output, state, input);
     }
 
-    // Sanity check that the pendulum is at rest
-    EXPECT_NEAR(0.0, motorJoint->GetVelocity(0), 1e-3);
+    // Sanity check that the pendulum is at rest. A small non-zero threshold is
+    // set to accommodate small joint velocity due to error reduction.
+    EXPECT_NEAR(0.0, motorJoint->GetVelocity(0), 2e-3);
 
     contacts = world->GetContactsFromLastStep();
     EXPECT_LT(numInitialContacts, contacts.size());

--- a/test/common_test/world_features.cc
+++ b/test/common_test/world_features.cc
@@ -95,14 +95,12 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     EXPECT_TRUE(engine->GetName().find(this->PhysicsEngineName(name)) !=
                 std::string::npos);
 
-    std::cout << "Here1 " << name << std::endl;
     sdf::Root root;
     const sdf::Errors errors = root.Load(common_test::worlds::kFallingWorld);
     EXPECT_TRUE(errors.empty()) << errors;
     const sdf::World *sdfWorld = root.WorldByIndex(0);
     EXPECT_NE(nullptr, sdfWorld);
 
-    std::cout << "Here2 " << name << std::endl;
     auto world = engine->ConstructWorld(*root.WorldByIndex(0));
     EXPECT_NE(nullptr, world);
 
@@ -115,7 +113,6 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     EXPECT_PRED_FORMAT2(vectorPredicate, gravity,
                         world->GetGravity());
 
-    std::cout << "Here3 " << name << std::endl;
     world->SetGravity({8, 4, 3});
     EXPECT_PRED_FORMAT2(vectorPredicate, Eigen::Vector3d(8, 4, 3),
                         world->GetGravity());
@@ -134,7 +131,6 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     auto linkNoGravity = modelNoGravity->GetLink(0);
     ASSERT_NE(nullptr, linkNoGravity);
 
-    std::cout << "Here4 " << name << std::endl;
     AssertVectorApprox vectorPredicate6(1e-6);
 
     // initial link pose
@@ -160,7 +156,6 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
                         Eigen::Vector3d(1, 0, -1),
                         world->GetGravity());
 
-    std::cout << "Here5 " << name << std::endl;
     // test other SetGravity API
     // set gravity along Z axis of linked frame, which is pitched by pi/4
     gz::physics::RelativeForce3d relativeGravity(
@@ -176,14 +171,12 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     gz::physics::ForwardStep::State state;
     gz::physics::ForwardStep::Output output;
 
-    std::cout << "Here6 " << name << std::endl;
     const size_t numSteps = 1000;
     for (size_t i = 0; i < numSteps; ++i)
     {
       world->Step(output, state, input);
     }
 
-    std::cout << "Here7 " << name << std::endl;
     AssertVectorApprox vectorPredicate2(1e-2);
     {
       Eigen::Vector3d pos = link->FrameDataRelativeToWorld().pose.translation();

--- a/test/common_test/world_features.cc
+++ b/test/common_test/world_features.cc
@@ -95,12 +95,14 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     EXPECT_TRUE(engine->GetName().find(this->PhysicsEngineName(name)) !=
                 std::string::npos);
 
+    std::cout << "Here1 " << name << std::endl;
     sdf::Root root;
     const sdf::Errors errors = root.Load(common_test::worlds::kFallingWorld);
     EXPECT_TRUE(errors.empty()) << errors;
     const sdf::World *sdfWorld = root.WorldByIndex(0);
     EXPECT_NE(nullptr, sdfWorld);
 
+    std::cout << "Here2 " << name << std::endl;
     auto world = engine->ConstructWorld(*root.WorldByIndex(0));
     EXPECT_NE(nullptr, world);
 
@@ -113,6 +115,7 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     EXPECT_PRED_FORMAT2(vectorPredicate, gravity,
                         world->GetGravity());
 
+    std::cout << "Here3 " << name << std::endl;
     world->SetGravity({8, 4, 3});
     EXPECT_PRED_FORMAT2(vectorPredicate, Eigen::Vector3d(8, 4, 3),
                         world->GetGravity());
@@ -131,6 +134,7 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     auto linkNoGravity = modelNoGravity->GetLink(0);
     ASSERT_NE(nullptr, linkNoGravity);
 
+    std::cout << "Here4 " << name << std::endl;
     AssertVectorApprox vectorPredicate6(1e-6);
 
     // initial link pose
@@ -156,6 +160,7 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
                         Eigen::Vector3d(1, 0, -1),
                         world->GetGravity());
 
+    std::cout << "Here5 " << name << std::endl;
     // test other SetGravity API
     // set gravity along Z axis of linked frame, which is pitched by pi/4
     gz::physics::RelativeForce3d relativeGravity(
@@ -171,12 +176,14 @@ TEST_F(WorldFeaturesTestGravity, GravityFeatures)
     gz::physics::ForwardStep::State state;
     gz::physics::ForwardStep::Output output;
 
+    std::cout << "Here6 " << name << std::endl;
     const size_t numSteps = 1000;
     for (size_t i = 0; i < numSteps; ++i)
     {
       world->Step(output, state, input);
     }
 
+    std::cout << "Here7 " << name << std::endl;
     AssertVectorApprox vectorPredicate2(1e-2);
     {
       Eigen::Vector3d pos = link->FrameDataRelativeToWorld().pose.translation();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes three issues in bullet-featherstone plugin:
1. After calling `SetPosition` to set a joint position, incorrect collision transforms are used in the next forward step
2. After calling `SetWorldPose` to set the pose of a FreeGroup, incorrect collision transforms are used in the next forward step
3. Collisions are ignored between a static object and any link on a fixed-base model that is a child of a fixed joint

## Summary
Added a `GzMultiBody` wrapper for `btMultiBody` to ensure that a flag is set whenever joint position is set or base transform is set indicating that collision transforms need to be updated. Then collision transforms are updated in the next forward step for any body which has the flag set, and the flag is reset.

For bug 3 above, I updated `SDFFeatures::CreateLinkCollider` to check the total dofs for a link on a fixed-base model, counting from the base, rather than just the dofs for the parent joint.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
