### PR TITLE
Update 09_use_custom_engine.md build commands

### DIFF
--- a/tutorials/09_use_custom_engine.md
+++ b/tutorials/09_use_custom_engine.md
@@ -172,7 +172,7 @@ mkdir build
 cd build
 cmake ..
 # Linux
-cmake --build . --target PluginTest
+make
 # Windows
 cmake --build . --target PluginTest --config Release
 ```


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
When building with the current instructions, it builds just the `PluginTest` but does not build the `libSimplePlugin.so`, resulting in the following message when running:
```
Error while loading the library [gz-physics/examples/simple_plugin/build/libSimplePlugin.so]: gz-physics/examples/simple_plugin/build/libSimplePlugin.so: cannot open shared object file: No such file or directory
Something went wrong, the engine is null
```

Instead of building just `PluginTest`, this PR switches to just using make to build everything. We could alternatively use `cmake --build .` without the `--target` to build everything. 


This was tested by following the tutorial and building the simple plugin example and getting a successful message:
```
Created empty world!
```

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.