### PR TITLE
Manual forward port of: Bazel updates (#817)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
-## MODULE.bazel
 module(
     name = "gz-physics",
+    compatibility_level = 8,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
@@ -14,12 +14,14 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies
 bazel_dep(name = "rules_gazebo", version = "0.0.6")
-bazel_dep(name = "gz-common")
-bazel_dep(name = "gz-math")
-bazel_dep(name = "gz-plugin")
-bazel_dep(name = "gz-utils")
-bazel_dep(name = "sdformat")
+bazel_dep(name = "gz-common", version = "7.0.0")
+bazel_dep(name = "gz-math", version = "9.0.0")
+bazel_dep(name = "gz-plugin", version = "4.0.0")
+bazel_dep(name = "gz-utils", version = "4.0.0")
+bazel_dep(name = "sdformat", version = "16.0.0")
 
+# Override Gz deps to be pulled from the `main` branches so that CI uses deps
+# from HEAD on `main`.
 archive_override(
     module_name = "gz-common",
     strip_prefix = "gz-common-main",


### PR DESCRIPTION
The change had to be amended to apply it on main. Specifically, the repo `archive_override`s in MODULE.bazel for gz deps was removed in that PR on the Jetty branch, but we want to preserve it on main to ensure CI uses gz deps from HEAD.

-- Original PR description
Fix in MODULE.bazel as pre-work to add automation to push new releases to BCR.
- Add `compatibility_level` to match what is set in BCR

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
