### PR TITLE
Suppress -Wreturn-type warning from octomap

### DIFF
--- a/dartsim/src/WorldFeatures.cc
+++ b/dartsim/src/WorldFeatures.cc
@@ -20,7 +20,16 @@
 
 #include <dart/collision/bullet/BulletCollisionDetector.hpp>
 #include <dart/collision/dart/DARTCollisionDetector.hpp>
+
+// Suppressing a -Wreturn-type warning in octomap
+// https://github.com/OctoMap/octomap/issues/431
+#include <gz/utils/SuppressWarning.hh>
+#ifndef _MSC_VER
+DETAIL_GZ_UTILS_BEGIN_WARNING_SUPPRESSION("-Wreturn-type")
 #include <dart/collision/fcl/FCLCollisionDetector.hpp>
+DETAIL_GZ_UTILS_WARN_RESUME
+#endif  // _MSC_VER
+
 #include <dart/constraint/BoxedLcpConstraintSolver.hpp>
 #include <dart/constraint/ConstraintSolver.hpp>
 #include <dart/constraint/DantzigBoxedLcpSolver.hpp>

--- a/dartsim/src/WorldFeatures.cc
+++ b/dartsim/src/WorldFeatures.cc
@@ -26,7 +26,9 @@
 #include <gz/utils/SuppressWarning.hh>
 #ifndef _MSC_VER
 DETAIL_GZ_UTILS_BEGIN_WARNING_SUPPRESSION("-Wreturn-type")
+#endif  // _MSC_VER
 #include <dart/collision/fcl/FCLCollisionDetector.hpp>
+#ifndef _MSC_VER
 DETAIL_GZ_UTILS_WARN_RESUME
 #endif  // _MSC_VER
 

--- a/test/plugins/DARTDoublePendulum.cc
+++ b/test/plugins/DARTDoublePendulum.cc
@@ -18,7 +18,15 @@
 #include <memory>
 #include <unordered_map>
 
+// Suppressing a -Wreturn-type warning in octomap
+// https://github.com/OctoMap/octomap/issues/431
+#include <gz/utils/SuppressWarning.hh>
+#ifndef _MSC_VER
+DETAIL_GZ_UTILS_BEGIN_WARNING_SUPPRESSION("-Wreturn-type")
 #include <dart/dart.hpp>
+DETAIL_GZ_UTILS_WARN_RESUME
+#endif  // _MSC_VER
+
 #include <dart/utils/utils.hpp>
 #include <dart/utils/urdf/urdf.hpp>
 

--- a/test/plugins/DARTDoublePendulum.cc
+++ b/test/plugins/DARTDoublePendulum.cc
@@ -18,15 +18,11 @@
 #include <memory>
 #include <unordered_map>
 
-// Suppressing a -Wreturn-type warning in octomap
-// https://github.com/OctoMap/octomap/issues/431
-#include <gz/utils/SuppressWarning.hh>
-#ifndef _MSC_VER
-DETAIL_GZ_UTILS_BEGIN_WARNING_SUPPRESSION("-Wreturn-type")
-#include <dart/dart.hpp>
-DETAIL_GZ_UTILS_WARN_RESUME
-#endif  // _MSC_VER
-
+#include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/Joint.hpp>
+#include <dart/dynamics/Skeleton.hpp>
+#include <dart/dynamics/SmartPointer.hpp>
+#include <dart/simulation/World.hpp>
 #include <dart/utils/utils.hpp>
 #include <dart/utils/urdf/urdf.hpp>
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes macOS CI

## Summary

There are compiler warnings coming from octomap on homebrew when compiling dartsim. The warning has been reported upstream at https://github.com/OctoMap/octomap/issues/431. For now suppress the warning.

This is a little messy since it uses macros defined in the `gz/utils/detail/` folder instead of the official API in `gz/utils/SuppressWarning.hh`, but there is currently no supported macro for suppressing this type of warning. I'll open a feature request in gz-utils to provide more flexible macros.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
