### PR TITLE
Add GetEngineVersion to GetEngineInfo (backport 821 to gz-physics9)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,15 @@
-## Gazebo Physics 9.x
+## Gazebo Physics 10.x
+
+### Gazebo Physics 10.0.0 ()
+
+1. Add `GetEngineVersion` to `GetEngineInfo` feature to separate engine name and version
+    * Adds `GetVersion()` method to `GetEngineInfo::Engine` API returning `gz::math::SemanticVersion`
+    * Adds `GetEngineVersion()` pure virtual method to `GetEngineInfo::Implementation`
+    * Implements `GetEngineVersion()` in all physics engine plugins:
+      - bullet and bullet-featherstone: parse `BT_BULLET_VERSION` macro to return SemanticVersion(3, 24)
+      - dartsim: parse `DART_VERSION` macro string to SemanticVersion
+      - tpe: return SemanticVersion(1, 0)
+    * Updates dartsim `GetEngineName()` to return "dartsim" only (was "dartsim-" DART_VERSION)
 
 ### Gazebo Physics 9.1.0 (2026-01-20)
 

--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -47,6 +47,7 @@
 
 #include <gz/common/Console.hh>
 #include <gz/math/eigen3/Conversions.hh>
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 
 namespace gz {
@@ -359,6 +360,10 @@ class Base : public Implements3d<FeatureList<Feature>>
 {
   // Note: Entity ID 0 is reserved for the "engine"
   public: std::size_t entityCount = 1;
+
+  // BT_BULLET_VERSION is an integer like 324 representing version 3.24
+  public: const gz::math::SemanticVersion engineVersion{
+      BT_BULLET_VERSION / 100, BT_BULLET_VERSION % 100};
 
   public: inline std::size_t GetNextEntity()
   {

--- a/bullet-featherstone/src/EntityManagementFeatures.cc
+++ b/bullet-featherstone/src/EntityManagementFeatures.cc
@@ -16,8 +16,10 @@
 */
 
 #include <btBulletDynamicsCommon.h>
+#include <LinearMath/btScalar.h>
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -301,6 +303,12 @@ const std::string &EntityManagementFeatures::GetEngineName(
 {
   static const std::string engineName = "bullet-featherstone";
   return engineName;
+}
+
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+  const Identity &) const
+{
+  return this->engineVersion;
 }
 
 /////////////////////////////////////////////////

--- a/bullet-featherstone/src/EntityManagementFeatures.hh
+++ b/bullet-featherstone/src/EntityManagementFeatures.hh
@@ -52,6 +52,9 @@ class EntityManagementFeatures :
   public: const std::string &GetEngineName(
       const Identity &_engineID) const override;
 
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &_engineID) const override;
+
   public: std::size_t GetEngineIndex(
       const Identity &_engineID) const override;
 

--- a/bullet/src/Base.hh
+++ b/bullet/src/Base.hh
@@ -29,6 +29,7 @@
 #include <map>
 
 #include <gz/common/Console.hh>
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 #include <gz/math/eigen3/Conversions.hh>
 
@@ -174,6 +175,10 @@ inline math::Pose3d convertToGz(const btTransform &_pose)
 
 class Base : public Implements3d<FeatureList<Feature>>
 {
+  // BT_BULLET_VERSION is an integer like 324 representing version 3.24
+  public: const gz::math::SemanticVersion engineVersion{
+      BT_BULLET_VERSION / 100, BT_BULLET_VERSION % 100};
+
   public: std::size_t entityCount = 0;
 
   public: inline std::size_t GetNextEntity()

--- a/bullet/src/EntityManagementFeatures.cc
+++ b/bullet/src/EntityManagementFeatures.cc
@@ -16,8 +16,10 @@
 */
 
 #include <btBulletDynamicsCommon.h>
+#include <LinearMath/btScalar.h>
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -115,6 +117,12 @@ const std::string &EntityManagementFeatures::GetEngineName(
 {
   static const std::string engineName = "bullet";
   return engineName;
+}
+
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+  const Identity &) const
+{
+  return this->engineVersion;
 }
 
 std::size_t EntityManagementFeatures::GetEngineIndex(const Identity &) const

--- a/bullet/src/EntityManagementFeatures.hh
+++ b/bullet/src/EntityManagementFeatures.hh
@@ -65,6 +65,8 @@ class EntityManagementFeatures :
 
   // ----- Get entities -----
   public: const std::string &GetEngineName(const Identity &) const override;
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &) const override;
   public: std::size_t GetEngineIndex(const Identity &) const override;
 
   public: std::size_t GetWorldCount(const Identity &) const override;

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -37,6 +37,7 @@
 #include <gz/common/Console.hh>
 #include <gz/math/eigen3/Conversions.hh>
 #include <gz/math/Inertial.hh>
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 
 #include <sdf/Types.hh>
@@ -261,6 +262,12 @@ struct EntityStorage
 
 class Base : public Implements3d<FeatureList<Feature>>
 {
+  public: const gz::math::SemanticVersion engineVersion = [](){
+    gz::math::SemanticVersion v;
+    v.Parse(DART_VERSION);
+    return v;
+  }();
+
   public: using DartWorld = dart::simulation::World;
   public: using DartWorldPtr = dart::simulation::WorldPtr;
   public: using DartSkeletonPtr = dart::dynamics::SkeletonPtr;

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -132,8 +132,15 @@ static std::size_t GetWorldOfShapeNode(const EntityManagementFeatures *_emf,
 const std::string &EntityManagementFeatures::GetEngineName(
     const Identity &/*_engineID*/) const
 {
-  static const std::string engineName = "dartsim-" DART_VERSION;
+  static const std::string engineName = "dartsim";
   return engineName;
+}
+
+/////////////////////////////////////////////////
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+    const Identity &/*_engineID*/) const
+{
+  return this->engineVersion;
 }
 
 /////////////////////////////////////////////////

--- a/dartsim/src/EntityManagementFeatures.hh
+++ b/dartsim/src/EntityManagementFeatures.hh
@@ -52,6 +52,9 @@ class GZ_PHYSICS_DARTSIM_PLUGIN_VISIBLE EntityManagementFeatures :
   // ----- Get entities -----
   public: const std::string &GetEngineName(const Identity &) const override;
 
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &) const override;
+
   public: std::size_t GetEngineIndex(const Identity &) const override;
 
   public: std::size_t GetWorldCount(const Identity &) const override;

--- a/examples/hello_world_plugin/HelloWorldPlugin.cc
+++ b/examples/hello_world_plugin/HelloWorldPlugin.cc
@@ -58,6 +58,13 @@ namespace mock
       return this->engineName;
     }
 
+    public: const gz::math::SemanticVersion &GetEngineVersion(
+        const Identity &/*_id*/) const override
+    {
+      static const gz::math::SemanticVersion version(1, 0);
+      return version;
+    }
+
     std::string engineName;
   };
   //! [implementation]

