### PR TITLE
Fix crash when recursively deleting nested models

### DIFF
--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -522,6 +522,10 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: bool RemoveModelImpl(const std::size_t _worldID,
                                const std::size_t _modelID)
   {
+    if (!this->worlds.HasEntity(_worldID) || !this->models.HasEntity(_modelID))
+    {
+      return false;
+    }
     const auto &world = this->worlds.at(_worldID);
     auto modelInfo = this->models.at(_modelID);
     auto skel = modelInfo->model;

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -659,6 +659,10 @@ bool EntityManagementFeatures::RemoveModel(const Identity &_modelID)
   if (this->models.HasEntity(_modelID))
   {
     auto worldID = this->GetWorldOfModelImpl(_modelID);
+    if (!this->worlds.HasEntity(worldID))
+    {
+      return false;
+    }
     auto model = this->models.at(_modelID)->model;
 
     auto filterPtr = GetFilterPtr(this, worldID);


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes gazebosim/gz-sim#3080

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
This PR fixes a crash that could occur when recursively deleting nested models if the parent `world` or `model` no longer exists.
Deleting a nested model without checking the validity of its `world` or parent `model` could lead to invalid access and a crash. Existence checks are added before deletion, ensuring safe and robust recursive removal of models.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers