### PR TITLE
Optimize build: Simplify and cleanup ComposePlugin and DeterminePlugin (Part 3)

### DIFF
--- a/include/gz/physics/FeatureList.hh
+++ b/include/gz/physics/FeatureList.hh
@@ -41,7 +41,6 @@ namespace gz
       // Forward declarations
       template <typename...> struct CombineLists;
       template <bool, typename...> struct SelfConflict;
-      template <typename> struct IterateList;
     }
 
     /////////////////////////////////////////////////
@@ -58,7 +57,7 @@ namespace gz
     /// using AdvancedList = FeatureList<BasicList, AdvancedA, AdvancedB>;
     /// \endcode
     template <typename... FeaturesT>
-    struct FeatureList : detail::IterateList<TypeList<FeaturesT...>>
+    struct FeatureList
     {
       /// Features is a std::tuple containing all the feature classes that are
       /// bundled in this list. This list is fully seralialized; any hierarchy
@@ -67,6 +66,7 @@ namespace gz
       public: using Features =
           typename detail::CombineLists<FeaturesT...>::Result;
 
+      /// This is the same as Features, but using TypeList
       public: using FlatFeatureTypeList =
           typename TupleToTypeList<Features>::type;
 

--- a/include/gz/physics/FeatureList.hh
+++ b/include/gz/physics/FeatureList.hh
@@ -41,7 +41,7 @@ namespace gz
       // Forward declarations
       template <typename...> struct CombineLists;
       template <bool, typename...> struct SelfConflict;
-      template <typename> struct IterateTuple;
+      template <typename> struct IterateList;
     }
 
     /////////////////////////////////////////////////
@@ -58,7 +58,7 @@ namespace gz
     /// using AdvancedList = FeatureList<BasicList, AdvancedA, AdvancedB>;
     /// \endcode
     template <typename... FeaturesT>
