### PR TITLE
Use portable shebang for bash scripts

### DIFF
--- a/test/static_assert/testrunner.bash
+++ b/test/static_assert/testrunner.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # mess with output to confuse jenkins build failure indications because these
 # tests pass when compilation fails. Multiple pipes for OSX compatibility


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Replace `#!/bin/bash` with portable `#!/usr/bin/env bash` in all bash scripts for portability across systems where bash may not be installed at `/bin/bash` (e.g. NixOS).

This came up while packaging gazebo for [nixpkgs](https://github.com/NixOS/nixpkgs), where builds fail because `/bin/bash` does not exist.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.