### PR TITLE
Prevent DART crash by adding check for negative damping

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -220,11 +220,11 @@ static JointType *ConstructSingleAxisJoint(
     // Check for negative damping
     if (properties.mDampingCoefficients[0] < 0.0)
     {
-      gzerr << "Detected negative damping coefficient (" 
-             << properties.mDampingCoefficients[0] 
-             << ") for joint [" << _sdfJoint.Name() 
-             << "]. Damping must be non-negative. "
-             << "Setting damping to zero." << std::endl;
+      gzerr << "Detected negative damping coefficient ("
+            << properties.mDampingCoefficients[0]
+            << ") for joint [" << _sdfJoint.Name()
+            << "]. Damping must be non-negative. "
+            << "Setting damping to zero." << std::endl;
       properties.mDampingCoefficients[0] = 0.0;
     }
   }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes [#3266](https://github.com/gazebosim/gz-sim/issues/3266)

## Summary
Loading an SDF model with a negative joint damping coefficient (e.g., <damping>-5.0</damping>) causes a crash when using the gz-physics DART plugin in Coverage build modes.
This PR added a check for negative damping to avoid crash.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
