### PR TITLE
Add support for loading physics engine plugins from the static plugin registry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,10 +4,12 @@ module(
     repo_name = "org_gazebosim_gz-physics",
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "bullet", version = "3.26.0-rc0")
 bazel_dep(name = "dartsim", version = "6.13.2")
 bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "bullet", version = "3.26.0-rc0")
-bazel_dep(name = "dartsim", version = "6.13.2")
+bazel_dep(name = "dartsim", version = "6.13.2.bcr.1")
 bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "rules",
+    srcs = ["gz_physics_plugin_libraries.bzl"],
+    visibility = ["//:__subpackages__"],
+)

--- a/bazel/gz_physics_plugin_libraries.bzl
+++ b/bazel/gz_physics_plugin_libraries.bzl
@@ -12,8 +12,8 @@ def _generate_static_plugin_src_impl(ctx):
             "GZ_PHYSICS_ADD_PLUGIN": "GZ_PHYSICS_ADD_STATIC_PLUGIN",
             "GZ_PHYSICS_ADD_PLUGIN_ALIAS": "GZ_PHYSICS_ADD_STATIC_PLUGIN_ALIAS",
             # Header substitutions:
-            # "plugin/Register.hh": "plugin/RegisterStatic.hh",
-            # "plugin/RegisterMore.hh": "plugin/RegisterStatic.hh",
+            "gz/physics/Register.hh": "gz/physics/RegisterStatic.hh",
+            "gz/physics/RegisterMore.hh": "gz/physics/RegisterStatic.hh",
         },
     )
 