--- a/include/gz/physics/GetEntities.hh
+++ b/include/gz/physics/GetEntities.hh
@@ -20,6 +20,7 @@
 
 #include <string>
 
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/FeatureList.hh>
 
 namespace gz
@@ -37,6 +38,10 @@ namespace gz
         /// is plugin-defined.
         public: const std::string &GetName() const;
 
+        /// \brief Get the version of this engine. The meaning of an engine
+        /// version is plugin-defined.
+        public: const gz::math::SemanticVersion &GetVersion() const;
+
         /// \brief Get the index of this engine. The meaning of an engine index
         /// is plugin-defined.
         public: std::size_t GetIndex() const;
@@ -46,6 +51,9 @@ namespace gz
       class Implementation : public virtual Feature::Implementation<PolicyT>
       {
         public: virtual const std::string &GetEngineName(
+            const Identity &_engineID) const = 0;
+
+        public: virtual const gz::math::SemanticVersion &GetEngineVersion(
             const Identity &_engineID) const = 0;
 
         public: virtual std::size_t GetEngineIndex(

--- a/include/gz/physics/detail/GetEntities.hh
+++ b/include/gz/physics/detail/GetEntities.hh
@@ -36,6 +36,15 @@ namespace gz
 
     /////////////////////////////////////////////////
     template <typename PolicyT, typename FeaturesT>
+    const gz::math::SemanticVersion &
+    GetEngineInfo::Engine<PolicyT, FeaturesT>::GetVersion() const
+    {
+      return this->template Interface<GetEngineInfo>()
+          ->GetEngineVersion(this->identity);
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
     std::size_t GetEngineInfo::Engine<PolicyT, FeaturesT>::GetIndex() const
     {
       return this->template Interface<GetEngineInfo>()

--- a/test/plugins/DARTDoublePendulum.cc
+++ b/test/plugins/DARTDoublePendulum.cc
@@ -216,6 +216,13 @@ namespace mock
         return name;
       }
 
+      public: const gz::math::SemanticVersion &GetEngineVersion(
+          const Identity &/*_engineID*/) const override
+      {
+        static const gz::math::SemanticVersion version(1, 0);
+        return version;
+      }
+
       public: std::size_t GetEngineIndex(
           const Identity &/*_engineID*/) const override
       {

--- a/tpe/plugin/src/Base.hh
+++ b/tpe/plugin/src/Base.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_TPE_PLUGIN_SRC_BASE_HH_
 #define GZ_PHYSICS_TPE_PLUGIN_SRC_BASE_HH_
 
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 
 #include <map>
@@ -61,6 +62,9 @@ struct CollisionInfo
 
 class Base : public Implements3d<FeatureList<Feature>>
 {
+  // TPE versioning is internal to gz-physics
+  public: const gz::math::SemanticVersion engineVersion{1, 0};
+
   public: inline Identity InitiateEngine(std::size_t /*_engineID*/) override
   {
     return this->GenerateIdentity(0);

--- a/tpe/plugin/src/EntityManagementFeatures.cc
+++ b/tpe/plugin/src/EntityManagementFeatures.cc
@@ -32,6 +32,12 @@ const std::string &EntityManagementFeatures::GetEngineName(
   return engineName;
 }
 
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+  const Identity &) const
+{
+  return this->engineVersion;
+}
+
 /////////////////////////////////////////////////
 std::size_t EntityManagementFeatures::GetEngineIndex(
   const Identity &) const

--- a/tpe/plugin/src/EntityManagementFeatures.hh
+++ b/tpe/plugin/src/EntityManagementFeatures.hh
@@ -54,6 +54,9 @@ class EntityManagementFeatures :
   // ----- Get entities -----
   public: const std::string &GetEngineName(const Identity &) const override;
 
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &) const override;
+
   public: std::size_t GetEngineIndex(const Identity &) const override;
 
   public: std::size_t GetWorldCount(const Identity &) const override;


### PR DESCRIPTION
# 🎉 New feature

Backport of #821 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.