### PR TITLE
Bazel updates: prep for BCR release automation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,8 +14,8 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies
 bazel_dep(name = "rules_gazebo", version = "0.0.6")
-bazel_dep(name = "gz-common", version = "7.0.0-pre1")
-bazel_dep(name = "gz-math", version = "9.0.0-pre1")
-bazel_dep(name = "gz-plugin", version = "4.0.0-pre1")
-bazel_dep(name = "gz-utils", version = "4.0.0-pre1")
-bazel_dep(name = "sdformat", version = "16.0.0-pre2")
+bazel_dep(name = "gz-common", version = "7.0.0")
+bazel_dep(name = "gz-math", version = "9.0.0")
+bazel_dep(name = "gz-plugin", version = "4.0.0")
+bazel_dep(name = "gz-utils", version = "4.0.0")
+bazel_dep(name = "sdformat", version = "16.0.0")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Couple fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR.

- Remove `archive_override` for gazebo package deps and use Jetty packages from BCR instead. As a result, bazel CI will use released versions of gz deps, which is consistent with cmake CI.
- Add `compatibility_level` to match [what is set in BCR](https://github.com/bazelbuild/bazel-central-registry/blob/928128b1c60e7e32d21ea8bde9fd802674eba5f3/modules/gz-physics/9.0.0-pre2/MODULE.bazel#L4)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.