### PR TITLE
Fix two warnings in gz_physics-main-cnlwin

### DIFF
--- a/dartsim/src/SimulationFeatures.hh
+++ b/dartsim/src/SimulationFeatures.hh
@@ -44,7 +44,7 @@ namespace dart
 {
 namespace collision
 {
-class Contact;
+struct Contact;
 }
 }
 

--- a/test/integration/DoublePendulum.cc
+++ b/test/integration/DoublePendulum.cc
@@ -113,7 +113,7 @@ void DoublePendulum_TEST(gz::plugin::PluginPtr _plugin)
   gz::math::PID pid0(100, 0, 10);
   gz::math::PID pid1(10, 0, 5);
   const std::chrono::duration<double> settleTime(std::chrono::seconds(4));
-  unsigned int settleSteps = settleTime / dt;
+  unsigned int settleSteps = static_cast<unsigned int>(settleTime / dt);
   for (unsigned int i = 0; i < settleSteps; ++i)
   {
     auto positions = output.Get<JointPositions>();


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes windows warnings appearing in: https://build.osrfoundation.org/job/gz_physics-main-cnlwin/1/msbuild/

## Summary
Small C++ linter kind of fixes.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
