### PR TITLE
Replace main branch with gz-physics9

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,9 +1,9 @@
 name: Bazel CI
 on:
   push:
-    branches: [gz-physics8, main]
+    branches: [gz-physics8, gz-physics9, main]
   pull_request:
-    branches: [gz-physics8, main]
+    branches: [gz-physics8, gz-physics9, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 Build | Status
 -- | --
-Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-physics/tree/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-physics/tree/main)
-Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-noble-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-main-noble-amd64)
-Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-main-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-main-clowin)](https://build.osrfoundation.org/job/gz_physics-main-clowin)
+Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-physics/tree/gz-physics9/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-physics/tree/gz-physics9)
+Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-gz-physics9-noble-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-gz-physics9-noble-amd64)
+Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-gz-physics9-homebrew-amd64)](https://build.osrfoundation.org/job/gz_physics-ci-gz-physics9-homebrew-amd64)
+Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-9-cnlwin)](https://build.osrfoundation.org/job/gz_physics-9-cnlwin)
 
 Gazebo Physics, a component of [Gazebo](https://gazebosim.org), provides an abstract physics interface
 designed to support simulation and rapid development of robot applications.
@@ -73,7 +73,7 @@ See the [installation tutorial](https://gazebosim.org/api/physics/8/installation
 
 # Usage
 
-Please refer to the [examples directory](https://github.com/gazebosim/gz-physics/raw/main/examples/).
+Please refer to the [examples directory](https://github.com/gazebosim/gz-physics/raw/gz-physics9/examples/).
 
 # Documentation
 
@@ -96,7 +96,7 @@ On Ubuntu, you can also generate the documentation from a clone of this reposito
 3. Clone the repository
 
     ```
-    git clone https://github.com/gazebosim/gz-physics -b main
+    git clone https://github.com/gazebosim/gz-physics -b gz-physics9
     ```
 
 4. Configure and build the documentation.
@@ -176,4 +176,4 @@ This library uses [Semantic Versioning](https://semver.org/). Additionally, this
 
 # License
 
-This library is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). See also the [LICENSE](https://github.com/gazebosim/gz-physics/blob/main/LICENSE) file.
+This library is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). See also the [LICENSE](https://github.com/gazebosim/gz-physics/blob/gz-physics9/LICENSE) file.

--- a/tutorials/03_physics_plugins.md
+++ b/tutorials/03_physics_plugins.md
@@ -71,16 +71,16 @@ Plugin implementations for other engines may choose to organize features into `F
 
 Dart ([Dynamic Animation and Robotics Toolkit](https://dartsim.github.io/)) is an open source library that provides data structures and algorithms for kinematic and dynamic applications in robotics and computer animation.
 It is the default physics engine used in Gazebo Simulation.
-The source code for Dartsim plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/main) under `dartsim` directory.
+The source code for Dartsim plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/gz-physics9) under `dartsim` directory.
 
-TPE ([Trivial Physics Engine](https://github.com/gazebosim/gz-physics/tree/main/tpe)) is an open source library created by Open Robotics that enables fast, inexpensive kinematics simulation for entities at large scale.
+TPE ([Trivial Physics Engine](https://github.com/gazebosim/gz-physics/tree/gz-physics9/tpe)) is an open source library created by Open Robotics that enables fast, inexpensive kinematics simulation for entities at large scale.
 It supports higher-order fleet dynamics without real physics (eg. gravity, force, constraint etc.) and multi-machine synchronization.
-The source code for TPE plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/main) under the `tpe/plugin` directory.
+The source code for TPE plugin can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/gz-physics9) under the `tpe/plugin` directory.
 
 Bullet ([Bullet3 Physics Engine](https://github.com/bulletphysics/bullet3)) is an open source library that supports real-time collision detection and multi-physics simulation for robotics and other application domains.
 Since Bullet supports two different APIs - a rigid-body API and a multibody API - with different physics implementations, there are two available plugin implementations:
-- The `bullet` plugin implements the rigid-body API, and the source code can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/main) under the `bullet` directory.
-- The `bullet-featherstone` plugin implements the multibody API (based on Featherstone's algorithms), and the source code can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/main) under the `bullet-featherstone` directory.
+- The `bullet` plugin implements the rigid-body API, and the source code can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/gz-physics9) under the `bullet` directory.
+- The `bullet-featherstone` plugin implements the multibody API (based on Featherstone's algorithms), and the source code can be found in [Gazebo Physics repository](https://github.com/gazebosim/gz-physics/tree/gz-physics9) under the `bullet-featherstone` directory.
 
 ### Entity Comparison
 
@@ -107,6 +107,6 @@ Entities are arranged in top-down hierarchical order.
 ### Feature Comparison
 
 For a list of all available `Features` in the Gazebo Physics library, check the classes inherited from `Feature` in the [Gazebo Physics API](https://gazebosim.org/api/physics/8/hierarchy.html).
-To check if a physics plugin implements a particular `Feature`, check the `FeatureLists` supported by that plugin as specified in the plugin.cc file, for example, [dartsim/src/plugin.cc](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/plugin.cc).
+To check if a physics plugin implements a particular `Feature`, check the `FeatureLists` supported by that plugin as specified in the plugin.cc file, for example, [dartsim/src/plugin.cc](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/plugin.cc).
 
 Next, check out the tutorial on \ref pluginloading "Loading physics plugins" on how to load a plugin and access a specific `Feature` interface of the plugin programmatically.

--- a/tutorials/05_plugin_loading.md
+++ b/tutorials/05_plugin_loading.md
@@ -17,7 +17,7 @@ plugin using \ref gz::physics "Gazebo Physics" API.
 
 ## Write a simple loader
 
-We will use a simplified physics plugin example for this tutorial. Source code can be found at [gz-physics/examples](https://github.com/gazebosim/gz-physics/tree/main/examples/hello_world_loader) folder.
+We will use a simplified physics plugin example for this tutorial. Source code can be found at [gz-physics/examples](https://github.com/gazebosim/gz-physics/tree/gz-physics9/examples/hello_world_loader) folder.
 
 First, create a workspace for the example plugin loader.
 
@@ -30,7 +30,7 @@ cd hello_world_loader
 Then download the example loader into your current directory by:
 
 ```bash
-wget https://raw.githubusercontent.com/gazebosim/gz-physics/main/examples/hello_world_loader/hello_world_loader.cc
+wget https://raw.githubusercontent.com/gazebosim/gz-physics/gz-physics9/examples/hello_world_loader/hello_world_loader.cc
 ```
 
 ### Examine the code

--- a/tutorials/08-implementing-a-custom-feature.md
+++ b/tutorials/08-implementing-a-custom-feature.md
@@ -13,7 +13,7 @@ In the last \ref createphysicsplugin "Implement a physics feature" tutorial, we
 know how to implement a dummy physics engine as a plugin and load it using
 \ref gz::physics "Gazebo Physics API". In this tutorial, we will look
 deeper into the structure of a physics engine plugin, for example, the available
-[DART](https://github.com/gazebosim/gz-physics/tree/main/dartsim)
+[DART](https://github.com/gazebosim/gz-physics/tree/gz-physics9/dartsim)
 physics engine in `gz-physics` repository and how to define a custom
 \ref gz::physics::Feature "Feature" for the plugin.
 
@@ -133,7 +133,7 @@ will not run at the same time when requested.
 
 ### Define custom feature template
 
-With the requirements and restrictions above, we first need to define a feature template for the custom feature. In this case, this feature will be responsible for retrieving world pointer from the physics engine. The template is placed in [World.hh](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/World.hh):
+With the requirements and restrictions above, we first need to define a feature template for the custom feature. In this case, this feature will be responsible for retrieving world pointer from the physics engine. The template is placed in [World.hh](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/World.hh):
 
 \snippet dartsim/src/World.hh feature template
 
@@ -176,24 +176,24 @@ After defining the feature template, we can add it to a custom
 The custom feature `RetrieveWorld` is added to `CustomFeatureList`, other custom
 features could also be added here.
 The `CustomFeatures` "FeatureList" here uses data structures and classes from:
-- [Base.hh](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/Base.hh), which defines structures that contain information to create `Model`, `Joint`, `Link`, and `Shape` objects in Dartsim API.
+- [Base.hh](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/Base.hh), which defines structures that contain information to create `Model`, `Joint`, `Link`, and `Shape` objects in Dartsim API.
 They act as an interface between Gazebo Physics Library and the actual physics engine.
 - \ref gz::physics::Implements3d "Implements3d" for implementing the
 custom feature with \ref gz::physics::FeaturePolicy3d "FeaturePolicy3d"
 ("FeaturePolicy" of 3 dimensions and scalar type `double`).
 
-We will then implement the actual function with Dartsim API in [CustomFeatures.cc](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/CustomFeatures.cc) to override the member function
+We will then implement the actual function with Dartsim API in [CustomFeatures.cc](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/CustomFeatures.cc) to override the member function
 declared in the custom feature header file:
 
 \snippet dartsim/src/CustomFeatures.cc implementation
 
 Here, we implement the behavior of `GetDartsimWorld` with Dartsim API to return the
 world pointer from `EntityStorage` object storing world pointers of `dartsim` in
-[Base](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/Base.hh) class.
+[Base](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/Base.hh) class.
 
 In the end, we add the implemented `CustomFeatures` "FeatureList" together with
 other \ref gz::physics::FeatureList "FeatureList" to final `DartsimFeatures`
-"FeatureList" as in [dartsim/src/plugin.cc](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/plugin.cc)
+"FeatureList" as in [dartsim/src/plugin.cc](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/plugin.cc)
 (please see the \ref createphysicsplugin "Implement a physics feature" tutorial
 for registering the plugin to Gazebo Physics).
 

--- a/tutorials/09_use_custom_engine.md
+++ b/tutorials/09_use_custom_engine.md
@@ -14,7 +14,7 @@ In the previous
 \ref implementcustomfeature "Implement custom feature" tutorial, we walked through how to
 define and implement a custom feature using an already supported physics
 engine. This tutorial will explain step-by-step how to interface with any physics engine
-using Gazebo Physics. We will use [TPE](https://github.com/gazebosim/gz-physics/tree/main/tpe) as an example in this tutorial.
+using Gazebo Physics. We will use [TPE](https://github.com/gazebosim/gz-physics/tree/gz-physics9/tpe) as an example in this tutorial.
 
 ### Structure of a physics plugin
 
@@ -38,7 +38,7 @@ gz-physics
 
 We link the external physics engine library
 in `CMakeLists.txt` of the plugin, assuming the physics engine library is
-already installed. In our case, [TPE](https://github.com/gazebosim/gz-physics/tree/main/tpe)
+already installed. In our case, [TPE](https://github.com/gazebosim/gz-physics/tree/gz-physics9/tpe)
 is placed inside Gazebo Physics and hence there is a `lib` folder under `tpe`.
 
 We declare and implement the \ref gz::physics::FeatureList "FeatureList"
@@ -46,7 +46,7 @@ interfacing with the physics engine API inside `plugin/src` folder
 (please see \ref implementcustomfeature "Implement custom feature"
 for the plugin feature requirements). Depending on design target, a \ref gz::physics::FeatureList "FeatureList"
 is generally a packing of related \ref gz::physics::Feature "Features".
-For example in TPE's [EntityManagementFeatures](https://github.com/gazebosim/gz-physics/blob/main/tpe/plugin/src/EntityManagementFeatures.hh)
+For example in TPE's [EntityManagementFeatures](https://github.com/gazebosim/gz-physics/blob/gz-physics9/tpe/plugin/src/EntityManagementFeatures.hh)
 , there are \ref gz::physics::GetEngineInfo "GetEngineInfo",
 \ref gz::physics::GetWorldFromEngine "GetWorldFromEngine", etc. features
 defined in the "FeatureList" structure for entity management purpose.
@@ -75,7 +75,7 @@ simple_plugin
 ### plugin.cc
 
 In this tutorial, we will show how to construct a simple simulation world using
-[TPE](https://github.com/gazebosim/gz-physics/tree/main/tpe) physics
+[TPE](https://github.com/gazebosim/gz-physics/tree/gz-physics9/tpe) physics
 engine. For this purpose, we will implement the pre-defined
 \ref gz::physics::ConstructEmptyWorldFeature "ConstructEmptyWorldFeature"
 and include this feature into an empty \ref gz::physics::FeatureList "FeatureList"
@@ -133,7 +133,7 @@ in the template file we just included, we need to override the generic declarati
 The `EntityManagementFeatures` "FeatureList" here inherits from:
 - (optionally) \ref gz::physics::tpelib::Base "Base"
 class for foundation metadata definitions of Models, Joints, Links, and Shapes objects
-of TPE to provide easy access to [tpelib](https://github.com/gazebosim/gz-physics/tree/main/tpe/lib)
+of TPE to provide easy access to [tpelib](https://github.com/gazebosim/gz-physics/tree/gz-physics9/tpe/lib)
 structures in the TPE library.
 - \ref gz::physics::Implements3d "Implements3d" for implementing the
 custom feature with \ref gz::physics::FeaturePolicy3d "FeaturePolicy3d"
@@ -148,7 +148,7 @@ Here we show the overriding of `ConstructEmptyWorld` member function of
 this is where we use the physics engine API to implement this member function.
 We simply instantiate \ref gz::physics::tpelib::World "World" object, set
 the world name and call \ref gz::physics::tpelib::Base::AddWorld "AddWorld"
-function which was defined in [Base.hh](https://github.com/gazebosim/gz-physics/blob/main/tpe/plugin/src/Base.hh).
+function which was defined in [Base.hh](https://github.com/gazebosim/gz-physics/blob/gz-physics9/tpe/plugin/src/Base.hh).
 
 Simple unit tests are good practice for sanity checks.
 While we won't go into detail, here is an example to test our new
@@ -158,8 +158,8 @@ While we won't go into detail, here is an example to test our new
 
 To get a more comprehensive view of how `EntityManagementFeatures` are constructed in TPE and Dartsim,
 feel free to take a look here:
-- Dartsim: [EntityManagementFeatures.hh](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/EntityManagementFeatures.hh) and [EntityManagementFeatures.cc](https://github.com/gazebosim/gz-physics/blob/main/dartsim/src/EntityManagementFeatures.cc)
-- TPE: [EntityManagementFeatures.hh](https://github.com/gazebosim/gz-physics/blob/main/tpe/plugin/src/EntityManagementFeatures.hh) and [EntityManagementFeatures.cc](https://github.com/gazebosim/gz-physics/blob/main/tpe/plugin/src/EntityManagementFeatures.cc)
+- Dartsim: [EntityManagementFeatures.hh](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/EntityManagementFeatures.hh) and [EntityManagementFeatures.cc](https://github.com/gazebosim/gz-physics/blob/gz-physics9/dartsim/src/EntityManagementFeatures.cc)
+- TPE: [EntityManagementFeatures.hh](https://github.com/gazebosim/gz-physics/blob/gz-physics9/tpe/plugin/src/EntityManagementFeatures.hh) and [EntityManagementFeatures.cc](https://github.com/gazebosim/gz-physics/blob/gz-physics9/tpe/plugin/src/EntityManagementFeatures.cc)
 
 ## Compile and run the example
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-jetty/issues/29.

## Summary

Replace references to `main` branch with `gz-physics9`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
