### PR TITLE
bullet-featherstone: Support ball joint damping

### DIFF
--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -851,7 +851,8 @@ Identity SDFFeatures::ConstructSdfModelImpl(
         {
           jointInfo->jointLimits =
             std::make_shared<btMultiBodyJointLimitConstraint>(
-              model->body.get(), i, static_cast<btScalar>(joint->Axis()->Lower()),
+              model->body.get(), i,
+              static_cast<btScalar>(joint->Axis()->Lower()),
               static_cast<btScalar>(joint->Axis()->Upper()));
           world->world->addMultiBodyConstraint(jointInfo->jointLimits.get());
         }


### PR DESCRIPTION


# 🎉 New feature

## Summary

The joint damping property is currently only set for revolute and prismatic joints. This PR updates the check to include ball joints.

Example of 3 links connected by ball joints

Before (no damping):
![bullet_ball_joint_no_damping](https://github.com/user-attachments/assets/c3bd9c7e-a0ae-4022-9121-f51b3c48fe02)

After (damping set to 1.0):
![bullet_ball_joint_damping](https://github.com/user-attachments/assets/10d38126-d5ed-4533-ab79-c44a151d97f5)


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
