### PR TITLE
Remove symlink loops in engine-plugins

### DIFF
--- a/bullet-featherstone/CMakeLists.txt
+++ b/bullet-featherstone/CMakeLists.txt
@@ -26,3 +26,8 @@ target_link_libraries(${bullet_plugin}
 
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${bullet_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
+
+if (WIN32)
+  # disable MSVC inherit via dominance warning
+  target_compile_options(${bullet_plugin} PUBLIC "/wd4250")
+endif()

--- a/bullet-featherstone/CMakeLists.txt
+++ b/bullet-featherstone/CMakeLists.txt
@@ -26,19 +26,3 @@ target_link_libraries(${bullet_plugin}
 
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${bullet_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
-
-# The library created by `gz_add_component` includes the ign-physics version
-# (i.e. libgz-physics1-name-plugin.so), but for portability,
-# we also install an unversioned symlink into the same versioned folder.
-set(versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${bullet_plugin}${CMAKE_SHARED_LIBRARY_SUFFIX})
-set(unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
-if (WIN32)
-  # disable MSVC inherit via dominance warning
-  target_compile_options(${bullet_plugin} PUBLIC "/wd4250")
-  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned}
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${unversioned})")
-else()
-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
-endif()

--- a/bullet/CMakeLists.txt
+++ b/bullet/CMakeLists.txt
@@ -26,19 +26,3 @@ target_link_libraries(${bullet_plugin}
 
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${bullet_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
-
-# The library created by `gz_add_component` includes the gz-physics version
-# (i.e. libgz-physics1-name-plugin.so), but for portability,
-# we also install an unversioned symlink into the same versioned folder.
-set(versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${bullet_plugin}${CMAKE_SHARED_LIBRARY_SUFFIX})
-set(unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
-if (WIN32)
-  # disable MSVC inherit via dominance warning
-  target_compile_options(${bullet_plugin} PUBLIC "/wd4250")
-  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned}
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${unversioned})")
-else()
-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
-endif()

--- a/bullet/CMakeLists.txt
+++ b/bullet/CMakeLists.txt
@@ -26,3 +26,8 @@ target_link_libraries(${bullet_plugin}
 
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${bullet_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
+
+if (WIN32)
+  # disable MSVC inherit via dominance warning
+  target_compile_options(${bullet_plugin} PUBLIC "/wd4250")
+endif()

--- a/dartsim/CMakeLists.txt
+++ b/dartsim/CMakeLists.txt
@@ -57,6 +57,11 @@ endif()
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${dartsim_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
 
+if (WIN32)
+  # disable MSVC inherit via dominance warning
+  target_compile_options(${dartsim_plugin} PUBLIC "/wd4250")
+endif()
+
 # Testing
 gz_build_tests(
   TYPE UNIT

--- a/dartsim/CMakeLists.txt
+++ b/dartsim/CMakeLists.txt
@@ -57,22 +57,6 @@ endif()
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${dartsim_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
 
-# The library created by `gz_add_component` includes the gz-physics version
-# (i.e. libgz-physics1-name-plugin.so), but for portability,
-# we also install an unversioned symlink into the same versioned folder.
-set(versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${dartsim_plugin}${CMAKE_SHARED_LIBRARY_SUFFIX})
-set(unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
-if (WIN32)
-  # disable MSVC inherit via dominance warning
-  target_compile_options(${dartsim_plugin} PUBLIC "/wd4250")
-  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned}
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${unversioned})")
-else()
-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
-endif()
-
 # Testing
 gz_build_tests(
   TYPE UNIT

--- a/tpe/plugin/CMakeLists.txt
+++ b/tpe/plugin/CMakeLists.txt
@@ -34,6 +34,11 @@ target_link_libraries(${tpe_plugin}
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${tpe_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
 
+if (WIN32)
+  # disable MSVC inherit via dominance warning
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
+endif()
+
 gz_build_tests(
   TYPE UNIT_tpe
   SOURCES ${test_sources}

--- a/tpe/plugin/CMakeLists.txt
+++ b/tpe/plugin/CMakeLists.txt
@@ -34,22 +34,6 @@ target_link_libraries(${tpe_plugin}
 # Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
 install(TARGETS ${tpe_plugin} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
 
-# The library created by `gz_add_component` includes the gz-physics version
-# (i.e. libgz-physics1-name-plugin.so), but for portability,
-# we also install an unversioned symlink into the same versioned folder.
-set(versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${tpe_plugin}${CMAKE_SHARED_LIBRARY_SUFFIX})
-set(unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
-if (WIN32)
-  # disable MSVC inherit via dominance warning
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
-  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned}
-      ${GZ_PHYSICS_ENGINE_INSTALL_DIR}\/${unversioned})")
-else()
-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR})
-endif()
-
 gz_build_tests(
   TYPE UNIT_tpe
   SOURCES ${test_sources}


### PR DESCRIPTION
# 🦟 Bug fix

Fixes gz-sim test failures with PR chain in https://github.com/gazebosim/gz-sim/pull/2910, part of https://github.com/gazebo-tooling/release-tools/issues/1309

## Summary

When testing the remaining Jetty version bumps (such as https://github.com/gazebosim/gz-sim/pull/2910), I ran a colcon build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ci__colcon_any-manual_ubuntu_noble_amd64&build=34)](https://build.osrfoundation.org/job/ci__colcon_any-manual_ubuntu_noble_amd64/34/) https://build.osrfoundation.org/job/ci__colcon_any-manual_ubuntu_noble_amd64/34/

and noticed two gz-sim test failures in particular the seem related to symlinked physics plugins:

* [INTEGRATION_pose_publisher_system](https://build.osrfoundation.org/job/ci__colcon_any-manual_ubuntu_noble_amd64/34/testReport/projectroot.test/integration/INTEGRATION_pose_publisher_system/)
* [INTEGRATION_save_world](https://build.osrfoundation.org/job/ci__colcon_any-manual_ubuntu_noble_amd64/34/testReport/projectroot.test/integration/INTEGRATION_save_world/)

In both cases:

~~~
[ RUN      ] PosePublisherTest.NestedModelLoadPlugin
(2025-05-17 19:47:41.276) [info] [ServerPrivate.cc:656] Loading SDF world file[/tmp/ws/src/gz-sim/test/worlds/nested_model.sdf].
(2025-05-17 19:47:41.344) [info] [SystemManager.cc:54] Serving entity system service on [/entity/system/add]
unknown file: Failure
C++ exception with description "filesystem error: status: Too many levels of symbolic links [/tmp/ws/install_isolated/gz-physics/lib/gz-physics-9/engine-plugins/libgz-physics-tpe-plugin.so]" thrown in the test body.
[  FAILED  ] PosePublisherTest.NestedModelLoadPlugin (102 ms)
~~~

Since there are no more versioned libraries, we should just remove these symlinks.

I will start a colcon build including this branch after confirming it doesn't break this package's CI.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
