### PR TITLE
fix(bullet-featherstone): Fix cross-DLL teardown segfaults by deferring mesh allocation

### DIFF
--- a/bullet-featherstone/src/SDFFeatures.cc
+++ b/bullet-featherstone/src/SDFFeatures.cc
@@ -1162,15 +1162,17 @@ bool SDFFeatures::AddSdfCollision(
             *mergedSubmesh.get(), maxConvexHulls, voxelResolution);
           gzdbg << "Optimizing mesh (" << meshSdf->OptimizationStr() << "): "
                 <<  mesh->Name() << std::endl;
-          // Create decomposed mesh and add it to MeshManager
-          // Note: MeshManager will call delete on this mesh in its destructor
-          // \todo(iche033) Consider updating MeshManager to accept
-          // unique pointers instead
-          common::Mesh *convexMesh = new common::Mesh;
-          convexMesh->SetName(convexMeshName);
-          for (const auto & submesh : decomposed)
-            convexMesh->AddSubMesh(submesh);
-          meshManager.AddMesh(convexMesh);
+
+          // Request MeshManager to allocate the mesh within gz-common.
+          // This allows MeshManager to strictly own the allocation, preventing
+          // cross-module DLL deletion crashes during teardown.
+          common::Mesh *convexMesh = meshManager.CreateMesh(convexMeshName);
+          if (convexMesh)
+          {
+            for (const auto & submesh : decomposed)
+              convexMesh->AddSubMesh(submesh);
+          }
+
           if (decomposed.empty())
           {
             // Print an error if convex decomposition returned empty submeshes
@@ -1179,7 +1181,7 @@ bool SDFFeatures::AddSdfCollision(
             gzerr << "Convex decomposition generated zero meshes: "
                    << mesh->Name() << std::endl;
           }
-          decomposedMesh = meshManager.MeshByName(convexMeshName);
+          decomposedMesh = convexMesh;
         }
       }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a segfault at teardown in [COMMON_TEST_collisions_bullet-featherstone](https://build.osrfoundation.org/view/gz-rotary/job/gz_physics-main-cnlwin/97/console)

Needs:
- https://github.com/gazebosim/gz-common/pull/796

## Summary
During process teardown, the `bullet-featherstone` plugin was consistently producing a segmentation fault. The root cause of this crash was a cross-module (DLL) object lifecycle mismatch concerning dynamically allocated `gz::common::Mesh` objects.

Previously, `bullet-featherstone` manually allocated a new mesh for convex decomposition via `new common::Mesh` and populated it using `AddSubMesh`. It then transferred ownership of this raw pointer to the global `MeshManager` singleton cache. Because of C++ template instantiation rules and One Definition Rule (ODR) linkage on Windows MSVC, compiler-generated inline deleters and/or shared pointer control blocks instantiated during this process became permanently tethered to the execution context of `bullet-featherstone.dll`.

During test teardown:
1. The Physics `Loader` goes out of scope, which gracefully unloads `bullet-featherstone.dll` from the process memory.
2. Later, when the executable natively exits, `MeshManager::~MeshManager` attempts to iterate over its internal map and `delete` the cached meshes.
3. The destruction sequence inevitably resolves its virtual destructors or allocator/deleter logic by jumping to the memory addresses initially bound in `bullet-featherstone.dll`.
4. Because the plugin DLL has already been unmapped, the execution jumps to unallocated memory, triggering a hard Access Violation (segfault).

This commit resolves the lifecycle violation by offloading the entire memory allocation responsibility to `gz-common`. By querying the newly added `MeshManager::CreateMesh()` API, all `operator new` instantiations, virtual deleters, and inline control blocks are safely and strictly anchored within the `gz_common_graphics.dll` linkage. This guarantees that when process teardown occurs, `MeshManager` safely deletes memory residing in its own still-mapped translation unit, successfully eliminating the teardown crash while fully maintaining performance caching.

Generated-by: Gemini 3.1 Pro

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