@@ -42,15 +42,9 @@ def gz_physics_plugin_libraries(static_lib_name, so_lib_name, srcs, includes = [
         so_lib_name: Name of the `cc_binary` shared library target which can be
           loaded at runtime. Set this to empty string if the shared library
           target should not be added.
-        srcs: List of source files including private headers. For example, this
-          can be a globbed list of *.cc and *.hh files.
+        srcs: List of source files including private headers. For example:
           ```
-          srcs = glob(
-              [
-                  "dartsim/src/*.cc",
-                  "dartsim/src/*.hh",
-              ],
-          ),
+          srcs = glob(["src/*.hh"] + ["src/plugin.cc"],
           ```
           Any test files should be excluded and can be added to separate
            `cc_test` targets.

--- a/bazel/gz_physics_plugin_libraries.bzl
+++ b/bazel/gz_physics_plugin_libraries.bzl
@@ -1,0 +1,110 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+visibility("public")
+
+def _generate_static_plugin_src_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.plugin_cc,
+        output = ctx.outputs.out,
+        substitutions = {
+            # Macro substitutions:
+            "GZ_PHYSICS_ADD_PLUGIN": "GZ_PHYSICS_ADD_STATIC_PLUGIN",
+            "GZ_PHYSICS_ADD_PLUGIN_ALIAS": "GZ_PHYSICS_ADD_STATIC_PLUGIN_ALIAS",
+            # Header substitutions:
+            # "plugin/Register.hh": "plugin/RegisterStatic.hh",
+            # "plugin/RegisterMore.hh": "plugin/RegisterStatic.hh",
+        },
+    )
+
+# This rule performs a substitution to link the plugin class to the static
+# plugin registry instead of the plugin hook registry for dynamic loading.
+_generate_static_plugin_src = rule(
+    attrs = {
+        "plugin_cc": attr.label(allow_single_file = True, mandatory = True),
+        "out": attr.output(mandatory = True),
+    },
+    implementation = _generate_static_plugin_src_impl,
+)
+
+def gz_physics_plugin_libraries(static_lib_name, so_lib_name, srcs, includes = [], **kwargs):
+    """
+    Adds two library targets for the physics plugin for static and dynamic loading respectively
+
+    Args:
+        static_lib_name: Name of the `cc_library` target with static linking.
+          Note that the plugin registration macro is substituted with
+          `GZ_ADD_STATIC_PLUGIN` in the source file for this target to register
+          the plugin with the static registry.
+          The `alwayslink` attribute of this target is set to True, so that
+          downstream linking preserves symbols which are not referenced
+          explicitly.
+        so_lib_name: Name of the `cc_binary` shared library target which can be
+          loaded at runtime. Set this to empty string if the shared library
+          target should not be added.
+        srcs: List of source files including private headers. For example, this
+          can be a globbed list of *.cc and *.hh files.
+          ```
+          srcs = glob(
+              [
+                  "dartsim/src/*.cc",
+                  "dartsim/src/*.hh",
+              ],
+          ),
+          ```
+          Any test files should be excluded and can be added to separate
+           `cc_test` targets.
+        includes: List of include dirs to be added to the `cc_library` and
+          `cc_binary` targets
+        **kwargs: Forwarded to both the `cc_library` and `cc_binary` targets.
+    """
+    if not static_lib_name:
+        fail("The static_lib_name field must be non-empty.")
+
+    supported_cc_extensions = ["cc", "cpp"]
+    cc_files = [f for f in srcs if f.split(".")[-1] in supported_cc_extensions]
+    non_cc_files = [f for f in srcs if f not in cc_files]
+
+    if not cc_files:
+        fail("Did not find any .cc files in the provided srcs for library with static_lib_name '", static_lib_name, "'.")
+
+    plugin_dir = "/".join(cc_files[0].split("/")[:-1])
+
+    # Run the _generate_static_plugin_src rule to generate modified source files
+    # suitable for registering the physics plugin(s) with the static plugin
+    # registry. Ideally the rule only needs to be run on source files which
+    # register System plugins with the GZ_PHYSICS_ADD_PLUGIN macro. However, in the
+    # bazel analysis phase, there is no way to determine whether a particular
+    # .cc file registers a physics plugin or not. To circumvent this limitation,
+    # the _generate_static_plugin_src rule is simply run for all source files.
+    # This has a very small overhead of writing out the original file as is into
+    # a new source file for the input source files which do not register a
+    # System plugin.
+    static_cc_files = []
+    for cc_file in cc_files:
+        name_without_extension = ".".join(cc_file.split(".")[:-1])
+        static_plugin_src_gen_without_extension = name_without_extension + "_static_plugin"
+        static_plugin_src_gen = static_plugin_src_gen_without_extension + ".cc"
+        _generate_static_plugin_src(
+            name = static_plugin_src_gen_without_extension,
+            plugin_cc = cc_file,
+            out = static_plugin_src_gen,
+        )
+        static_cc_files.append(static_plugin_src_gen)
+
+    cc_library(
+        name = static_lib_name,
+        alwayslink = True,
+        includes = includes + [plugin_dir],
+        srcs = non_cc_files + static_cc_files,
+        **kwargs
+    )
+
+    if so_lib_name:
+        cc_binary(
+            name = so_lib_name,
+            linkshared = True,
+            includes = includes,
+            srcs = srcs,
+            **kwargs
+        )

--- a/bullet-featherstone/BUILD.bazel
+++ b/bullet-featherstone/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
+load("//bazel:gz_physics_plugin_libraries.bzl", "gz_physics_plugin_libraries")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -51,10 +52,10 @@ cc_library(
     ],
 )
 