-    struct FeatureList : detail::IterateTuple<std::tuple<FeaturesT...>>
+    struct FeatureList : detail::IterateList<TypeList<FeaturesT...>>
     {
       /// Features is a std::tuple containing all the feature classes that are
       /// bundled in this list. This list is fully seralialized; any hierarchy
@@ -66,6 +66,9 @@ namespace gz
       /// member.
       public: using Features =
           typename detail::CombineLists<FeaturesT...>::Result;
+
+      public: using FlatFeatureTypeList =
+          typename TupleToTypeList<Features>::type;
 
       public: using FeatureTuple = std::tuple<FeaturesT...>;
 
@@ -79,7 +82,7 @@ namespace gz
 
       /// \brief A static constexpr function which indicates whether any
       /// features in SomeFeatureList conflict with any features in
-      /// SomeFeatureList.
+      /// this list.
       ///
       /// \tparam SomeFeatureList
       ///   The list to compare against for conflicts.

--- a/include/gz/physics/TemplateHelpers.hh
+++ b/include/gz/physics/TemplateHelpers.hh
@@ -31,11 +31,6 @@ namespace gz
     /// is useful for template metaprogramming.
     template <class... T> struct type { };
 
-    /// TODO(MXG): Remove this and use std::void_t instead when migrating to
-    /// C++17
-    template <typename...>
-    using void_t = void;
-
     /////////////////////////////////////////////////
     /// \brief Contains a static constexpr field named `value` which will be
     /// true if the type `From` has a const-quality less than or equal to the
@@ -83,7 +78,7 @@ namespace gz
   struct Select ## X \
   { \
     template<typename F, typename PolicyT, typename FeaturesT, \
-             typename = ::gz::physics::void_t<>> \
+             typename = std::void_t<>> \
     struct Implementation \
     { \
       using type = ::gz::physics::Empty; \
@@ -91,7 +86,7 @@ namespace gz
     \
     template<typename F, typename PolicyT, typename FeaturesT> \
     struct Implementation<F, PolicyT, FeaturesT, \
-                          ::gz::physics::void_t< \
+                          std::void_t< \
                               typename F::template X <PolicyT, FeaturesT>>> \
     { \
       using type = typename F::template X <PolicyT, FeaturesT>; \

--- a/include/gz/physics/TemplateHelpers.hh
+++ b/include/gz/physics/TemplateHelpers.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_TEMPLATEHELPERS_HH_
 #define GZ_PHYSICS_TEMPLATEHELPERS_HH_
 
+#include <tuple>
 #include <type_traits>
 
 namespace gz
@@ -30,6 +31,71 @@ namespace gz
     /// \brief This can be used to turn a type into a function argument, which
     /// is useful for template metaprogramming.
     template <class... T> struct type { };
+
+    /// \brief A minimal variadic template container for types.
+    /// This is used instead of std::tuple for intermediate template
+    /// metaprogramming to drastically reduce compiler memory and instantiation
+    /// times.
+    template <typename... Ts>
+    struct TypeList {
+      static constexpr std::size_t size = sizeof...(Ts);
+    };
+
+    /// \brief Concatenate multiple TypeLists into a single TypeList.
+    ///
+    /// This uses an O(log N) tree-based recursion instead of an O(N) linear
+    /// recursion. When concatenating many lists (e.g., during feature
+    /// flattening), a linear recursion would instantiate a deeply nested stack
+    /// of templates, which can quickly exceed the compiler's maximum
+    /// instantiation depth or heap space limits (especially on MSVC).
+    /// By pairing elements and recursing down, we keep the instantiation stack
+    /// shallow and dramatically reduce compiler memory consumption.
+    template <typename... Lists>
+    struct TypeListCat;
+
+    template <>
+    struct TypeListCat<> {
+      using type = TypeList<>;
+    };
+
+    template <typename... Ts>
+    struct TypeListCat<TypeList<Ts...>> {
+      using type = TypeList<Ts...>;
+    };
+
+    template <typename... T1, typename... T2>
+    struct TypeListCat<TypeList<T1...>, TypeList<T2...>> {
+      using type = TypeList<T1..., T2...>;
+    };
+
+    // We explicitly require at least 3 lists (L1, L2, L3) to use this
+    // recursive specialization. This prevents an ambiguity error with the
+    // 2-element base case `TypeListCat<TypeList<T1...>, TypeList<T2...>>`
+    // when exactly 2 lists are provided.
+    template <typename L1, typename L2, typename L3, typename... Rest>
+    struct TypeListCat<L1, L2, L3, Rest...> {
+      using type = typename TypeListCat<
+          typename TypeListCat<L1, L2>::type,
+          typename TypeListCat<L3, Rest...>::type>::type;
+    };
+
+    /// \brief Convert a TypeList to a std::tuple
+    template <typename T>
+    struct ToTuple;
+
+    template <typename... Ts>
+    struct ToTuple<TypeList<Ts...>> {
+      using type = std::tuple<Ts...>;
+    };
+
+    /// \brief Convert a std::tuple to a TypeList
+    template <typename T>
+    struct TupleToTypeList;
+
+    template <typename... Ts>
+    struct TupleToTypeList<std::tuple<Ts...>> {
+      using type = TypeList<Ts...>;
+    };
 
     /////////////////////////////////////////////////
     /// \brief Contains a static constexpr field named `value` which will be

--- a/include/gz/physics/detail/DeclareDerivedType.hh
+++ b/include/gz/physics/detail/DeclareDerivedType.hh
@@ -48,7 +48,7 @@
             template type<PolicyT, FeaturesT> \
     { \
       public: using Identifier = Derived ## Identifier; \
-      public: using UpcastIdentifiers = std::tuple< \
+      public: using UpcastIdentifiers = TypeList< \
           Derived ## Identifier, \
           /* Allow this derived type to be upcast to plain base types */ \
           ::gz::physics::detail:: Base ## Identifier>; \

--- a/include/gz/physics/detail/Entity.hh
+++ b/include/gz/physics/detail/Entity.hh
@@ -37,48 +37,34 @@ namespace gz
       /// This class provides a static constexpr member named `value` which is
       /// true if T is one of the entries of Tuple, and false otherwise.
       template <typename T, typename Tuple>
-      struct TupleContainsBase;
+      struct TypeListContainsBase;
 
-      /// \private This specialization implements TupleContainsBase. It only
-      /// works if Tuple is a std::tuple; any other type for the second template
+      /// \private This specialization implements TypeListContainsBase. It only
+      /// works if List is a TypeList; any other type for the second template
       /// argument will fail to compile.
       template <typename T, typename... Types>
-      struct TupleContainsBase<T, std::tuple<Types...>>
-          : std::integral_constant<bool,
-              !std::is_same<
-                std::tuple<typename std::conditional<
-                  std::is_base_of<T, Types>::value, Empty, Types>::type...>,
-                std::tuple<Types...>
-              >::value> { };
-
-      /////////////////////////////////////////////////
-      template <typename ToFeatureTuple, typename FromFeatureList>
-      struct HasAllFeaturesImpl;
-
-      template <typename FromFeatureList,
-                typename ToFeature1, typename... RemainingFeatures>
-      struct HasAllFeaturesImpl<
-          std::tuple<ToFeature1, RemainingFeatures...>, FromFeatureList>
+      struct TypeListContainsBase<T, TypeList<Types...>>
+          : std::integral_constant<bool, (std::is_base_of_v<T, Types> || ...)>
       {
-        static constexpr bool innerValue =
-            FromFeatureList::template HasFeature<ToFeature1>();
-
-        static constexpr bool value = innerValue
-            && HasAllFeaturesImpl<std::tuple<RemainingFeatures...>,
-                                  FromFeatureList>::value;
-
-        static_assert(
-            innerValue,
-            "YOU CANNOT IMPLICITLY UPCAST TO THIS ENTITY TYPE, BECAUSE IT "
-            "CONTAINS A FEATURE THAT IS NOT INCLUDED IN THE ENTITY THAT YOU "
-            "ARE CASTING FROM.");
       };
 
       /////////////////////////////////////////////////
-      template <typename FromFeatureList>
-      struct HasAllFeaturesImpl<std::tuple<>, FromFeatureList>
+      template <typename ToFeatureList, typename FromFeatureList>
+      struct HasAllFeaturesImpl;
+
+      template <typename... ToFeatures, typename FromFeatureList>
+      struct HasAllFeaturesImpl<TypeList<ToFeatures...>, FromFeatureList>
       {
-        static constexpr bool value = true;
+        // Note: For an empty TypeList (base case), the C++17 fold expression
+        // over `&&` evaluates to `true` by definition.
+        // See: https://en.cppreference.com/w/cpp/language/fold
+        static constexpr bool value =
+            (FromFeatureList::template HasFeature<ToFeatures>() && ...);
+        static_assert(
+            value || sizeof...(ToFeatures) == 0,
+            "YOU CANNOT IMPLICITLY UPCAST TO THIS ENTITY TYPE, BECAUSE IT "
+            "CONTAINS A FEATURE THAT IS NOT INCLUDED IN THE ENTITY THAT YOU "
+            "ARE CASTING FROM.");
       };
 
       /////////////////////////////////////////////////
@@ -92,7 +78,7 @@ namespace gz
 
         static constexpr bool value =
             HasAllFeaturesImpl<
-                typename ToFeatures::Features,
+                typename ToFeatures::FlatFeatureTypeList,
                 FromFeatures>::value;
       };
 
@@ -101,7 +87,7 @@ namespace gz
       struct CheckForDowncastableMessage
       {
         static constexpr bool value =
-            TupleContainsBase<typename To::Identifier,
+            TypeListContainsBase<typename To::Identifier,
                               typename From::UpcastIdentifiers>::value;
 
         static_assert(
@@ -116,7 +102,7 @@ namespace gz
       struct CheckForDowncastableMessage<To, From, true>
       {
         static constexpr bool value =
-            TupleContainsBase<typename To::Identifier,
+            TypeListContainsBase<typename To::Identifier,
                               typename From::UpcastIdentifiers>::value;
 
         static_assert(
@@ -140,7 +126,7 @@ namespace gz
         static_assert(HasAllFeatures<To, From>::value);
 
         static_assert(CheckForDowncastableMessage<To, From,
-                      TupleContainsBase<
+                      TypeListContainsBase<
                         typename From::Identifier,
                         typename To::UpcastIdentifiers>::value>::value);
 

--- a/include/gz/physics/detail/FeatureList.hh
+++ b/include/gz/physics/detail/FeatureList.hh
@@ -36,100 +36,34 @@ namespace gz
     namespace detail
     {
       /////////////////////////////////////////////////
-      template <typename>
-      struct IterateList;
+      /// \private ComposePluginFromList takes a TypeList of fully-instantiated
+      /// Feature Implementation classes (e.g.,
+      /// FeatureA::Implementation<Policy>, FeatureB::Implementation<Policy>)
+      /// and generates a linear inheritance chain of SpecializedPlugin
+      /// instances.
+      ///
+      /// This tail-recursive linear chain avoids the "Ambiguous Base Class"
+      /// compiler error that would occur with flat multiple inheritance if
+      /// multiple features happen to share the same underlying base class from
+      /// gz-plugin.
+      template <typename List>
+      struct ComposePluginFromList;
 
-      template <typename Current, typename... T>
-      struct IterateList<TypeList<Current, T...>>
+      template <typename Impl, typename... Others>
+      struct ComposePluginFromList<TypeList<Impl, Others...>>
       {
-        using CurrentTupleEntry = Current;
-        using NextTupleEntry = IterateList<TypeList<T...>>;
-      };
-
-      template <typename Current>
-      struct IterateList<TypeList<Current>>
-      {
-        using CurrentTupleEntry = Current;
+        struct type :
+            ::gz::plugin::SpecializedPlugin<Impl>,
+            ComposePluginFromList<TypeList<Others...>>::type { };
       };
 
       template <>
-      struct IterateList<TypeList<>>
-      {
-        using CurrentTupleEntry = void;
-      };
-
-      template <typename Iterable, typename = std::void_t<>>
-      struct GetNext
-      {
-        using n = void;
-      };
-
-      template <typename Iterable>
-      struct GetNext<Iterable, std::void_t<typename Iterable::NextTupleEntry>>
-      {
-        // This struct is intentionally named with only one letter, because its
-        // name will be repeated many times in the symbol names of aggregated
-        // types. Do not change this name to anything longer than 1 letter or
-        // else the compiled symbol names will be needlessly long, and that can
-        // be costly to memory and performance.
-        struct n : Iterable::NextTupleEntry { };
-      };
-
-      template <typename Policy, typename Feature, typename = std::void_t<>>
-      struct ComposePlugin;
-
-      template <typename Policy, typename Feature, bool HasRequirements>
-      struct CheckRequirements
-      {
-        using type =
-            ::gz::plugin::SpecializedPlugin<
-                typename Feature::template Implementation<Policy>>;
-      };
-
-      template <typename Policy, typename Feature>
-      struct CheckRequirements<Policy, Feature, true>
-      {
-        struct type :
-            ::gz::plugin::SpecializedPlugin<
-                typename Feature::template Implementation<Policy>>,
-            ComposePlugin<Policy, typename Feature::RequiredFeatures>::type { };
-      };
-
-      template <typename Policy, typename Feature, typename>
-      struct ComposePlugin
-      {
-        struct type : CheckRequirements<Policy, Feature,
-            !std::is_void_v<typename Feature::RequiredFeatures>>::type { };
-      };
-
-      template <typename Policy, typename Iterable>
-      struct ComposePlugin<Policy, Iterable,
-          std::void_t<typename Iterable::CurrentTupleEntry>>
-      {
-        struct type :
-            ComposePlugin<Policy, typename Iterable::CurrentTupleEntry>::type,
-            ComposePlugin<Policy, typename GetNext<Iterable>::n> { };
-      };
-
-      template <typename Policy>
-      struct ComposePlugin<Policy, void, std::void_t<>>
+      struct ComposePluginFromList<TypeList<>>
       {
         struct type { };
       };
 
-      /////////////////////////////////////////////////
-      /// \private This class is used to determine what type of
-      /// SpecializedPluginPtr should be used by the entities provided by a
-      /// plugin.
-      template <typename Policy, typename FeaturesT>
-      struct DeterminePlugin
-      {
-        struct Specializer
-            : ::gz::plugin::detail::SelectSpecializers<
-              typename ComposePlugin<Policy, FeaturesT>::type> { };
 
-        using type = ::gz::plugin::TemplatePluginPtr<Specializer>;
-      };
 
       /////////////////////////////////////////////////
       /// \private This class provides a sanity check to make sure at compile
@@ -476,38 +410,7 @@ namespace gz
       struct SelfConflict<AssertNoConflict>
           : std::integral_constant<bool, false> {};
 
-      /////////////////////////////////////////////////
-      /// \private Extract the API out of a FeatureList
-      template <template<typename> class Selector,
-                typename FeatureT, typename = std::void_t<>>
-      struct Aggregate
-      {
-        public: template<typename... T>
-        struct type
-            : public virtual Selector<FeatureT>::template type<T...>,
-              public virtual Aggregate<Selector,
-                typename FeatureT::RequiredFeatures>::template type<T...>
-        { };
-      };
 
-      template <template<typename> class Selector>
-      struct Aggregate<Selector, void, std::void_t<>>
-      {
-        public: template<typename... T>
-        struct type { };
-      };
-
-      template <template<typename> class Selector, typename Iterable>
-      struct Aggregate<Selector, Iterable,
-            std::void_t<typename Iterable::CurrentTupleEntry>>
-      {
-        public: template <typename... T>
-        struct type
-            : public virtual Aggregate<Selector,
-                  typename Iterable::CurrentTupleEntry>::template type<T...>,
-              public virtual Aggregate<Selector,
-                  typename GetNext<Iterable>::n>::template type<T...> { };
-      };
 
       /////////////////////////////////////////////////
       template <template<typename> class Selector, typename FeatureListT>
@@ -564,7 +467,6 @@ namespace gz
     template <typename SomeFeatureList, bool AssertNoConflict>
     constexpr bool FeatureList<FeaturesT...>::ConflictsWith()
     {
-      // TODO(MXG): Replace this with a simple fold expression once we use C++17
       return
           detail::ConflictingLists<
               SomeFeatureList, AssertNoConflict, FlatFeatureTypeList>::value
@@ -715,6 +617,30 @@ namespace gz
       using ExtractImplementation =
         typename ExtractAPI<ImplementationSelector, List>
             ::template type<PolicyT>;
+
+      /////////////////////////////////////////////////
+      /// \private This class is used to determine what type of
+      /// SpecializedPluginPtr should be used by the entities provided by a
+      /// plugin.
+      template <typename Policy, typename FeaturesT>
+      struct DeterminePlugin
+      {
+        template <typename T>
+        struct Selector
+        {
+          template <typename PolicyT>
+          using type = typename T::template Implementation<PolicyT>;
+        };
+
+        struct Specializer
+            : ::gz::plugin::detail::SelectSpecializers<
+              typename ComposePluginFromList<
+                  typename ExtractAPI<Selector, FeaturesT>
+                      ::template Bases<Policy>
+              >::type> { };
+
+        using type = ::gz::plugin::TemplatePluginPtr<Specializer>;
+      };
     }
   }
 }

--- a/include/gz/physics/detail/FeatureList.hh
+++ b/include/gz/physics/detail/FeatureList.hh
@@ -36,24 +36,24 @@ namespace gz
     namespace detail
     {
       /////////////////////////////////////////////////
-      template <typename T>
-      struct IterateTuple;
+      template <typename>
+      struct IterateList;
 
       template <typename Current, typename... T>
-      struct IterateTuple<std::tuple<Current, T...>>
+      struct IterateList<TypeList<Current, T...>>
       {
         using CurrentTupleEntry = Current;
-        using NextTupleEntry = IterateTuple<std::tuple<T...>>;
+        using NextTupleEntry = IterateList<TypeList<T...>>;
       };
 
       template <typename Current>
-      struct IterateTuple<std::tuple<Current>>
+      struct IterateList<TypeList<Current>>
       {
         using CurrentTupleEntry = Current;
       };
 
       template <>
-      struct IterateTuple<std::tuple<>>
+      struct IterateList<TypeList<>>
       {
         using CurrentTupleEntry = void;
       };
@@ -172,30 +172,48 @@ namespace gz
       class ExtractFeatures
           : public VerifyFeatures<F>
       {
-        public: using type = std::tuple<F>;
+        public: using type = TypeList<F>;
       };
 
       /// \private This specialization of ExtractFeatures is used to wipe away
       /// a tuple that is currently holding a set of features, then verify those
-      /// features, and finally repackage them as a tuple.
+      /// features, and finally repackage them as a TypeList.
       template <typename... F>
       class ExtractFeatures<std::tuple<F...>>
           : public VerifyFeatures<F...>
       {
-        public: using type = std::tuple<F...>;
+        public: using type = TypeList<F...>;
+      };
+
+      /// \private This specialization of ExtractFeatures is used to wipe away
+      /// a TypeList that is currently holding a set of features, then verify
+      /// those features, and finally repackage them as a TypeList.
+      template <typename... F>
+      class ExtractFeatures<TypeList<F...>>
+          : public VerifyFeatures<F...>
+      {
+        public: using type = TypeList<F...>;
+      };
+
+      template <typename T> struct TupleToTypeList;
+      template <typename... Ts>
+      struct TupleToTypeList<std::tuple<Ts...>>
+      {
+        using type = TypeList<Ts...>;
       };
 
       /// \private This specialization of ExtractFeatures is used to wipe away
       /// the FeatureList that is currently holding a set of features, then
       /// verify those features, and finally repackage them as the raw feature
-      /// tuple that is being held by the FeatureList.
+      /// TypeList that is being held by the FeatureList.
       template <typename SomeFeatureList>
       class ExtractFeatures<
               SomeFeatureList,
               std::void_t<typename SomeFeatureList::Features>>
           : public VerifyFeatures<typename SomeFeatureList::Features>
       {
-        public: using type = typename SomeFeatureList::Features;
+        public: using type =
+            typename TupleToTypeList<typename SomeFeatureList::Features>::type;
       };
 
       /// \private This specialization skips over any void entries. This allows
@@ -204,112 +222,101 @@ namespace gz
       template <>
       class ExtractFeatures<void>
       {
-        public: using type = std::tuple<>;
+        public: using type = TypeList<>;
       };
 
       /////////////////////////////////////////////////
-      /// \private This struct wraps the TupleContainsBase class to create a
-      /// tuple filter that can be passed to FilterTuple.
-      template <typename DiscardTuple>
-      struct RedundantTupleFilter
+      /// \private This struct wraps the TypeListContainsBase class to create a
+      /// TypeList filter that can be passed to FilterList.
+      template <typename DiscardList>
+      struct RedundantListFilter
       {
         template <typename T>
-        struct Apply : TupleContainsBase<T, DiscardTuple> { };
+        struct Apply : TypeListContainsBase<T, DiscardList> { };
       };
 
       /////////////////////////////////////////////////
-      template <template <typename> class Filter, typename InputTuple>
-      struct FilterTuple;
+      template <template <typename> class Filter, typename InputList>
+      struct FilterList;
 
       /////////////////////////////////////////////////
-      /// \private This class will apply a Filter to a tuple and produce a new
-      /// tuple that only includes the tuple elements which were ignored by the
-      /// Filter.
+      /// \private This class will apply a Filter to a TypeList and produce a
+      /// new TypeList that only includes the TypeList elements which were
+      /// ignored by the Filter.
       template <template <typename> class Filter, typename... InputTypes>
-      struct FilterTuple<Filter, std::tuple<InputTypes...>>
+      struct FilterList<Filter, TypeList<InputTypes...>>
       {
-        using type = decltype(std::tuple_cat(
+        using type = typename TypeListCat<
             std::conditional_t<
               // If the input type is a base class of anything that should be
               // discared ...
               Filter<InputTypes>::value,
-              // ... then we should leave it out of the final tuple ...
-              std::tuple<>,
+              // ... then we should leave it out of the final TypeList ...
+              TypeList<>,
               // ... otherwise, include it.
-              std::tuple<InputTypes>
+              TypeList<InputTypes>
             // Do this for each type in the InputTypes parameter pack.
-            >()...));
+            >...
+        >::type;
       };
 
       /////////////////////////////////////////////////
-      /// \private Use this struct to remove the tuple elements of one tuple
-      /// from another tuple
-      template <typename DiscardTuple>
-      struct SubtractTuple
+      /// \private Use this struct to remove the TypeList elements of one
+      /// TypeList from another TypeList
+      template <typename DiscardList>
+      struct SubtractList
       {
         template <typename T>
         using Filter =
-            typename RedundantTupleFilter<DiscardTuple>::template Apply<T>;
+            typename RedundantListFilter<DiscardList>::template Apply<T>;
 
         /// This struct will contain a nested struct called `type` which will be
-        /// a tuple with all the elements of FromTuple that are not present in
-        /// DiscardTuple
-        template <typename FromTuple>
-        struct From : FilterTuple<Filter, FromTuple> { };
+        /// a TypeList with all the elements of FromList that are not present in
+        /// DiscardList
+        template <typename FromList>
+        struct From : FilterList<Filter, FromList> { };
       };
 
       /////////////////////////////////////////////////
-      /// \private This template takes in a tuple as InputTuple and gives back
-      /// a tuple where every element type is only present once.
+      /// \private This template takes in a TypeList as InputList and gives back
+      /// a TypeList where every element type is only present once.
+      template <typename InputList, typename AccumulatedList = TypeList<>>
+      struct RemoveListRedundancies;
+
+      template <typename AccumulatedList>
+      struct RemoveListRedundancies<TypeList<>, AccumulatedList>
+      {
+        using type = TypeList<>;
+      };
+
+      template <typename F1, typename... Others, typename... Acc>
+      struct RemoveListRedundancies<TypeList<F1, Others...>, TypeList<Acc...>>
+      {
+        using PartialResult =
+            std::conditional_t<
+              TypeListContainsBase<F1, TypeList<Acc...>>::value,
+              TypeList<>,
+              TypeList<F1>
+            >;
+
+        using NextAcc =
+            typename TypeListCat<TypeList<Acc...>, PartialResult>::type;
+
+        using type = typename TypeListCat<
+            PartialResult,
+            typename RemoveListRedundancies<TypeList<Others...>, NextAcc>::type
+        >::type;
+      };
+
       template <typename InputTuple>
       struct RemoveTupleRedundancies;
-
-      template <typename T>
-      struct wrap { };
-
-      template <typename Tuple>
-      struct unwrap;
-
-      template <typename... T>
-      struct unwrap<std::tuple<wrap<T>...>>
-      {
-        using type = std::tuple<T...>;
-      };
 
       template <typename... InputTupleArgs>
       struct RemoveTupleRedundancies<std::tuple<InputTupleArgs...>>
       {
-        template <typename PartialResultInput, typename...>
-        struct Impl;
-
-        template <typename PartialResultInput>
-        struct Impl<PartialResultInput>
-        {
-          using type = std::tuple<>;
-        };
-
-        template <typename ParentResultInput, typename F1, typename... Others>
-        struct Impl<ParentResultInput, F1, Others...>
-        {
-          using PartialResult =
-              std::conditional_t<
-                TupleContainsBase<wrap<F1>, ParentResultInput>::value,
-                std::tuple<>,
-                std::tuple<wrap<F1>>
-              >;
-
-          using AggregateResult = decltype(std::tuple_cat(
-              ParentResultInput(), PartialResult()));
-
-          using type = decltype(std::tuple_cat(
-              PartialResult(),
-              typename Impl<AggregateResult, Others...>::type()));
-        };
-
-        using type =
-          typename unwrap<
-            typename Impl<std::tuple<>, InputTupleArgs...>::type
-          >::type;
+        using type = typename ToTuple<
+            typename RemoveListRedundancies<TypeList<InputTupleArgs...>>::type
+        >::type;
       };
 
       /////////////////////////////////////////////////
@@ -325,19 +332,20 @@ namespace gz
       {
         using type = std::conditional_t<
             std::is_void_v<typename FeatureOrList::RequiredFeatures>,
-            std::tuple<FeatureOrList>,
-            decltype(std::tuple_cat(
-              std::tuple<FeatureOrList>(),
+            TypeList<FeatureOrList>,
+            typename TypeListCat<
+              TypeList<FeatureOrList>,
               typename FlattenFeatures<
-                typename FeatureOrList::RequiredFeatures>::type()))
+                typename FeatureOrList::RequiredFeatures>::type>::type
         >;
       };
 
       /////////////////////////////////////////////////
       template <typename List>
-      struct ExpandFeatures<List, std::void_t<typename List::Features>>
+      struct ExpandFeatures<List, std::void_t<typename List::FeatureTuple>>
       {
-        using type = typename FlattenFeatures<typename List::Features>::type;
+        using type =
+            typename FlattenFeatures<typename List::FeatureTuple>::type;
       };
 
       /////////////////////////////////////////////////
@@ -353,15 +361,23 @@ namespace gz
       template <typename... Features>
       struct FlattenFeatures<std::tuple<Features...>, std::void_t<>>
       {
-        using type = decltype(std::tuple_cat(
-            typename ExpandFeatures<Features>::type()...));
+        using type = typename TypeListCat<
+            typename ExpandFeatures<Features>::type...>::type;
+      };
+
+      /////////////////////////////////////////////////
+      template <typename... Features>
+      struct FlattenFeatures<TypeList<Features...>, std::void_t<>>
+      {
+        using type = typename TypeListCat<
+            typename ExpandFeatures<Features>::type...>::type;
       };
 
       /////////////////////////////////////////////////
       template <>
       struct FlattenFeatures<void>
       {
-        using type = std::tuple<>;
+        using type = TypeList<>;
       };
 
       /////////////////////////////////////////////////
@@ -374,7 +390,7 @@ namespace gz
       template <typename PartialResultInput>
       struct CombineListsImpl<PartialResultInput>
       {
-        using type = std::tuple<>;
+        using type = TypeList<>;
       };
 
       template <typename ParentResultInput, typename F1, typename... Others>
@@ -383,66 +399,61 @@ namespace gz
         // Add the features of the feature list F1, while filtering out any
         // repeated features.
         using InitialResult =
-            typename SubtractTuple<ParentResultInput>
+            typename SubtractList<ParentResultInput>
             ::template From<typename ExtractFeatures<F1>::type>::type;
 
         // Add the features that are required by F1, while filtering out any
         // repeated features.
-        using PartialResult = decltype(std::tuple_cat(
-            InitialResult(),
-            typename SubtractTuple<
-              decltype(std::tuple_cat(ParentResultInput(), InitialResult()))>
+        using PartialResult = typename TypeListCat<
+            InitialResult,
+            typename SubtractList<
+              typename TypeListCat<ParentResultInput, InitialResult>::type>
               ::template From<
                 typename ExtractFeatures<typename F1::RequiredFeatures>::type
-            >::type()));
+            >::type>::type;
 
-        // Define the tuple that the child should use to filter its list
+        // Define the TypeList that the child should use to filter its list
         using ChildFilter =
-            decltype(std::tuple_cat(ParentResultInput(), PartialResult()));
+            typename TypeListCat<ParentResultInput, PartialResult>::type;
 
         // Construct the final result
-        using type = decltype(std::tuple_cat(
-            PartialResult(),
-            typename CombineListsImpl<ChildFilter, Others...>::type()));
+        using type = typename TypeListCat<
+            PartialResult,
+            typename CombineListsImpl<ChildFilter, Others...>::type>::type;
       };
 
       /// \private CombineLists is used to take variadic lists of features,
-      /// FeatureLists, or std::tuples of features, and collapse them into a
+      /// FeatureLists, or TypeLists of features, and collapse them into a
       /// serialized std::tuple of features.
       ///
       /// This class works recursively.
       template <typename... FeatureLists>
       struct CombineLists
       {
-        public: using Result =
-            typename CombineListsImpl<std::tuple<>, FeatureLists...>::type;
+        public: using Result = typename ToTuple<
+            typename CombineListsImpl<TypeList<>, FeatureLists...>::type>::type;
       };
 
       /////////////////////////////////////////////////
       /// \private This class helps to implement the function
       /// FeatureList::ConflictsWith(). Its implementation is conceptually
-      /// similar to TupleContainsBase.
+      /// similar to TypeListContainsBase.
       template <typename SomeFeatureList, bool AssertNoConflict, typename Tuple>
       struct ConflictingLists;
 
       /// \private Implementation of ConflictingLists. If the Tuple argument is
-      /// not a std::tuple, this class will be undefined.
+      /// not a TypeList, this class will be undefined.
       template <typename SomeFeatureList, bool AssertNoConflict,
                 typename... Features>
       struct ConflictingLists<
-          SomeFeatureList, AssertNoConflict, std::tuple<Features...>>
+          SomeFeatureList, AssertNoConflict, TypeList<Features...>>
           : std::integral_constant<bool,
-              !std::is_same<
-                std::tuple<typename std::conditional<
-                  Features::template ConflictsWith<
-                    SomeFeatureList, AssertNoConflict>(),
-                  Empty, Features>::type...>,
-              std::tuple<Features...>
-            >::value> { };
+              (Features::template ConflictsWith<
+                SomeFeatureList, AssertNoConflict>() || ...)> { };
 
       /////////////////////////////////////////////////
-      /// \private Check whether any feature within a std::tuple of features
-      /// conflicts with any other feature in that tuple.
+      /// \private Check whether any feature within a TypeList of features
+      /// conflicts with any other feature in that TypeList.
       template <bool AssertNoConflict, typename... FeatureLists>
       struct SelfConflict;
 
@@ -506,11 +517,10 @@ namespace gz
         struct Select;
 
         template <typename... Features, typename... T>
-        struct Select<std::tuple<Features...>, T...>
+        struct Select<TypeList<Features...>, T...>
         {
-          using type =
-            typename RemoveTupleRedundancies<
-              std::tuple<typename Selector<Features>::template type<T...>...>
+          using type = typename RemoveListRedundancies<
+              TypeList<typename Selector<Features>::template type<T...>...>
             >::type;
         };
 
@@ -520,32 +530,24 @@ namespace gz
         template <typename... T>
         using Bases =
             typename Select<
-              typename FilterTuple<
+              typename FilterList<
                 Filter,
                 typename FlattenFeatures<FeatureListT>::type
               >::type,
               T...
             >::type;
 
-        template <typename... T>
-        struct S : std::tuple_size<Bases<T...>> { };
-
-        template <typename... T>
-        using IndexSequence = std::make_index_sequence<S<T...>::value>;
-
-        template <typename>
+        template <typename List>
         struct Impl;
 
-        template <std::size_t... I>
-        struct Impl<std::index_sequence<I...>>
+        template <typename... B>
+        struct Impl<TypeList<B...>>
         {
-          template<typename... T>
-          class type
-              : public virtual std::tuple_element<I, Bases<T...>>::type... { };
+          class type : public virtual B... { };
         };
 
         template <typename... T>
-        using type = typename Impl<IndexSequence<T...>>::template type<T...>;
+        using type = typename Impl<Bases<T...>>::type;
       };
     }
 
@@ -554,7 +556,7 @@ namespace gz
     template <typename F>
     constexpr bool FeatureList<FeaturesT...>::HasFeature()
     {
-      return detail::TupleContainsBase<F, Features>::value;
+      return detail::TypeListContainsBase<F, FlatFeatureTypeList>::value;
     }
 
     /////////////////////////////////////////////////
@@ -565,10 +567,11 @@ namespace gz
       // TODO(MXG): Replace this with a simple fold expression once we use C++17
       return
           detail::ConflictingLists<
-              SomeFeatureList, AssertNoConflict, Features>::value
+              SomeFeatureList, AssertNoConflict, FlatFeatureTypeList>::value
        || detail::ConflictingLists<
               FeatureList<FeaturesT...>, AssertNoConflict,
-              typename FeatureList<SomeFeatureList>::Features>::value;
+              typename FeatureList<SomeFeatureList>::FlatFeatureTypeList>::
+              value;
     }
 
     /////////////////////////////////////////////////
@@ -637,15 +640,17 @@ namespace gz
     GZ_PHYSICS_CREATE_SELECTOR(X) \
     /* Symbol used by X-types to identify other X-types */ \
     struct X ## Identifier { }; \
+    template <typename PolicyT, typename FeaturesT> \
+    struct X ## _API : public ::gz::physics::detail::ExtractAPI< \
+          detail::Select ## X, FeaturesT> \
+            ::template type<PolicyT, FeaturesT> { }; \
   } \
   template <typename PolicyT, typename FeaturesT> \
-  class X : public ::gz::physics::detail::ExtractAPI< \
-        detail::Select ## X, FeaturesT> \
-          ::template type<PolicyT, FeaturesT>, \
+  class X : public detail:: X ## _API <PolicyT, FeaturesT>, \
       public virtual Entity<PolicyT, FeaturesT> \
   { \
     public: using Identifier = detail:: X ## Identifier; \
-    public: using UpcastIdentifiers = std::tuple<detail:: X ## Identifier>; \
+    public: using UpcastIdentifiers = TypeList<detail:: X ## Identifier>; \
     public: using Base = Entity<PolicyT, FeaturesT>; \
     \
     public: X(const X&) = default; \

--- a/include/gz/physics/detail/FeatureList.hh
+++ b/include/gz/physics/detail/FeatureList.hh
@@ -58,14 +58,14 @@ namespace gz
         using CurrentTupleEntry = void;
       };
 
-      template <typename Iterable, typename = void_t<>>
+      template <typename Iterable, typename = std::void_t<>>
       struct GetNext
       {
         using n = void;
       };
 
       template <typename Iterable>
-      struct GetNext<Iterable, void_t<typename Iterable::NextTupleEntry>>
+      struct GetNext<Iterable, std::void_t<typename Iterable::NextTupleEntry>>
       {
         // This struct is intentionally named with only one letter, because its
         // name will be repeated many times in the symbol names of aggregated
@@ -75,7 +75,7 @@ namespace gz
         struct n : Iterable::NextTupleEntry { };
       };
 
-      template <typename Policy, typename Feature, typename = void_t<>>
+      template <typename Policy, typename Feature, typename = std::void_t<>>
       struct ComposePlugin;
 
       template <typename Policy, typename Feature, bool HasRequirements>
@@ -104,7 +104,7 @@ namespace gz
 
       template <typename Policy, typename Iterable>
       struct ComposePlugin<Policy, Iterable,
-          void_t<typename Iterable::CurrentTupleEntry>>
+          std::void_t<typename Iterable::CurrentTupleEntry>>
       {
         struct type :
             ComposePlugin<Policy, typename Iterable::CurrentTupleEntry>::type,
@@ -112,7 +112,7 @@ namespace gz
       };
 
       template <typename Policy>
-      struct ComposePlugin<Policy, void, void_t<>>
+      struct ComposePlugin<Policy, void, std::void_t<>>
       {
         struct type { };
       };
@@ -168,7 +168,7 @@ namespace gz
       /// This default implementation simply takes in a single feature and puts
       /// it into a tuple of size one. This allows us to use std::tuple_cat on
       /// it later to combine it with tuples that may contain multiple features.
-      template <typename F, typename = void_t<> >
+      template <typename F, typename = std::void_t<> >
       class ExtractFeatures
           : public VerifyFeatures<F>
       {
@@ -192,7 +192,7 @@ namespace gz
       template <typename SomeFeatureList>
       class ExtractFeatures<
               SomeFeatureList,
-              void_t<typename SomeFeatureList::Features>>
+              std::void_t<typename SomeFeatureList::Features>>
           : public VerifyFeatures<typename SomeFeatureList::Features>
       {
         public: using type = typename SomeFeatureList::Features;
@@ -315,12 +315,12 @@ namespace gz
       /////////////////////////////////////////////////
       /// \private This template is used to take a hierarchy of FeatureLists and
       /// flatten them into a single tuple.
-      template <typename FeatureTuple, typename = void_t<>>
+      template <typename FeatureTuple, typename = std::void_t<>>
       struct FlattenFeatures;
 
       /////////////////////////////////////////////////
       /// \private This template is a helper for FlattenFeatures
-      template <typename FeatureOrList, typename = void_t<>>
+      template <typename FeatureOrList, typename = std::void_t<>>
       struct ExpandFeatures
       {
         using type = std::conditional_t<
@@ -335,7 +335,7 @@ namespace gz
 
       /////////////////////////////////////////////////
       template <typename List>
-      struct ExpandFeatures<List, void_t<typename List::Features>>
+      struct ExpandFeatures<List, std::void_t<typename List::Features>>
       {
         using type = typename FlattenFeatures<typename List::Features>::type;
       };
@@ -343,7 +343,7 @@ namespace gz
       /////////////////////////////////////////////////
       template <typename FeatureListT>
       struct FlattenFeatures<
-          FeatureListT, void_t<typename FeatureListT::FeatureTuple>>
+          FeatureListT, std::void_t<typename FeatureListT::FeatureTuple>>
       {
         using type =
             typename FlattenFeatures<typename FeatureListT::FeatureTuple>::type;
@@ -351,7 +351,7 @@ namespace gz
 
       /////////////////////////////////////////////////
       template <typename... Features>
-      struct FlattenFeatures<std::tuple<Features...>, void_t<>>
+      struct FlattenFeatures<std::tuple<Features...>, std::void_t<>>
       {
         using type = decltype(std::tuple_cat(
             typename ExpandFeatures<Features>::type()...));
@@ -468,7 +468,7 @@ namespace gz
       /////////////////////////////////////////////////
       /// \private Extract the API out of a FeatureList
       template <template<typename> class Selector,
-                typename FeatureT, typename = void_t<>>
+                typename FeatureT, typename = std::void_t<>>
       struct Aggregate
       {
         public: template<typename... T>
@@ -480,7 +480,7 @@ namespace gz
       };
 
       template <template<typename> class Selector>
-      struct Aggregate<Selector, void, void_t<>>
+      struct Aggregate<Selector, void, std::void_t<>>
       {
         public: template<typename... T>
         struct type { };
@@ -488,7 +488,7 @@ namespace gz
 
       template <template<typename> class Selector, typename Iterable>
       struct Aggregate<Selector, Iterable,
-            void_t<typename Iterable::CurrentTupleEntry>>
+            std::void_t<typename Iterable::CurrentTupleEntry>>
       {
         public: template <typename... T>
         struct type

--- a/include/gz/physics/detail/InspectFeatures.hh
+++ b/include/gz/physics/detail/InspectFeatures.hh
@@ -104,21 +104,15 @@ namespace gz
         }
       };
 
-      /// \private Implementation of InspectFeatures.
-      template <typename PolicyT, typename FeatureListT>
-      struct InspectFeatures<PolicyT, FeatureListT,
-          std::void_t<typename FeatureListT::CurrentTupleEntry>>
+      /// \private Implementation of InspectFeatures for std::tuple.
+      template <typename PolicyT, typename... Features>
+      struct InspectFeatures<PolicyT, std::tuple<Features...>>
       {
-        using Branch1 = InspectFeatures<PolicyT,
-            typename FeatureListT::CurrentTupleEntry>;
-        using Branch2 = InspectFeatures<PolicyT,
-            typename GetNext<FeatureListT>::n>;
-
-        /// \brief Check that each feature is provided by the plugin.
         template <typename PtrT>
         static bool Verify(const PtrT &_pimpl)
         {
-          return Branch1::Verify(_pimpl) && Branch2::Verify(_pimpl);
+          return (InspectFeatures<PolicyT, Features>::Verify(_pimpl) && ... &&
+                  true);
         }
 
         template <typename LoaderT, typename ContainerT>
@@ -126,18 +120,26 @@ namespace gz
             const LoaderT &_loader,
             ContainerT &_plugins)
         {
-          Branch1::EraseIfMissing(_loader, _plugins);
-          Branch2::EraseIfMissing(_loader, _plugins);
+          (InspectFeatures<PolicyT, Features>::EraseIfMissing(_loader,
+                                                              _plugins),
+           ...);
         }
 
         template <typename PtrT>
         static void MissingNames(const PtrT &_pimpl,
                                  std::set<std::string> &_names)
         {
-          Branch1::MissingNames(_pimpl, _names);
-          Branch2::MissingNames(_pimpl, _names);
+          (InspectFeatures<PolicyT, Features>::MissingNames(_pimpl, _names),
+           ...);
         }
       };
+
+      /// \private Implementation of InspectFeatures for FeatureLists.
+      template <typename PolicyT, typename FeatureListT>
+      struct InspectFeatures<PolicyT, FeatureListT,
+          std::void_t<typename FeatureListT::FeatureTuple>>
+          : InspectFeatures<PolicyT, typename FeatureListT::FeatureTuple>
+      { };
     }
   }
 }

--- a/include/gz/physics/detail/InspectFeatures.hh
+++ b/include/gz/physics/detail/InspectFeatures.hh
@@ -104,10 +104,11 @@ namespace gz
         }
       };
 
-      /// \private Implementation of InspectFeatures for std::tuple.
+      /// \private Implementation of InspectFeatures for TypeList.
       template <typename PolicyT, typename... Features>
-      struct InspectFeatures<PolicyT, std::tuple<Features...>>
+      struct InspectFeatures<PolicyT, TypeList<Features...>>
       {
+        /// \brief Check that each feature is provided by the plugin.
         template <typename PtrT>
         static bool Verify(const PtrT &_pimpl)
         {
@@ -137,8 +138,8 @@ namespace gz
       /// \private Implementation of InspectFeatures for FeatureLists.
       template <typename PolicyT, typename FeatureListT>
       struct InspectFeatures<PolicyT, FeatureListT,
-          std::void_t<typename FeatureListT::FeatureTuple>>
-          : InspectFeatures<PolicyT, typename FeatureListT::FeatureTuple>
+          std::void_t<typename FeatureListT::FlatFeatureTypeList>>
+          : InspectFeatures<PolicyT, typename FeatureListT::FlatFeatureTypeList>
       { };
     }
   }

--- a/include/gz/physics/detail/InspectFeatures.hh
+++ b/include/gz/physics/detail/InspectFeatures.hh
@@ -36,7 +36,7 @@ namespace gz
       /////////////////////////////////////////////////
       /// \private This class is used to inspect what features are provided by
       /// a plugin. It implements the API of RequestEngine.
-      template <typename PolicyT, typename FeatureT, typename = void_t<> >
+      template <typename PolicyT, typename FeatureT, typename = std::void_t<> >
       struct InspectFeatures
       {
         using Interface = typename FeatureT::template Implementation<PolicyT>;
@@ -78,7 +78,7 @@ namespace gz
       };
 
       template <typename PolicyT>
-      struct InspectFeatures<PolicyT, void, void_t<> >
+      struct InspectFeatures<PolicyT, void, std::void_t<> >
       {
         template <typename PtrT>
         static bool Verify(const PtrT &/*_pimpl*/)
@@ -107,7 +107,7 @@ namespace gz
       /// \private Implementation of InspectFeatures.
       template <typename PolicyT, typename FeatureListT>
       struct InspectFeatures<PolicyT, FeatureListT,
-          void_t<typename FeatureListT::CurrentTupleEntry>>
+          std::void_t<typename FeatureListT::CurrentTupleEntry>>
       {
         using Branch1 = InspectFeatures<PolicyT,
             typename FeatureListT::CurrentTupleEntry>;

--- a/src/FeatureList_TEST.cc
+++ b/src/FeatureList_TEST.cc
@@ -233,9 +233,9 @@ TEST(FeatureList_TEST, Hierarchy)
   HierarchyLevel3();
 
   using Level3Tuple = detail::FlattenFeatures<HierarchyLevel3>::type;
-  EXPECT_TRUE((detail::TupleContainsBase<FeatureA, Level3Tuple>::value));
-  EXPECT_TRUE((detail::TupleContainsBase<FeatureB, Level3Tuple>::value));
-  EXPECT_TRUE((detail::TupleContainsBase<FeatureC, Level3Tuple>::value));
-  EXPECT_TRUE((detail::TupleContainsBase<Conflict1, Level3Tuple>::value));
-  EXPECT_TRUE((detail::TupleContainsBase<Conflict2, Level3Tuple>::value));
+  EXPECT_TRUE((detail::TypeListContainsBase<FeatureA, Level3Tuple>::value));
+  EXPECT_TRUE((detail::TypeListContainsBase<FeatureB, Level3Tuple>::value));
+  EXPECT_TRUE((detail::TypeListContainsBase<FeatureC, Level3Tuple>::value));
+  EXPECT_TRUE((detail::TypeListContainsBase<Conflict1, Level3Tuple>::value));
+  EXPECT_TRUE((detail::TypeListContainsBase<Conflict2, Level3Tuple>::value));
 }

--- a/src/FilterTuple_TEST.cc
+++ b/src/FilterTuple_TEST.cc
@@ -25,47 +25,47 @@ class ClassB : public physics::Feature { };
 class ClassC : public physics::Feature { };
 class ClassD : public ClassB { };
 
-using Filter = std::tuple<ClassA, ClassD>;
-using Input = std::tuple<ClassB, ClassC, ClassD, ClassA>;
+using Filter = physics::TypeList<ClassA, ClassD>;
+using Input = physics::TypeList<ClassB, ClassC, ClassD, ClassA>;
 
-using Result = physics::detail::SubtractTuple<Filter>
+using Result = physics::detail::SubtractList<Filter>
     ::From<Input>::type;
 
 using UnfilteredResult =
-    physics::detail::SubtractTuple<std::tuple<>>::From<Input>::type;
+    physics::detail::SubtractList<physics::TypeList<>>::From<Input>::type;
 
 TEST(FilterTuple_TEST, FilterTupleResult)
 {
   // ClassA and ClassD should be filtered out because they are in Filter.
   // ClassB should be filtered out because it is a base class of ClassD.
   // Therefore we should only be left with ClassC.
-  EXPECT_EQ(1u, std::tuple_size<Result>::value);
+  EXPECT_EQ(1u, Result::size);
 
-  EXPECT_EQ(4u, std::tuple_size<UnfilteredResult>::value);
+  EXPECT_EQ(4u, UnfilteredResult::size);
   std::cout << typeid(UnfilteredResult).name() << std::endl;
 }
 
 
 using SingleCombineLists =
   physics::detail::CombineListsImpl<
-      std::tuple<>, ClassA>::type;
+      physics::TypeList<>, ClassA>::type;
 
 using SingleCombineListsInitial =
   physics::detail::CombineListsImpl<
-      std::tuple<>, ClassA>::InitialResult;
+      physics::TypeList<>, ClassA>::InitialResult;
 
 using SingleCombineListsPartial =
   physics::detail::CombineListsImpl<
-      std::tuple<>, ClassA>::PartialResult;
+      physics::TypeList<>, ClassA>::PartialResult;
 
 using SingleCombineListsChildFilter =
   physics::detail::CombineListsImpl<
-      std::tuple<>, ClassA>::ChildFilter;
+      physics::TypeList<>, ClassA>::ChildFilter;
 
 TEST(FilterTuple_TEST, CombineListsResult)
 {
-  EXPECT_EQ(1u, std::tuple_size<SingleCombineListsInitial>::value);
-  EXPECT_EQ(1u, std::tuple_size<SingleCombineListsPartial>::value);
-  EXPECT_EQ(1u, std::tuple_size<SingleCombineListsChildFilter>::value);
-  EXPECT_EQ(1u, std::tuple_size<SingleCombineLists>::value);
+  EXPECT_EQ(1u, SingleCombineListsInitial::size);
+  EXPECT_EQ(1u, SingleCombineListsPartial::size);
+  EXPECT_EQ(1u, SingleCombineListsChildFilter::size);
+  EXPECT_EQ(1u, SingleCombineLists::size);
 }


### PR DESCRIPTION
# 🎉 New feature

Needs:
- #916 
- #917 
 
## Summary


This PR simplifies the feature aggregation logic by replacing the binary-tree `ComposePlugin`, `CheckRequirements`, and `IterateList` mechanisms with a simple tail-recursive `ComposePluginFromList`.

In addition, because `ExtractAPI` already computes a flat `TypeList` of unique base classes, we can feed those directly into `ComposePluginFromList` to construct the linear inheritance chain of `SpecializedPlugin`s required by `gz-plugin` without the need for complex `std::is_void_v` branching.

This completely removes the need for `GetNext`, `IterateList`, and `Aggregate`. 

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Compare against `main` by building the code while measuring memory consumption 
```
/usr/bin/time -v make gz-physics-dartsim-plugin
```

I get similar results as in #917, with slightly less memory consumption. The point of this PR is to simplify and clean up the code.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.0 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
