### PR TITLE
BallJoint: apply axis properties to ball joints

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -249,11 +249,11 @@ static dart::dynamics::UniversalJoint *ConstructUniversalJoint(
 /////////////////////////////////////////////////
 template <typename JointType>
 static JointType *ConstructBallJoint(
-    const ModelInfo &_modelInfo,
+    const ModelInfo &/*_modelInfo*/,
     const ::sdf::Joint &_sdfJoint,
     dart::dynamics::BodyNode * const _parent,
     dart::dynamics::BodyNode * const _child,
-    const Eigen::Isometry3d &_T_joint)
+    const Eigen::Isometry3d &/*_T_joint*/)
 {
   // SDF does not support any of the properties for ball joint, besides the
   // name and relative transforms to its parent and child.

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -18,6 +18,7 @@
 #include "SDFFeatures.hh"
 
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <memory>
 #include <string>

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -17,6 +17,7 @@
 
 #include <type_traits>
 
+#include <dart/dynamics/BallJoint.hpp>
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/DegreeOfFreedom.hpp>
 #include <dart/dynamics/FreeJoint.hpp>
@@ -417,6 +418,14 @@ TEST_P(SDFFeatures_TEST, CheckDartsimData)
       screwJointTest->getJoint(1));
   ASSERT_NE(nullptr, screwJoint);
   EXPECT_DOUBLE_EQ(-GZ_PI, screwJoint->getPitch());
+
+  const dart::dynamics::SkeletonPtr ballJointTest =
+      dartWorld->getSkeleton("ball_joint_test");
+  ASSERT_NE(nullptr, ballJointTest);
+  ASSERT_EQ(2u, ballJointTest->getNumBodyNodes());
+  const auto *ballJoint = dynamic_cast<const dart::dynamics::BallJoint*>(
+      ballJointTest->getJoint(1));
+  ASSERT_NE(nullptr, ballJoint);
 }
 
 /////////////////////////////////////////////////

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -322,7 +322,7 @@ TEST_P(SDFFeatures_TEST, CheckDartsimData)
   dart::simulation::WorldPtr dartWorld = world->GetDartsimWorld();
   ASSERT_NE(nullptr, dartWorld);
 
-  ASSERT_EQ(8u, dartWorld->getNumSkeletons());
+  ASSERT_EQ(9u, dartWorld->getNumSkeletons());
 
   const dart::dynamics::SkeletonPtr skeleton = dartWorld->getSkeleton(1);
   ASSERT_NE(nullptr, skeleton);

--- a/test/common_test/worlds/test.world
+++ b/test/common_test/worlds/test.world
@@ -358,6 +358,17 @@
         <thread_pitch>2</thread_pitch>
       </joint>
     </model>
+    <model name="ball_joint_test">
+      <link name="link0"/>
+      <link name="link1"/>
+      <joint name="j0" type="ball">
+        <parent>link0</parent>
+        <child>link1</child>
+        <axis>
+          <damping>0.1</damping>
+        </axis>
+      </joint>
+    </model>
     <!-- Remove joint types as they get supported -->
     <model name="unsupported_joint_test">
       <link name="link0"/>

--- a/test/common_test/worlds/test.world
+++ b/test/common_test/worlds/test.world
@@ -464,7 +464,7 @@
             <ambient>1 1 0 1</ambient>
           </material>
         </visual>
-      
+
         <visual name="vis_cylinder">
           <pose>0 0 0.5 0 0 0</pose>
           <geometry>
@@ -493,7 +493,7 @@
             </friction>
           </surface>
         </collision>
-    
+
         <collision name="col_cylinder">
           <pose>0 0 0.5 0 0 0</pose>
           <geometry>
@@ -504,7 +504,7 @@
           </geometry>
         </collision>
       </link>
-      
+
       <!-- pin joint for upper link, at origin of upper link -->
       <joint name="upper_joint" type="revolute">
         <parent>base</parent>
@@ -513,7 +513,7 @@
           <xyz>1.0 0 0</xyz>
         </axis>
       </joint>
-     
+
     </model>
   </world>
 </sdf>

--- a/tpe/plugin/src/SDFFeatures_TEST.cc
+++ b/tpe/plugin/src/SDFFeatures_TEST.cc
@@ -96,7 +96,7 @@ TEST(SDFFeatures_TEST, CheckTpeData)
   auto tpeWorld = world.GetTpeLibWorld();
   ASSERT_NE(nullptr, tpeWorld);
 
-  ASSERT_EQ(8u, tpeWorld->GetChildCount());
+  ASSERT_EQ(9u, tpeWorld->GetChildCount());
 
   // check model 01
   {


### PR DESCRIPTION
# 🎉 New feature

Closes #634

## Summary

Allow joint properties to be applied to ball joints in the dart sim physics engine.

As suggested in https://github.com/gazebosim/gz-physics/issues/634, the properties from the first `<axis>` field in the ball joint are applied to all DoF if this element is set. Otherwise the defaults are used, which is current behaviour.

## Test it

- Add an `<axis>` element to a model using a ball joint and set some of the properties (eg. `<limit>`).
- Prior to the change the property would have no effect, after the change the joint range should be restricted.

### Example: `wind.sdf`

- Modify the `wind.sdf` model to include `<axis>` elements for each sphere restricting the movement:

```xml
     <joint name="sphere_1_joint" type="ball">
        <parent>roof</parent>
        <child>sphere_1</child>
        <axis>
          <limit>
            <lower>0</lower>
            <upper>0</upper>
          </limit>
          <dynamics>
            <damping>0.01</damping>
          </dynamics>
        </axis>
      </joint>
 ```

_Figure: Expected `wind.sdf` behaviour with ball joint limit. Wind sock does not move._
![ball_joint_with_limit](https://github.com/user-attachments/assets/5e52458d-51de-4bc2-8d79-c92bdd98eec8)

The motivation for this change is to stabilise a complex closed kinematic chain mechanism employing multiple ball joints (a helicopter rotor head). Without this change the simulation is not stable, and the joints vibrated so badly the simulated model does not maintain integrity (companion change to adjust the dynamic joint erp and cfm properties is also required to get satisfactory behaviour. That is be the subject of the follow up PRs:

- https://github.com/gazebosim/gz-physics/pull/754
- https://github.com/gazebosim/gz-sim/pull/2960

_Figure: Application of ball joint properties to a helicopter rotor head demonstrating swash plate collective and cyclic operation_.

![heli_flapping_blades_1](https://github.com/user-attachments/assets/85622b65-999c-4925-b5d2-9823b8375546)


- [ ] Add test

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.