### PR TITLE
Relax tolerances for failing tests on arm64

### DIFF
--- a/test/integration/FrameSemantics2d.cc
+++ b/test/integration/FrameSemantics2d.cc
@@ -32,7 +32,13 @@ TEST(FrameSemantics_TEST, RelativeAlignedBox2d)
 /////////////////////////////////////////////////
 TEST(FrameSemantics_TEST, FrameID2d)
 {
+#ifdef __aarch64__
+  // Relax tolerance for arm64
+  // See https://github.com/gazebosim/gz-physics/issues/790
+  TestFrameID<ignition::physics::FeaturePolicy2d>(3e-12, "2d");
+#else
   TestFrameID<ignition::physics::FeaturePolicy2d>(1e-12, "2d");
+#endif
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/JointTypes2f.cc
+++ b/test/integration/JointTypes2f.cc
@@ -20,7 +20,13 @@
 /////////////////////////////////////////////////
 TEST(JointTypes_TEST, RevoluteJoint2f)
 {
+#ifdef __aarch64__
+  // Relax tolerance on arm64
+  // See https://github.com/gazebosim/gz-physics/issues/791
+  TestRevoluteJoint<FeaturePolicy2f>(3e-8, "2f");
+#else
   TestRevoluteJoint<FeaturePolicy2f>(1e-16, "2f");
+#endif
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Partial backport of #806.
Fixes CI for https://github.com/gazebosim/gz-physics/issues/789, https://github.com/gazebosim/gz-physics/issues/790, https://github.com/gazebosim/gz-physics/issues/791.

## Summary

Several tests are failing on arm64 that pass with other CPU architectures. This works around the issue by relaxing the test tolerances on arm64 while retaining the original tolerance for other architectures.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
