### PR TITLE
Fix bullet version warning message

### DIFF
--- a/test/common_test/joint_transmitted_wrench_features.cc
+++ b/test/common_test/joint_transmitted_wrench_features.cc
@@ -419,7 +419,7 @@ TYPED_TEST(JointTransmittedWrenchFixture, ContactForces)
   {
     gzwarn << "ContactForces test is skipped. "
 #if BT_BULLET_VERSION_LE_325
-           <<  "Requires bullet3 version >= 3.25."
+           <<  "Requires bullet3 version > 3.25."
     // This test requires https://github.com/bulletphysics/bullet3/pull/4462
 #else
            <<  "See https://github.com/gazebosim/gz-physics/issues/726."


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a typo in a warning message

## Summary

I noticed a typo in a test warning message. The test currently requires version `> 3.25`, but the message currently says that it needs `>= 3.25`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