-cc_binary(
-    name = "libgz-physics-bullet-featherstone-plugin.so",
+gz_physics_plugin_libraries(
     srcs = ["src/plugin.cc"] + private_headers,
-    linkshared = True,
+    so_lib_name = "libgz-physics-bullet-featherstone-plugin.so",
+    static_lib_name = "libgz-physics-bullet-featherstone-plugin-static",
     visibility = ["//visibility:public"],
     deps = [
         ":bullet-featherstone",

--- a/bullet/BUILD.bazel
+++ b/bullet/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
+load("//bazel:gz_physics_plugin_libraries.bzl", "gz_physics_plugin_libraries")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -49,10 +50,10 @@ cc_library(
     ],
 )
 
-cc_binary(
-    name = "libgz-physics-bullet-plugin.so",
+gz_physics_plugin_libraries(
     srcs = ["src/plugin.cc"] + private_headers,
-    linkshared = True,
+    so_lib_name = "libgz-physics-bullet-plugin.so",
+    static_lib_name = "libgz-physics-bullet-plugin-static",
     visibility = ["//visibility:public"],
     deps = [
         ":bullet",

--- a/dartsim/BUILD.bazel
+++ b/dartsim/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
+load("//bazel:gz_physics_plugin_libraries.bzl", "gz_physics_plugin_libraries")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -67,13 +68,13 @@ cc_library(
     ],
 )
 
-cc_binary(
-    name = "libgz-physics-dartsim-plugin.so",
+gz_physics_plugin_libraries(
     srcs = ["src/plugin.cc"] + private_headers,
+    so_lib_name = "libgz-physics-dartsim-plugin.so",
+    static_lib_name = "libgz-physics-dartsim-plugin-static",
     defines = [
         "BAZEL_DARTSIM_DISABLE_UNREGISTER_COLLISION_DETECTORS",
     ],
-    linkshared = True,
     visibility = ["//visibility:public"],
     deps = [
         ":dartsim",

--- a/include/gz/physics/RegisterStatic.hh
+++ b/include/gz/physics/RegisterStatic.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_REGISTER_STATIC_HH_
+#define GZ_PHYSICS_REGISTER_STATIC_HH_
+
+#include <gz/physics/detail/RegisterStatic.hh>
+#include <gz/physics/Implements.hh>
+
+// -------------------- Add a physics engine plugin ------------------------
+
+/// \brief Add a plugin that can be used as physics engine to the static plugin
+/// registry.
+///
+/// 1. The first argument is the name of the class that wraps the physics engine
+///    into a plugin.
+/// 2. The second argument is the Feature Policy for this plugin,
+///    e.g. gz::physics::FeaturePolicy3d
+/// 3. The third argument is the Feature List, specifying all the features that
+///    this plugin provides,
+///    e.g. gz::physics::StandardFeatures
+///
+/// Note that the Feature Policy and Feature List should match the types that
+/// you pass to the gz::physics::Implements<P, L> that your plugin class
+/// inherits.
+#define GZ_PHYSICS_ADD_STATIC_PLUGIN(PluginType, FeaturePolicyT, FeatureListT) \
+  DETAIL_GZ_PHYSICS_ADD_STATIC_PLUGIN(PluginType, FeaturePolicyT, FeatureListT)
+
+#endif

--- a/include/gz/physics/detail/RegisterStatic.hh
+++ b/include/gz/physics/detail/RegisterStatic.hh
@@ -31,13 +31,13 @@ namespace gz
     {
       template <typename PluginT, typename FeaturePolicyT,
                 typename FeatureListOrTuple>
-      struct Registrar;
+      struct StaticRegistrar;
 
       template <typename PluginT, typename FeaturePolicyT,
                 typename FeatureListT>
-      struct Registrar
+      struct StaticRegistrar
       {
-        static void StaticRegisterPlugin()
+        static void RegisterPlugin()
         {
           StaticRegistrar<PluginT, FeaturePolicyT,
               typename FeatureListT::Features>::RegisterPlugin();
@@ -48,7 +48,7 @@ namespace gz
                 typename... Features>
       struct StaticRegistrar<PluginT, FeaturePolicyT, std::tuple<Features...>>
       {
-        static void StaticRegisterPlugin()
+        static void RegisterPlugin()
         {
           gz::plugin::detail::StaticRegistrar<
                 PluginT, Feature::Implementation<FeaturePolicyT>,
@@ -70,17 +70,17 @@ namespace gz
   { \
   namespace \
   { \
-    struct ExecuteWhenLoadingLibrary##UniqueID \
+    struct RegisterStaticPlugin##UniqueID \
     { \
-      ExecuteWhenLoadingLibrary##UniqueID() \
+      RegisterStaticPlugin##UniqueID() \
       { \
         ::gz::physics::detail::StaticRegistrar< \
             PluginType, FeaturePolicyT, FeatureListT>:: \
-            StaticRegisterPlugin(); \
+            RegisterPlugin(); \
       } \
     }; \
   \
-    static ExecuteWhenLoadingLibrary##UniqueID execute##UniqueID; \
+    static RegisterStaticPlugin##UniqueID execute##UniqueID; \
   }  /* namespace */ \
   }
 

--- a/include/gz/physics/detail/RegisterStatic.hh
+++ b/include/gz/physics/detail/RegisterStatic.hh
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_DETAIL_REGISTER_STATIC_HH_
+#define GZ_PHYSICS_DETAIL_REGISTER_STATIC_HH_
+
+#include <tuple>
+
+#include <gz/plugin/RegisterStatic.hh>
+#include <gz/physics/Feature.hh>
+
+namespace gz
+{
+  namespace physics
+  {
+    namespace detail
+    {
+      template <typename PluginT, typename FeaturePolicyT,
+                typename FeatureListOrTuple>
+      struct Registrar;
+
+      template <typename PluginT, typename FeaturePolicyT,
+                typename FeatureListT>
+      struct Registrar
+      {
+        static void StaticRegisterPlugin()
+        {
+          StaticRegistrar<PluginT, FeaturePolicyT,
+              typename FeatureListT::Features>::RegisterPlugin();
+        }
+      };
+
+      template <typename PluginT, typename FeaturePolicyT,
+                typename... Features>
+      struct StaticRegistrar<PluginT, FeaturePolicyT, std::tuple<Features...>>
+      {
+        static void StaticRegisterPlugin()
+        {
+          gz::plugin::detail::StaticRegistrar<
+                PluginT, Feature::Implementation<FeaturePolicyT>,
+                typename Features::template Implementation<FeaturePolicyT>...>::
+              Register();
+        }
+      };
+    }
+  }
+}
+
+// Dev Note (MXG): Using a namespace called detail_gz_physics avoids
+// confusion with the gz::physics namespace. This is important because
+// users might call this macro within their own namespace scope, which can
+// create unexpected and confusing namespace hierarchies.
+#define DETAIL_GZ_PHYSICS_ADD_STATIC_PLUGIN_HELPER( \
+  UniqueID, PluginType, FeaturePolicyT, FeatureListT) \
+  namespace detail_gz_physics \
+  { \
+  namespace \
+  { \
+    struct ExecuteWhenLoadingLibrary##UniqueID \
+    { \
+      ExecuteWhenLoadingLibrary##UniqueID() \
+      { \
+        ::gz::physics::detail::StaticRegistrar< \
+            PluginType, FeaturePolicyT, FeatureListT>:: \
+            StaticRegisterPlugin(); \
+      } \
+    }; \
+  \
+    static ExecuteWhenLoadingLibrary##UniqueID execute##UniqueID; \
+  }  /* namespace */ \
+  }
+
+#define DETAIL_GZ_PHYSICS_ADD_STATIC_PLUGIN_WITH_COUNTER( \
+  UniqueID, PluginType, FeaturePolicyT, FeatureListT) \
+  DETAIL_GZ_PHYSICS_ADD_STATIC_PLUGIN_HELPER( \
+    UniqueID, PluginType, FeaturePolicyT, FeatureListT)
+
+#define DETAIL_GZ_PHYSICS_ADD_STATIC_PLUGIN( \
+  PluginType, FeaturePolicyT, FeatureListT) \
+  DETAIL_GZ_PHYSICS_ADD_STATIC_PLUGIN_WITH_COUNTER( \
+  __COUNTER__, PluginType, FeaturePolicyT, FeatureListT)
+
+#endif

--- a/tpe/BUILD.bazel
+++ b/tpe/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
+load("//bazel:gz_physics_plugin_libraries.bzl", "gz_physics_plugin_libraries")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -108,10 +109,10 @@ cc_library(
     ],
 )
 
-cc_binary(
-    name = "libgz-physics-tpe-plugin.so",
+gz_physics_plugin_libraries(
     srcs = ["plugin/src/plugin.cc"] + private_headers + tpelib_private_headers,
-    linkshared = True,
+    so_lib_name = "libgz-physics-tpe-plugin.so",
+    static_lib_name = "libgz-physics-tpe-plugin-static",
     visibility = ["//visibility:public"],
     deps = [
         ":Export-tpelib",


### PR DESCRIPTION

# 🎉 New feature

## Summary

Adds a new `GZ_PHYSICS_ADD_STATIC_PLUGIN` macro for registering physics engine plugins in the static plugin registry. 

The bazel build files are updated to generate static plugins in addition to shared libs in the same way as https://github.com/gazebosim/gz-sim/pull/2950/files#top for gz-sim systems / plugins. This should not change existing behavior. The tests are still running using the shared libs.

## Test it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
