### PR TITLE
Manual backport of: Bazel updates (#817)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
-## MODULE.bazel
 module(
     name = "gz-physics",
+    compatibility_level = 8,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
@@ -14,38 +14,8 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies
 bazel_dep(name = "rules_gazebo", version = "0.0.6")
-bazel_dep(name = "gz-common")
-bazel_dep(name = "gz-math")
-bazel_dep(name = "gz-plugin")
-bazel_dep(name = "gz-utils")
-bazel_dep(name = "sdformat")
-
-archive_override(
-    module_name = "gz-common",
-    strip_prefix = "gz-common-gz-common6",
-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/gz-common6.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-math",
-    strip_prefix = "gz-math-gz-math8",
-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/heads/gz-math8.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-plugin",
-    strip_prefix = "gz-plugin-gz-plugin3",
-    urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/heads/gz-plugin3.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-utils",
-    strip_prefix = "gz-utils-gz-utils3",
-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
-)
-
-archive_override(
-    module_name = "sdformat",
-    strip_prefix = "sdformat-sdf15",
-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/heads/sdf15.tar.gz"],
-)
+bazel_dep(name = "gz-common", version = "6.2.1")
+bazel_dep(name = "gz-math", version = "8.1.1.bcr.1")
+bazel_dep(name = "gz-plugin", version = "3.1.0")
+bazel_dep(name = "gz-utils", version = "3.1.1")
+bazel_dep(name = "sdformat", version = "15.3.0.bcr.2")


### PR DESCRIPTION
Manually backported to use Ionic packages for gz deps from BCR instead of Jetty deps.

-- Original PR description:

Couple fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR.

- Remove archive_override for gazebo package deps and use Jetty packages from BCR instead. As a result, bazel CI will use released versions of gz deps, which is consistent with cmake CI.
- Add compatibility_level to match what is set in BCR

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
