### PR TITLE
Test gz-physics9 with dart 6.16 in prerelease

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,10 +1,10 @@
 libbenchmark-dev
-libdart6.13-collision-bullet-dev
-libdart6.13-collision-ode-dev
-libdart6.13-dev
-libdart6.13-external-ikfast-dev
-libdart6.13-external-odelcpsolver-dev
-libdart6.13-utils-urdf-dev
+libdart6.16-collision-bullet-dev
+libdart6.16-collision-ode-dev
+libdart6.16-dev
+libdart6.16-external-ikfast-dev
+libdart6.16-external-odelcpsolver-dev
+libdart6.16-utils-urdf-dev
 libeigen3-dev
 libgz-cmake5-dev
 libgz-common7-dev


### PR DESCRIPTION
testing dart 6.16 deb packages that are currently in the prerelease repo

testing in conjunction with https://github.com/gazebo-tooling/gzdev/compare/master...ci_matching_branch/physics9_prerelease