### PR TITLE
[Bazel] Fix missing symbol for getEngineInstallDir

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,7 +58,6 @@ sources = glob(
     ],
     exclude = [
         "src/*_TEST.cc",
-        "src/InstallationDirectories.cc",
     ],
 )
 
@@ -72,6 +71,7 @@ cc_library(
     name = "gz-physics",
     srcs = sources,
     hdrs = public_headers,
+    defines = ["GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR='\"\"'"],
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes a downstream linker error in gz-sim when building the physics system, which uses the `getEngineInstallDir` method as a fallback to find the physics engine plugin lib. The `getEngineInstallDir` method is implemented in `src/InstallationDirectories.cc`, so it needs to be included under `srcs` in the `gz-physics` library target.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
