### PR TITLE
Fix spelling in simulation concepts tutorial

### DIFF
--- a/tutorials/06-physics-simulation-concepts.md
+++ b/tutorials/06-physics-simulation-concepts.md
@@ -128,7 +128,7 @@ and the blades will stop after some time due to friction.
 
 @image html img/lift_drag_torque.gif width=100%
 
-Several simulation features come into effect in this demo. The lift and drag force is computed by taking the wind pressure, mass of the cude, and gravity into account, and the resulting force is exerted on multiple joints. Dartsim is used to power this demo.
+Several simulation features come into effect in this demo. The lift and drag force is computed by taking the wind pressure, mass of the cube, and gravity into account, and the resulting force is exerted on multiple joints. Dartsim is used to power this demo.
 
 ### Buoyancy
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This is a minor spelling fix in the documentation. No testing is necessary. 

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.