### PR TITLE
Fix path in physics plugin implementation tutorial

### DIFF
--- a/tutorials/07-implementing-a-physics-plugin.md
+++ b/tutorials/07-implementing-a-physics-plugin.md
@@ -109,7 +109,7 @@ to create a simple loader. Then we test our plugin using the loader as follow:
 
 ```bash
 cd ~
-./hello_world_loader/build/hello_world_loader simple_plugin/build/libHelloWorldPlugin.so
+./hello_world_loader/build/hello_world_loader hello_world_plugin/build/libHelloWorldPlugin.so
 ```
 
 And you will see the engine info of our plugin:


### PR DESCRIPTION

## Summary
Found this issue where the command to implement our custom physics plugin was wrong, due to the wrong folder name. This PR fixes it.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.