### PR TITLE
Prepare for 9.0.0~pre2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,21 @@
 
 1. **Baseline:** this includes all changes from 8.3.0 and earlier.
 
+1. Fix crash when recursively deleting nested models
+    * [Pull request #781](https://github.com/gazebosim/gz-physics/pull/781)
+
+1. Update `09_use_custom_engine.md` build commands
+    * [Pull request #780](https://github.com/gazebosim/gz-physics/pull/780)
+
+1. Fix spelling in simulation concepts tutorial
+    * [Pull request #778](https://github.com/gazebosim/gz-physics/pull/778)
+
+1. Fix path in physics plugin implementation tutorial
+    * [Pull request #777](https://github.com/gazebosim/gz-physics/pull/777)
+
+1. [Bazel] Update bazel module to use jetty release branches
+    * [Pull request #776](https://github.com/gazebosim/gz-physics/pull/776)
+
 1. bullet-featherstone: Add Kinematic feature
     * [Pull request #618](https://github.com/gazebosim/gz-physics/pull/618)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 9.0.0~pre2 release.

Comparison to 9.0.0~pre1: https://github.com/gazebosim/gz-physics/compare/gz-physics9_9.0.0-pre1...gz-physics9


## Checklist
- [X] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [X] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
