### PR TITLE
Take II: Add GetEngineVersionInfo to GetEngineInfo (feature backport #821)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,14 +2,15 @@
 
 ### Gazebo Physics 10.0.0 ()
 
-1. Add `GetEngineVersion` to `GetEngineInfo` feature to separate engine name and version
-    * Adds `GetVersion()` method to `GetEngineInfo::Engine` API returning `gz::math::SemanticVersion`
-    * Adds `GetEngineVersion()` pure virtual method to `GetEngineInfo::Implementation`
-    * Implements `GetEngineVersion()` in all physics engine plugins:
+1. Add `GetEngineVersionInfo` feature for engine version reporting
+    * Adds new `GetEngineVersionInfo` feature as a separate, opt-in feature
+    * Adds `GetVersion()` method to `GetEngineVersionInfo::Engine` API returning `gz::math::SemanticVersion`
+    * Adds `GetEngineVersion()` pure virtual method to `GetEngineVersionInfo::Implementation`
+    * Implements `GetEngineVersionInfo` in all physics engine plugins:
       - bullet and bullet-featherstone: parse `BT_BULLET_VERSION` macro to return SemanticVersion(3, 24)
       - dartsim: parse `DART_VERSION` macro string to SemanticVersion
       - tpe: return SemanticVersion(1, 0)
-    * Updates dartsim `GetEngineName()` to return "dartsim" only (was "dartsim-" DART_VERSION)
+    * Leaves `GetEngineInfo` unchanged to avoid breaking 3rd-party plugins
 
 ### Gazebo Physics 9.1.0 (2026-01-20)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,15 @@
-## Gazebo Physics 9.x
+## Gazebo Physics 10.x
+
+### Gazebo Physics 10.0.0 ()
+
+1. Add `GetEngineVersion` to `GetEngineInfo` feature to separate engine name and version
+    * Adds `GetVersion()` method to `GetEngineInfo::Engine` API returning `gz::math::SemanticVersion`
+    * Adds `GetEngineVersion()` pure virtual method to `GetEngineInfo::Implementation`
+    * Implements `GetEngineVersion()` in all physics engine plugins:
+      - bullet and bullet-featherstone: parse `BT_BULLET_VERSION` macro to return SemanticVersion(3, 24)
+      - dartsim: parse `DART_VERSION` macro string to SemanticVersion
+      - tpe: return SemanticVersion(1, 0)
+    * Updates dartsim `GetEngineName()` to return "dartsim" only (was "dartsim-" DART_VERSION)
 
 ### Gazebo Physics 9.1.0 (2026-01-20)
 

--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -47,6 +47,7 @@
 
 #include <gz/common/Console.hh>
 #include <gz/math/eigen3/Conversions.hh>
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 
 namespace gz {
@@ -359,6 +360,10 @@ class Base : public Implements3d<FeatureList<Feature>>
 {
   // Note: Entity ID 0 is reserved for the "engine"
   public: std::size_t entityCount = 1;
+
+  // BT_BULLET_VERSION is an integer like 324 representing version 3.24
+  public: const gz::math::SemanticVersion engineVersion{
+      BT_BULLET_VERSION / 100, BT_BULLET_VERSION % 100};
 
   public: inline std::size_t GetNextEntity()
   {

--- a/bullet-featherstone/src/EntityManagementFeatures.cc
+++ b/bullet-featherstone/src/EntityManagementFeatures.cc
@@ -16,8 +16,10 @@
 */
 
 #include <btBulletDynamicsCommon.h>
+#include <LinearMath/btScalar.h>
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -301,6 +303,12 @@ const std::string &EntityManagementFeatures::GetEngineName(
 {
   static const std::string engineName = "bullet-featherstone";
   return engineName;
+}
+
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+  const Identity &) const
+{
+  return this->engineVersion;
 }
 
 /////////////////////////////////////////////////

--- a/bullet-featherstone/src/EntityManagementFeatures.hh
+++ b/bullet-featherstone/src/EntityManagementFeatures.hh
@@ -52,6 +52,9 @@ class EntityManagementFeatures :
   public: const std::string &GetEngineName(
       const Identity &_engineID) const override;
 
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &_engineID) const override;
+
   public: std::size_t GetEngineIndex(
       const Identity &_engineID) const override;
 

--- a/bullet-featherstone/src/EntityManagementFeatures.hh
+++ b/bullet-featherstone/src/EntityManagementFeatures.hh
@@ -34,6 +34,7 @@ namespace bullet_featherstone {
 struct EntityManagementFeatureList : gz::physics::FeatureList<
   ConstructEmptyWorldFeature,
   GetEngineInfo,
+  GetEngineVersionInfo,
   GetJointFromModel,
   GetLinkFromModel,
   GetModelFromWorld,

--- a/bullet/src/Base.hh
+++ b/bullet/src/Base.hh
@@ -29,6 +29,7 @@
 #include <map>
 
 #include <gz/common/Console.hh>
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 #include <gz/math/eigen3/Conversions.hh>
 
@@ -174,6 +175,10 @@ inline math::Pose3d convertToGz(const btTransform &_pose)
 
 class Base : public Implements3d<FeatureList<Feature>>
 {
+  // BT_BULLET_VERSION is an integer like 324 representing version 3.24
+  public: const gz::math::SemanticVersion engineVersion{
+      BT_BULLET_VERSION / 100, BT_BULLET_VERSION % 100};
+
   public: std::size_t entityCount = 0;
 
   public: inline std::size_t GetNextEntity()

--- a/bullet/src/EntityManagementFeatures.cc
+++ b/bullet/src/EntityManagementFeatures.cc
@@ -16,8 +16,10 @@
 */
 
 #include <btBulletDynamicsCommon.h>
+#include <LinearMath/btScalar.h>
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -115,6 +117,12 @@ const std::string &EntityManagementFeatures::GetEngineName(
 {
   static const std::string engineName = "bullet";
   return engineName;
+}
+
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+  const Identity &) const
+{
+  return this->engineVersion;
 }
 
 std::size_t EntityManagementFeatures::GetEngineIndex(const Identity &) const

--- a/bullet/src/EntityManagementFeatures.hh
+++ b/bullet/src/EntityManagementFeatures.hh
@@ -65,6 +65,8 @@ class EntityManagementFeatures :
 
   // ----- Get entities -----
   public: const std::string &GetEngineName(const Identity &) const override;
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &) const override;
   public: std::size_t GetEngineIndex(const Identity &) const override;
 
   public: std::size_t GetWorldCount(const Identity &) const override;

--- a/bullet/src/EntityManagementFeatures.hh
+++ b/bullet/src/EntityManagementFeatures.hh
@@ -33,6 +33,7 @@ namespace bullet {
 
 struct EntityManagementFeatureList : gz::physics::FeatureList<
   GetEngineInfo,
+  GetEngineVersionInfo,
   GetWorldFromEngine,
   GetModelFromWorld,
   GetLinkFromModel,

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -37,6 +37,7 @@
 #include <gz/common/Console.hh>
 #include <gz/math/eigen3/Conversions.hh>
 #include <gz/math/Inertial.hh>
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 
 #include <sdf/Types.hh>
@@ -261,6 +262,12 @@ struct EntityStorage
 
 class Base : public Implements3d<FeatureList<Feature>>
 {
+  public: const gz::math::SemanticVersion engineVersion = [](){
+    gz::math::SemanticVersion v;
+    v.Parse(DART_VERSION);
+    return v;
+  }();
+
   public: using DartWorld = dart::simulation::World;
   public: using DartWorldPtr = dart::simulation::WorldPtr;
   public: using DartSkeletonPtr = dart::dynamics::SkeletonPtr;

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -132,8 +132,15 @@ static std::size_t GetWorldOfShapeNode(const EntityManagementFeatures *_emf,
 const std::string &EntityManagementFeatures::GetEngineName(
     const Identity &/*_engineID*/) const
 {
-  static const std::string engineName = "dartsim-" DART_VERSION;
+  static const std::string engineName = "dartsim";
   return engineName;
+}
+
+/////////////////////////////////////////////////
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+    const Identity &/*_engineID*/) const
+{
+  return this->engineVersion;
 }
 
 /////////////////////////////////////////////////

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -132,7 +132,7 @@ static std::size_t GetWorldOfShapeNode(const EntityManagementFeatures *_emf,
 const std::string &EntityManagementFeatures::GetEngineName(
     const Identity &/*_engineID*/) const
 {
-  static const std::string engineName = "dartsim-" DART_VERSION;
+  static const std::string engineName = "dartsim";
   return engineName;
 }
 

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -132,7 +132,7 @@ static std::size_t GetWorldOfShapeNode(const EntityManagementFeatures *_emf,
 const std::string &EntityManagementFeatures::GetEngineName(
     const Identity &/*_engineID*/) const
 {
-  static const std::string engineName = "dartsim";
+  static const std::string engineName = "dartsim-" DART_VERSION;
   return engineName;
 }
 

--- a/dartsim/src/EntityManagementFeatures.hh
+++ b/dartsim/src/EntityManagementFeatures.hh
@@ -52,6 +52,9 @@ class GZ_PHYSICS_DARTSIM_PLUGIN_VISIBLE EntityManagementFeatures :
   // ----- Get entities -----
   public: const std::string &GetEngineName(const Identity &) const override;
 
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &) const override;
+
   public: std::size_t GetEngineIndex(const Identity &) const override;
 
   public: std::size_t GetWorldCount(const Identity &) const override;

--- a/dartsim/src/EntityManagementFeatures.hh
+++ b/dartsim/src/EntityManagementFeatures.hh
@@ -36,6 +36,7 @@ namespace dartsim {
 
 struct EntityManagementFeatureList : FeatureList<
   GetEntities,
+  GetEngineVersionInfo,
   RemoveEntities,
   ConstructEmptyWorldFeature,
   ConstructEmptyModelFeature,

--- a/examples/hello_world_plugin/HelloWorldPlugin.cc
+++ b/examples/hello_world_plugin/HelloWorldPlugin.cc
@@ -58,6 +58,13 @@ namespace mock
       return this->engineName;
     }
 
+    public: const gz::math::SemanticVersion &GetEngineVersion(
+        const Identity &/*_id*/) const override
+    {
+      static const gz::math::SemanticVersion version(1, 0);
+      return version;
+    }
+
     std::string engineName;
   };
   //! [implementation]

--- a/examples/hello_world_plugin/HelloWorldPlugin.cc
+++ b/examples/hello_world_plugin/HelloWorldPlugin.cc
@@ -29,7 +29,8 @@ namespace mock
   //! [feature list]
   // List of all features that this plugin will implement
   struct HelloWorldFeatureList : gz::physics::FeatureList<
-      gz::physics::GetEngineInfo
+      gz::physics::GetEngineInfo,
+      gz::physics::GetEngineVersionInfo
   > { };
   //! [feature list]
 

--- a/include/gz/physics/GetEntities.hh
+++ b/include/gz/physics/GetEntities.hh
@@ -20,6 +20,7 @@
 
 #include <string>
 
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/FeatureList.hh>
 
 namespace gz
@@ -37,6 +38,10 @@ namespace gz
         /// is plugin-defined.
         public: const std::string &GetName() const;
 
+        /// \brief Get the version of this engine. The meaning of an engine
+        /// version is plugin-defined.
+        public: const gz::math::SemanticVersion &GetVersion() const;
+
         /// \brief Get the index of this engine. The meaning of an engine index
         /// is plugin-defined.
         public: std::size_t GetIndex() const;
@@ -46,6 +51,9 @@ namespace gz
       class Implementation : public virtual Feature::Implementation<PolicyT>
       {
         public: virtual const std::string &GetEngineName(
+            const Identity &_engineID) const = 0;
+
+        public: virtual const gz::math::SemanticVersion &GetEngineVersion(
             const Identity &_engineID) const = 0;
 
         public: virtual std::size_t GetEngineIndex(

--- a/include/gz/physics/GetEntities.hh
+++ b/include/gz/physics/GetEntities.hh
@@ -38,10 +38,6 @@ namespace gz
         /// is plugin-defined.
         public: const std::string &GetName() const;
 
-        /// \brief Get the version of this engine. The meaning of an engine
-        /// version is plugin-defined.
-        public: const gz::math::SemanticVersion &GetVersion() const;
-
         /// \brief Get the index of this engine. The meaning of an engine index
         /// is plugin-defined.
         public: std::size_t GetIndex() const;
@@ -53,10 +49,27 @@ namespace gz
         public: virtual const std::string &GetEngineName(
             const Identity &_engineID) const = 0;
 
-        public: virtual const gz::math::SemanticVersion &GetEngineVersion(
-            const Identity &_engineID) const = 0;
-
         public: virtual std::size_t GetEngineIndex(
+            const Identity &_engineID) const = 0;
+      };
+    };
+
+    /////////////////////////////////////////////////
+    /// \brief This feature retrieves the physics engine version.
+    class GZ_PHYSICS_VISIBLE GetEngineVersionInfo : public virtual Feature
+    {
+      public: template <typename PolicyT, typename FeaturesT>
+      class Engine : public virtual Feature::Engine<PolicyT, FeaturesT>
+      {
+        /// \brief Get the version of this engine. The meaning of an engine
+        /// version is plugin-defined.
+        public: const gz::math::SemanticVersion &GetVersion() const;
+      };
+
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        public: virtual const gz::math::SemanticVersion &GetEngineVersion(
             const Identity &_engineID) const = 0;
       };
     };

--- a/include/gz/physics/detail/GetEntities.hh
+++ b/include/gz/physics/detail/GetEntities.hh
@@ -36,6 +36,15 @@ namespace gz
 
     /////////////////////////////////////////////////
     template <typename PolicyT, typename FeaturesT>
+    const gz::math::SemanticVersion &
+    GetEngineInfo::Engine<PolicyT, FeaturesT>::GetVersion() const
+    {
+      return this->template Interface<GetEngineInfo>()
+          ->GetEngineVersion(this->identity);
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
     std::size_t GetEngineInfo::Engine<PolicyT, FeaturesT>::GetIndex() const
     {
       return this->template Interface<GetEngineInfo>()

--- a/include/gz/physics/detail/GetEntities.hh
+++ b/include/gz/physics/detail/GetEntities.hh
@@ -36,15 +36,6 @@ namespace gz
 
     /////////////////////////////////////////////////
     template <typename PolicyT, typename FeaturesT>
-    const gz::math::SemanticVersion &
-    GetEngineInfo::Engine<PolicyT, FeaturesT>::GetVersion() const
-    {
-      return this->template Interface<GetEngineInfo>()
-          ->GetEngineVersion(this->identity);
-    }
-
-    /////////////////////////////////////////////////
-    template <typename PolicyT, typename FeaturesT>
     std::size_t GetEngineInfo::Engine<PolicyT, FeaturesT>::GetIndex() const
     {
       return this->template Interface<GetEngineInfo>()
@@ -549,6 +540,15 @@ namespace gz
       return ConstModelPtrType(this->pimpl,
             this->template Interface<WorldModelFeature>()
               ->GetWorldModel(this->identity));
+    }
+
+    /////////////////////////////////////////////////
+    template <typename PolicyT, typename FeaturesT>
+    const gz::math::SemanticVersion &
+    GetEngineVersionInfo::Engine<PolicyT, FeaturesT>::GetVersion() const
+    {
+      return this->template Interface<GetEngineVersionInfo>()
+          ->GetEngineVersion(this->identity);
     }
   }
 }

--- a/test/include/mock/MockDoublePendulum.hh
+++ b/test/include/mock/MockDoublePendulum.hh
@@ -28,6 +28,7 @@ namespace mock
   using MockDoublePendulumList = gz::physics::FeatureList<
     gz::physics::ForwardStep,
     gz::physics::GetEngineInfo,
+    gz::physics::GetEngineVersionInfo,
     gz::physics::GetWorldFromEngine
   >;
 

--- a/test/plugins/DARTDoublePendulum.cc
+++ b/test/plugins/DARTDoublePendulum.cc
@@ -216,6 +216,13 @@ namespace mock
         return name;
       }
 
+      public: const gz::math::SemanticVersion &GetEngineVersion(
+          const Identity &/*_engineID*/) const override
+      {
+        static const gz::math::SemanticVersion version(1, 0);
+        return version;
+      }
+
       public: std::size_t GetEngineIndex(
           const Identity &/*_engineID*/) const override
       {

--- a/tpe/plugin/src/Base.hh
+++ b/tpe/plugin/src/Base.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_TPE_PLUGIN_SRC_BASE_HH_
 #define GZ_PHYSICS_TPE_PLUGIN_SRC_BASE_HH_
 
+#include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 
 #include <map>
@@ -61,6 +62,9 @@ struct CollisionInfo
 
 class Base : public Implements3d<FeatureList<Feature>>
 {
+  // TPE versioning is internal to gz-physics
+  public: const gz::math::SemanticVersion engineVersion{1, 0};
+
   public: inline Identity InitiateEngine(std::size_t /*_engineID*/) override
   {
     return this->GenerateIdentity(0);

--- a/tpe/plugin/src/EntityManagementFeatures.cc
+++ b/tpe/plugin/src/EntityManagementFeatures.cc
@@ -32,6 +32,12 @@ const std::string &EntityManagementFeatures::GetEngineName(
   return engineName;
 }
 
+const gz::math::SemanticVersion &EntityManagementFeatures::GetEngineVersion(
+  const Identity &) const
+{
+  return this->engineVersion;
+}
+
 /////////////////////////////////////////////////
 std::size_t EntityManagementFeatures::GetEngineIndex(
   const Identity &) const

--- a/tpe/plugin/src/EntityManagementFeatures.hh
+++ b/tpe/plugin/src/EntityManagementFeatures.hh
@@ -54,6 +54,9 @@ class EntityManagementFeatures :
   // ----- Get entities -----
   public: const std::string &GetEngineName(const Identity &) const override;
 
+  public: const gz::math::SemanticVersion &GetEngineVersion(
+      const Identity &) const override;
+
   public: std::size_t GetEngineIndex(const Identity &) const override;
 
   public: std::size_t GetWorldCount(const Identity &) const override;

--- a/tpe/plugin/src/EntityManagementFeatures.hh
+++ b/tpe/plugin/src/EntityManagementFeatures.hh
@@ -34,6 +34,7 @@ namespace tpeplugin {
 
 struct EntityManagementFeatureList : FeatureList<
   GetEngineInfo,
+  GetEngineVersionInfo,
   GetWorldFromEngine,
   GetModelFromWorld,
   GetNestedModelFromModel,


### PR DESCRIPTION
# 🎉 New feature

Rework of #857 to respect API

## Summary

**API Changes:**

1. Add `GetEngineVersionInfo` feature for engine version reporting
    * Adds new `GetEngineVersionInfo` feature as a separate, opt-in feature
    * Adds `GetVersion()` method to `GetEngineVersionInfo::Engine` API returning `gz::math::SemanticVersion`
    * Adds `GetEngineVersion()` pure virtual method to `GetEngineVersionInfo::Implementation`
    * Implements `GetEngineVersionInfo` in all physics engine plugins:
      - bullet and bullet-featherstone: parse `BT_BULLET_VERSION` macro to return SemanticVersion(3, 24)
      - dartsim: parse `DART_VERSION` macro string to SemanticVersion
      - tpe: return SemanticVersion(1, 0)


Leaves `GetEngineInfo` unchanged to avoid breaking 3rd-party plugins,  difference from #857

## Test

Testing with https://github.com/gazebosim/gz-sim/pull/3213, adding:

```diff
diff --git a/src/systems/physics/Physics.cc b/src/systems/physics/Physics.cc
index 98f4aa2fe..5bf7b510f 100644
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -180,7 +180,8 @@ class gz::sim::systems::PhysicsPrivate
           physics::sdf::ConstructSdfWorld,
           physics::GetLinkFromModel,
           physics::GetShapeFromLink,
-          physics::GetEngineInfo
+          physics::GetEngineInfo,
+          physics::GetEngineVersionInfo
           >{};
 
   /// \brief Engine type with just the minimum features.
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus/Sonnet 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.