### PR TITLE
Refactor Gravity feature

### DIFF
--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -526,6 +526,40 @@ class Base : public Implements3d<FeatureList<Feature>>
     return this->models.at(_modelID);
   }
 
+  /// \brief Helper function for setting gravity mode on a link
+  public: static void SetLinkGravityMode(LinkInfo * _linkInfo, bool _enabled)
+  {
+    if (!_linkInfo || !_linkInfo->link)
+      return;
+
+    // Added-mass links must keep DART gravity disabled: gravity is applied
+    // manually as F=ma each step. Let SetLinkAddedMass own that flag.
+    if (_linkInfo->inertial.has_value() &&
+        _linkInfo->inertial->FluidAddedMass().has_value())
+    {
+      return;
+    }
+
+    _linkInfo->link->setGravityMode(_enabled);
+  }
+
+  /// \brief Helper function for getting gravity mode of a link
+  public: static bool GetLinkGravityMode(const LinkInfo * _linkInfo)
+  {
+    if (!_linkInfo || !_linkInfo->link)
+      return true;
+
+    // Added-mass links have DART gravity forcibly disabled; exclude them so
+    // their internal state doesn't pollute the user-visible gravity flag.
+    if (_linkInfo->inertial.has_value() &&
+        _linkInfo->inertial->FluidAddedMass().has_value())
+    {
+      return true;
+    }
+
+    return _linkInfo->link->getGravityMode();
+  }
+
   public: detail::EntityStorage<DartWorldPtr, std::string> worlds;
   public: detail::EntityStorage<ModelInfoPtr, DartConstSkeletonPtr> models;
   public: detail::EntityStorage<LinkInfoPtr, const DartBodyNode*> links;

--- a/dartsim/src/LinkFeatures.cc
+++ b/dartsim/src/LinkFeatures.cc
@@ -41,6 +41,42 @@ void LinkFeatures::AddLinkExternalTorqueInWorld(
   bn->addExtTorque(_torque, false);
 }
 
+/////////////////////////////////////////////////
+void LinkFeatures::SetLinkGravityEnabled(const Identity &_id, bool _enabled)
+{
+  auto linkInfo = this->ReferenceInterface<LinkInfo>(_id);
+  if (!linkInfo || !linkInfo->link)
+    return;
+
+  // Added-mass links must keep DART gravity disabled: gravity is applied
+  // manually as F=ma each step. Let SetLinkAddedMass own that flag.
+  if (linkInfo->inertial.has_value() &&
+      linkInfo->inertial->FluidAddedMass().has_value())
+  {
+    return;
+  }
+
+  linkInfo->link->setGravityMode(_enabled);
+}
+
+/////////////////////////////////////////////////
+bool LinkFeatures::GetLinkGravityEnabled(const Identity &_id) const
+{
+  auto linkInfo = this->ReferenceInterface<LinkInfo>(_id);
+  if (!linkInfo || !linkInfo->link)
+    return true;
+
+  // Added-mass links have DART gravity forcibly disabled; exclude them so
+  // their internal state doesn't pollute the user-visible gravity flag.
+  if (linkInfo->inertial.has_value() &&
+      linkInfo->inertial->FluidAddedMass().has_value())
+  {
+    return true;
+  }
+
+  return linkInfo->link->getGravityMode();
+}
+
 }
 }
 }

--- a/dartsim/src/LinkFeatures.cc
+++ b/dartsim/src/LinkFeatures.cc
@@ -45,36 +45,14 @@ void LinkFeatures::AddLinkExternalTorqueInWorld(
 void LinkFeatures::SetLinkGravityEnabled(const Identity &_id, bool _enabled)
 {
   auto linkInfo = this->ReferenceInterface<LinkInfo>(_id);
-  if (!linkInfo || !linkInfo->link)
-    return;
-
-  // Added-mass links must keep DART gravity disabled: gravity is applied
-  // manually as F=ma each step. Let SetLinkAddedMass own that flag.
-  if (linkInfo->inertial.has_value() &&
-      linkInfo->inertial->FluidAddedMass().has_value())
-  {
-    return;
-  }
-
-  linkInfo->link->setGravityMode(_enabled);
+  this->SetLinkGravityMode(linkInfo, _enabled);
 }
 
 /////////////////////////////////////////////////
 bool LinkFeatures::GetLinkGravityEnabled(const Identity &_id) const
 {
   auto linkInfo = this->ReferenceInterface<LinkInfo>(_id);
-  if (!linkInfo || !linkInfo->link)
-    return true;
-
-  // Added-mass links have DART gravity forcibly disabled; exclude them so
-  // their internal state doesn't pollute the user-visible gravity flag.
-  if (linkInfo->inertial.has_value() &&
-      linkInfo->inertial->FluidAddedMass().has_value())
-  {
-    return true;
-  }
-
-  return linkInfo->link->getGravityMode();
+  return this->GetLinkGravityMode(linkInfo);
 }
 
 }

--- a/dartsim/src/LinkFeatures.hh
+++ b/dartsim/src/LinkFeatures.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_PHYSICS_DARTSIM_SRC_LINKFEATURES_HH_
 #define GZ_PHYSICS_DARTSIM_SRC_LINKFEATURES_HH_
 
+#include <gz/physics/Gravity.hh>
 #include <gz/physics/Link.hh>
 
 #include "Base.hh"
@@ -27,7 +28,8 @@ namespace physics {
 namespace dartsim {
 
 struct LinkFeatureList : FeatureList<
-  AddLinkExternalForceTorque
+  AddLinkExternalForceTorque,
+  LinkGravityEnabled
 > { };
 
 class LinkFeatures :
@@ -42,6 +44,12 @@ class LinkFeatures :
 
   public: void AddLinkExternalTorqueInWorld(
       const Identity &_id, const AngularVectorType &_torque) override;
+
+  // ----- Link Gravity Enabled -----
+  public: void SetLinkGravityEnabled(
+      const Identity &_id, bool _enabled) override;
+
+  public: bool GetLinkGravityEnabled(const Identity &_id) const override;
 };
 
 }

--- a/dartsim/src/LinkFeatures.hh
+++ b/dartsim/src/LinkFeatures.hh
@@ -29,7 +29,7 @@ namespace dartsim {
 
 struct LinkFeatureList : FeatureList<
   AddLinkExternalForceTorque,
-  LinkGravityEnabled
+  GravityEnabled
 > { };
 
 class LinkFeatures :

--- a/dartsim/src/ModelFeatures.cc
+++ b/dartsim/src/ModelFeatures.cc
@@ -62,6 +62,72 @@ bool ModelFeatures::GetModelStatic(const Identity &_id) const
   return !modelInfo->model->isMobile();
 }
 
+/////////////////////////////////////////////////
+void ModelFeatures::SetModelGravityEnabled(
+    const Identity &_id, bool _enabled)
+{
+  auto modelInfo = this->GetModelInfo(_id);
+  if (!modelInfo || !modelInfo->model)
+    return;
+
+  for (const auto &linkInfo : modelInfo->links)
+  {
+    if (!linkInfo || !linkInfo->link)
+      continue;
+
+    // Added-mass links must keep DART gravity disabled
+    if (linkInfo->inertial.has_value() &&
+        linkInfo->inertial->FluidAddedMass().has_value())
+    {
+      continue;
+    }
+
+    linkInfo->link->setGravityMode(_enabled);
+  }
+
+  // Also apply to nested models recursively.
+  for (const std::size_t nestedID : modelInfo->nestedModels)
+  {
+    this->SetModelGravityEnabled(this->GenerateIdentity(
+        nestedID, this->GetModelInfo(nestedID)), _enabled);
+  }
+}
+
+/////////////////////////////////////////////////
+bool ModelFeatures::GetModelGravityEnabled(const Identity &_id) const
+{
+  const auto modelInfo = this->GetModelInfo(_id);
+  if (!modelInfo || !modelInfo->model)
+    return false;
+
+  for (const auto &linkInfo : modelInfo->links)
+  {
+    if (!linkInfo || !linkInfo->link)
+      continue;
+
+    // Added-mass links have DART gravity forcibly disabled; exclude them
+    if (linkInfo->inertial.has_value() &&
+        linkInfo->inertial->FluidAddedMass().has_value())
+    {
+      continue;
+    }
+
+    if (!linkInfo->link->getGravityMode())
+      return false;
+  }
+
+  // Also check nested models.
+  for (const std::size_t nestedID : modelInfo->nestedModels)
+  {
+    if (!this->GetModelGravityEnabled(this->GenerateIdentity(
+        nestedID, this->GetModelInfo(nestedID))))
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 }
 }

--- a/dartsim/src/ModelFeatures.cc
+++ b/dartsim/src/ModelFeatures.cc
@@ -28,22 +28,16 @@ void ModelFeatures::SetModelStatic(const Identity &_id, bool _static)
   if (!modelInfo || !modelInfo->model)
     return;
   auto skeleton = modelInfo->model;
-  const bool wasStatic = !skeleton->isMobile();
 
   // In DART, isMobile=false means the skeleton is fixed (static).
   skeleton->setMobile(!_static);
 
-  // When transitioning from static (kinematic) to dynamic, zero out any
+  // When transitioning between states, zero out any
   // velocities and accelerations that DART may have stored on the skeleton
-  // while it was kinematic. Without this the stored state is released as
-  // momentum when the body becomes dynamic.
-  if (wasStatic && !_static)
-  {
-    skeleton->resetVelocities();
-    skeleton->resetAccelerations();
-    skeleton->clearExternalForces();
-    skeleton->clearInternalForces();
-  }
+  skeleton->resetVelocities();
+  skeleton->resetAccelerations();
+  skeleton->clearExternalForces();
+  skeleton->clearInternalForces();
 
   // Also apply to nested models recursively.
   for (const std::size_t nestedID : modelInfo->nestedModels)

--- a/dartsim/src/ModelFeatures.cc
+++ b/dartsim/src/ModelFeatures.cc
@@ -62,52 +62,6 @@ bool ModelFeatures::GetModelStatic(const Identity &_id) const
   return !modelInfo->model->isMobile();
 }
 
-/////////////////////////////////////////////////
-void ModelFeatures::SetModelGravityEnabled(const Identity &_id, bool _enabled)
-{
-  auto modelInfo = this->GetModelInfo(_id);
-  if (!modelInfo || !modelInfo->model)
-    return;
-  for (const auto &linkInfo : modelInfo->links)
-  {
-    if (!linkInfo || !linkInfo->link)
-      continue;
-    // Added-mass links must keep DART gravity disabled: gravity is applied
-    // manually as F=ma each step. Let SetLinkAddedMass own that flag.
-    if (linkInfo->inertial.has_value() &&
-        linkInfo->inertial->FluidAddedMass().has_value())
-      continue;
-    linkInfo->link->setGravityMode(_enabled);
-  }
-
-  // Also apply to nested models recursively.
-  for (const std::size_t nestedID : modelInfo->nestedModels)
-  {
-    this->SetModelGravityEnabled(this->GenerateIdentity(
-        nestedID, this->GetModelInfo(nestedID)), _enabled);
-  }
-}
-
-/////////////////////////////////////////////////
-bool ModelFeatures::GetModelGravityEnabled(const Identity &_id) const
-{
-  const auto modelInfo = this->GetModelInfo(_id);
-  if (!modelInfo || !modelInfo->model)
-    return true;
-  for (const auto &linkInfo : modelInfo->links)
-  {
-    if (!linkInfo || !linkInfo->link)
-      continue;
-    // Added-mass links have DART gravity forcibly disabled; exclude them so
-    // their internal state doesn't pollute the user-visible gravity flag.
-    if (linkInfo->inertial.has_value() &&
-        linkInfo->inertial->FluidAddedMass().has_value())
-      continue;
-    if (!linkInfo->link->getGravityMode())
-      return false;
-  }
-  return true;
-}
 
 }
 }

--- a/dartsim/src/ModelFeatures.cc
+++ b/dartsim/src/ModelFeatures.cc
@@ -75,7 +75,8 @@ void ModelFeatures::SetModelGravityEnabled(
     if (!linkInfo || !linkInfo->link)
       continue;
 
-    // Added-mass links must keep DART gravity disabled
+    // Added-mass links must keep DART gravity disabled: gravity is applied
+    // manually as F=ma each step. Let SetLinkAddedMass own that flag.
     if (linkInfo->inertial.has_value() &&
         linkInfo->inertial->FluidAddedMass().has_value())
     {
@@ -105,7 +106,8 @@ bool ModelFeatures::GetModelGravityEnabled(const Identity &_id) const
     if (!linkInfo || !linkInfo->link)
       continue;
 
-    // Added-mass links have DART gravity forcibly disabled; exclude them
+    // Added-mass links have DART gravity forcibly disabled; exclude them so
+    // their internal state doesn't pollute the user-visible gravity flag.
     if (linkInfo->inertial.has_value() &&
         linkInfo->inertial->FluidAddedMass().has_value())
     {

--- a/dartsim/src/ModelFeatures.cc
+++ b/dartsim/src/ModelFeatures.cc
@@ -72,18 +72,7 @@ void ModelFeatures::SetModelGravityEnabled(
 
   for (const auto &linkInfo : modelInfo->links)
   {
-    if (!linkInfo || !linkInfo->link)
-      continue;
-
-    // Added-mass links must keep DART gravity disabled: gravity is applied
-    // manually as F=ma each step. Let SetLinkAddedMass own that flag.
-    if (linkInfo->inertial.has_value() &&
-        linkInfo->inertial->FluidAddedMass().has_value())
-    {
-      continue;
-    }
-
-    linkInfo->link->setGravityMode(_enabled);
+    this->SetLinkGravityMode(linkInfo.get(), _enabled);
   }
 
   // Also apply to nested models recursively.
@@ -103,18 +92,7 @@ bool ModelFeatures::GetModelGravityEnabled(const Identity &_id) const
 
   for (const auto &linkInfo : modelInfo->links)
   {
-    if (!linkInfo || !linkInfo->link)
-      continue;
-
-    // Added-mass links have DART gravity forcibly disabled; exclude them so
-    // their internal state doesn't pollute the user-visible gravity flag.
-    if (linkInfo->inertial.has_value() &&
-        linkInfo->inertial->FluidAddedMass().has_value())
-    {
-      continue;
-    }
-
-    if (!linkInfo->link->getGravityMode())
+    if (!this->GetLinkGravityMode(linkInfo.get()))
       return false;
   }
 

--- a/dartsim/src/ModelFeatures.cc
+++ b/dartsim/src/ModelFeatures.cc
@@ -82,7 +82,7 @@ bool ModelFeatures::GetModelGravityEnabled(const Identity &_id) const
 {
   const auto modelInfo = this->GetModelInfo(_id);
   if (!modelInfo || !modelInfo->model)
-    return false;
+    return true;
 
   for (const auto &linkInfo : modelInfo->links)
   {

--- a/dartsim/src/ModelFeatures.hh
+++ b/dartsim/src/ModelFeatures.hh
@@ -30,7 +30,7 @@ namespace dartsim {
 
 struct ModelFeatureList : FeatureList<
   ModelStaticState,
-  ModelGravityEnabled
+  GravityEnabled
 > { };
 
 class ModelFeatures :

--- a/dartsim/src/ModelFeatures.hh
+++ b/dartsim/src/ModelFeatures.hh
@@ -20,6 +20,8 @@
 
 #include <gz/physics/Model.hh>
 
+#include <gz/physics/Gravity.hh>
+
 #include "Base.hh"
 
 namespace gz {
@@ -27,7 +29,8 @@ namespace physics {
 namespace dartsim {
 
 struct ModelFeatureList : FeatureList<
-  ModelStaticState
+  ModelStaticState,
+  ModelGravityEnabled
 > { };
 
 class ModelFeatures :
@@ -40,6 +43,12 @@ class ModelFeatures :
 
   // Documentation inherited
   public: bool GetModelStatic(const Identity &_id) const override;
+
+  // ----- Model Gravity Enabled -----
+  public: void SetModelGravityEnabled(
+      const Identity &_id, bool _enabled) override;
+
+  public: bool GetModelGravityEnabled(const Identity &_id) const override;
 };
 
 }

--- a/dartsim/src/ModelFeatures.hh
+++ b/dartsim/src/ModelFeatures.hh
@@ -27,8 +27,7 @@ namespace physics {
 namespace dartsim {
 
 struct ModelFeatureList : FeatureList<
-  ModelStaticState,
-  ModelGravityEnabled
+  ModelStaticState
 > { };
 
 class ModelFeatures :
@@ -41,13 +40,6 @@ class ModelFeatures :
 
   // Documentation inherited
   public: bool GetModelStatic(const Identity &_id) const override;
-
-  // Documentation inherited
-  public: void SetModelGravityEnabled(
-      const Identity &_id, bool _enabled) override;
-
-  // Documentation inherited
-  public: bool GetModelGravityEnabled(const Identity &_id) const override;
 };
 
 }

--- a/include/gz/physics/Gravity.hh
+++ b/include/gz/physics/Gravity.hh
@@ -46,13 +46,14 @@ namespace gz
       public: template <typename PolicyT, typename FeaturesT>
       class Model : public virtual Feature::Model<PolicyT, FeaturesT>
       {
-        /// \brief Set whether gravity is enabled for this model and its links.
+        /// \brief Set whether gravity is enabled for all of this model's links
+        /// and the links of nested models recursively.
         /// \param[in] _enabled True to enable gravity, false to disable it.
         public: void SetGravityEnabled(bool _enabled);
 
         /// \brief Get whether gravity is enabled for this model.
-        /// \return True if gravity is enabled for all entities, false
-        /// otherwise.
+        /// \return True if gravity is enabled for all child links and the
+        /// links of nested models recursively, false otherwise.
         public: bool GetGravityEnabled() const;
       };
 

--- a/include/gz/physics/Gravity.hh
+++ b/include/gz/physics/Gravity.hh
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_GRAVITY_HH_
+#define GZ_PHYSICS_GRAVITY_HH_
+
+#include <gz/physics/FeatureList.hh>
+#include <gz/physics/GetEntities.hh>
+
+namespace gz
+{
+  namespace physics
+  {
+    /////////////////////////////////////////////////
+    /// \brief Feature for getting and setting whether gravity affects a link.
+    class GZ_PHYSICS_VISIBLE LinkGravityEnabled : public virtual Feature
+    {
+      /// \brief The Link API for getting and setting gravity mode.
+      public: template <typename PolicyT, typename FeaturesT>
+      class Link : public virtual Feature::Link<PolicyT, FeaturesT>
+      {
+        /// \brief Set whether gravity is enabled for this link.
+        /// \param[in] _enabled True to enable gravity, false to disable it.
+        public: void SetGravityEnabled(bool _enabled);
+
+        /// \brief Get whether gravity is enabled for this link.
+        /// \return True if gravity is enabled, false otherwise.
+        public: bool GetGravityEnabled() const;
+      };
+
+      /// \private The implementation API for link gravity mode.
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        /// \brief Implementation API for setting the link gravity mode.
+        /// \param[in] _id Identity of the link.
+        /// \param[in] _enabled True to enable gravity.
+        public: virtual void SetLinkGravityEnabled(
+            const Identity &_id, bool _enabled) = 0;
+
+        /// \brief Implementation API for getting the link gravity mode.
+        /// \param[in] _id Identity of the link.
+        /// \return True if gravity is enabled.
+        public: virtual bool GetLinkGravityEnabled(
+            const Identity &_id) const = 0;
+      };
+    };
+
+    /////////////////////////////////////////////////
+    using ModelGravityEnabledRequiredFeatures = FeatureList<
+      LinkGravityEnabled,
+      GetLinkFromModel,
+      GetNestedModelFromModel>;
+
+    /////////////////////////////////////////////////
+    /// \brief Feature for getting and setting whether gravity affects a model
+    /// and all its child entities.
+    class GZ_PHYSICS_VISIBLE ModelGravityEnabled
+        : public virtual
+          FeatureWithRequirements<ModelGravityEnabledRequiredFeatures>
+    {
+      /// \brief The Model API for getting and setting gravity mode.
+      public: template <typename PolicyT, typename FeaturesT>
+      class Model
+          : public virtual GetLinkFromModel::Model<PolicyT, FeaturesT>,
+            public virtual GetNestedModelFromModel::Model<PolicyT, FeaturesT>
+      {
+        /// \brief Set whether gravity is enabled for this model and its links.
+        /// \param[in] _enabled True to enable gravity, false to disable it.
+        public: void SetGravityEnabled(bool _enabled);
+
+        /// \brief Get whether gravity is enabled for this model.
+        /// \return True if gravity is enabled for all entities, false
+        /// otherwise.
+        public: bool GetGravityEnabled() const;
+      };
+    };
+  }
+}
+
+#include <gz/physics/detail/Gravity.hh>
+
+#endif

--- a/include/gz/physics/Gravity.hh
+++ b/include/gz/physics/Gravity.hh
@@ -60,18 +60,9 @@ namespace gz
       };
     };
 
-    /////////////////////////////////////////////////
-    struct ModelGravityEnabledRequiredFeatures : FeatureList<
-      LinkGravityEnabled,
-      GetLinkFromModel,
-      GetNestedModelFromModel> { };
-
-    /////////////////////////////////////////////////
     /// \brief Feature for getting and setting whether gravity affects a model
     /// and all its child entities.
-    class GZ_PHYSICS_VISIBLE ModelGravityEnabled
-        : public virtual
-          FeatureWithRequirements<ModelGravityEnabledRequiredFeatures>
+    class GZ_PHYSICS_VISIBLE ModelGravityEnabled : public virtual Feature
     {
       /// \brief The Model API for getting and setting gravity mode.
       public: template <typename PolicyT, typename FeaturesT>
@@ -85,6 +76,23 @@ namespace gz
         /// \return True if gravity is enabled for all entities, false
         /// otherwise.
         public: bool GetGravityEnabled() const;
+      };
+
+      /// \private The implementation API for model gravity mode.
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        /// \brief Implementation API for setting the model gravity mode.
+        /// \param[in] _id Identity of the model.
+        /// \param[in] _enabled True to enable gravity.
+        public: virtual void SetModelGravityEnabled(
+            const Identity &_id, bool _enabled) = 0;
+
+        /// \brief Implementation API for getting the model gravity mode.
+        /// \param[in] _id Identity of the model.
+        /// \return True if gravity is enabled.
+        public: virtual bool GetModelGravityEnabled(
+            const Identity &_id) const = 0;
       };
     };
   }

--- a/include/gz/physics/Gravity.hh
+++ b/include/gz/physics/Gravity.hh
@@ -61,10 +61,10 @@ namespace gz
     };
 
     /////////////////////////////////////////////////
-    using ModelGravityEnabledRequiredFeatures = FeatureList<
+    struct ModelGravityEnabledRequiredFeatures : FeatureList<
       LinkGravityEnabled,
       GetLinkFromModel,
-      GetNestedModelFromModel>;
+      GetNestedModelFromModel> { };
 
     /////////////////////////////////////////////////
     /// \brief Feature for getting and setting whether gravity affects a model
@@ -75,9 +75,7 @@ namespace gz
     {
       /// \brief The Model API for getting and setting gravity mode.
       public: template <typename PolicyT, typename FeaturesT>
-      class Model
-          : public virtual GetLinkFromModel::Model<PolicyT, FeaturesT>,
-            public virtual GetNestedModelFromModel::Model<PolicyT, FeaturesT>
+      class Model : public virtual Feature::Model<PolicyT, FeaturesT>
       {
         /// \brief Set whether gravity is enabled for this model and its links.
         /// \param[in] _enabled True to enable gravity, false to disable it.

--- a/include/gz/physics/Gravity.hh
+++ b/include/gz/physics/Gravity.hh
@@ -25,9 +25,9 @@ namespace gz
 {
   namespace physics
   {
-    /////////////////////////////////////////////////
-    /// \brief Feature for getting and setting whether gravity affects a link.
-    class GZ_PHYSICS_VISIBLE LinkGravityEnabled : public virtual Feature
+    /// \brief Feature for getting and setting whether gravity affects a link
+    /// or a model.
+    class GZ_PHYSICS_VISIBLE GravityEnabled : public virtual Feature
     {
       /// \brief The Link API for getting and setting gravity mode.
       public: template <typename PolicyT, typename FeaturesT>
@@ -42,28 +42,6 @@ namespace gz
         public: bool GetGravityEnabled() const;
       };
 
-      /// \private The implementation API for link gravity mode.
-      public: template <typename PolicyT>
-      class Implementation : public virtual Feature::Implementation<PolicyT>
-      {
-        /// \brief Implementation API for setting the link gravity mode.
-        /// \param[in] _id Identity of the link.
-        /// \param[in] _enabled True to enable gravity.
-        public: virtual void SetLinkGravityEnabled(
-            const Identity &_id, bool _enabled) = 0;
-
-        /// \brief Implementation API for getting the link gravity mode.
-        /// \param[in] _id Identity of the link.
-        /// \return True if gravity is enabled.
-        public: virtual bool GetLinkGravityEnabled(
-            const Identity &_id) const = 0;
-      };
-    };
-
-    /// \brief Feature for getting and setting whether gravity affects a model
-    /// and all its child entities.
-    class GZ_PHYSICS_VISIBLE ModelGravityEnabled : public virtual Feature
-    {
       /// \brief The Model API for getting and setting gravity mode.
       public: template <typename PolicyT, typename FeaturesT>
       class Model : public virtual Feature::Model<PolicyT, FeaturesT>
@@ -78,10 +56,22 @@ namespace gz
         public: bool GetGravityEnabled() const;
       };
 
-      /// \private The implementation API for model gravity mode.
+      /// \private The implementation API for gravity mode.
       public: template <typename PolicyT>
       class Implementation : public virtual Feature::Implementation<PolicyT>
       {
+        /// \brief Implementation API for setting the link gravity mode.
+        /// \param[in] _id Identity of the link.
+        /// \param[in] _enabled True to enable gravity.
+        public: virtual void SetLinkGravityEnabled(
+            const Identity &_id, bool _enabled) = 0;
+
+        /// \brief Implementation API for getting the link gravity mode.
+        /// \param[in] _id Identity of the link.
+        /// \return True if gravity is enabled.
+        public: virtual bool GetLinkGravityEnabled(
+            const Identity &_id) const = 0;
+
         /// \brief Implementation API for setting the model gravity mode.
         /// \param[in] _id Identity of the model.
         /// \param[in] _enabled True to enable gravity.

--- a/include/gz/physics/Model.hh
+++ b/include/gz/physics/Model.hh
@@ -59,40 +59,6 @@ namespace gz
       };
     };
 
-    /////////////////////////////////////////////////
-    /// \brief Feature for getting and setting whether gravity affects a model.
-    class GZ_PHYSICS_VISIBLE ModelGravityEnabled : public virtual Feature
-    {
-      /// \brief The Model API for getting and setting gravity mode.
-      public: template <typename PolicyT, typename FeaturesT>
-      class Model : public virtual Feature::Model<PolicyT, FeaturesT>
-      {
-        /// \brief Set whether gravity is enabled for this model.
-        /// \param[in] _enabled True to enable gravity, false to disable it.
-        public: void SetGravityEnabled(bool _enabled);
-
-        /// \brief Get whether gravity is enabled for this model.
-        /// \return True if gravity is enabled, false otherwise.
-        public: bool GetGravityEnabled() const;
-      };
-
-      /// \private The implementation API for model gravity mode.
-      public: template <typename PolicyT>
-      class Implementation : public virtual Feature::Implementation<PolicyT>
-      {
-        /// \brief Implementation API for setting the model gravity mode.
-        /// \param[in] _id Identity of the model.
-        /// \param[in] _enabled True to enable gravity.
-        public: virtual void SetModelGravityEnabled(
-            const Identity &_id, bool _enabled) = 0;
-
-        /// \brief Implementation API for getting the model gravity mode.
-        /// \param[in] _id Identity of the model.
-        /// \return True if gravity is enabled.
-        public: virtual bool GetModelGravityEnabled(
-            const Identity &_id) const = 0;
-      };
-    };
   }
 }
 

--- a/include/gz/physics/detail/Gravity.hh
+++ b/include/gz/physics/detail/Gravity.hh
@@ -46,72 +46,16 @@ template <typename PolicyT, typename FeaturesT>
 void ModelGravityEnabled::Model<PolicyT, FeaturesT>::SetGravityEnabled(
     bool _enabled)
 {
-  if (auto * linkIface = this->template Interface<GetLinkFromModel>())
-  {
-    const std::size_t linkCount = linkIface->GetLinkCount(this->identity);
-    for (std::size_t i = 0; i < linkCount; ++i)
-    {
-      auto link = LinkPtr<PolicyT, FeaturesT>(
-          this->pimpl, linkIface->GetLink(this->identity, i));
-      if (link)
-      {
-        link->SetGravityEnabled(_enabled);
-      }
-    }
-  }
-
-  if (auto * nestedIface =
-      this->template Interface<GetNestedModelFromModel>())
-  {
-    const std::size_t nestedModelCount =
-        nestedIface->GetNestedModelCount(this->identity);
-    for (std::size_t i = 0; i < nestedModelCount; ++i)
-    {
-      auto nestedModel = ModelPtr<PolicyT, FeaturesT>(
-          this->pimpl, nestedIface->GetNestedModel(this->identity, i));
-      if (nestedModel)
-      {
-        nestedModel->SetGravityEnabled(_enabled);
-      }
-    }
-  }
+  this->template Interface<ModelGravityEnabled>()
+      ->SetModelGravityEnabled(this->identity, _enabled);
 }
 
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
 bool ModelGravityEnabled::Model<PolicyT, FeaturesT>::GetGravityEnabled() const
 {
-  if (auto * linkIface = this->template Interface<GetLinkFromModel>())
-  {
-    const std::size_t linkCount = linkIface->GetLinkCount(this->identity);
-    for (std::size_t i = 0; i < linkCount; ++i)
-    {
-      auto link = LinkPtr<PolicyT, FeaturesT>(
-          this->pimpl, linkIface->GetLink(this->identity, i));
-      if (link && !link->GetGravityEnabled())
-      {
-        return false;
-      }
-    }
-  }
-
-  if (auto * nestedIface =
-      this->template Interface<GetNestedModelFromModel>())
-  {
-    const std::size_t nestedModelCount =
-        nestedIface->GetNestedModelCount(this->identity);
-    for (std::size_t i = 0; i < nestedModelCount; ++i)
-    {
-      auto nestedModel = ModelPtr<PolicyT, FeaturesT>(
-          this->pimpl, nestedIface->GetNestedModel(this->identity, i));
-      if (nestedModel && !nestedModel->GetGravityEnabled())
-      {
-        return false;
-      }
-    }
-  }
-
-  return true;
+  return this->template Interface<ModelGravityEnabled>()
+      ->GetModelGravityEnabled(this->identity);
 }
 
 }

--- a/include/gz/physics/detail/Gravity.hh
+++ b/include/gz/physics/detail/Gravity.hh
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_DETAIL_GRAVITY_HH_
+#define GZ_PHYSICS_DETAIL_GRAVITY_HH_
+
+#include <gz/physics/Gravity.hh>
+
+namespace gz
+{
+namespace physics
+{
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+void LinkGravityEnabled::Link<PolicyT, FeaturesT>::SetGravityEnabled(
+    bool _enabled)
+{
+  this->template Interface<LinkGravityEnabled>()
+      ->SetLinkGravityEnabled(this->identity, _enabled);
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+bool LinkGravityEnabled::Link<PolicyT, FeaturesT>::GetGravityEnabled() const
+{
+  return this->template Interface<LinkGravityEnabled>()
+      ->GetLinkGravityEnabled(this->identity);
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+void ModelGravityEnabled::Model<PolicyT, FeaturesT>::SetGravityEnabled(
+    bool _enabled)
+{
+  const std::size_t linkCount = this->GetLinkCount();
+  for (std::size_t i = 0; i < linkCount; ++i)
+  {
+    auto link = this->GetLink(i);
+    if (link)
+    {
+      link->SetGravityEnabled(_enabled);
+    }
+  }
+
+  const std::size_t nestedModelCount = this->GetNestedModelCount();
+  for (std::size_t i = 0; i < nestedModelCount; ++i)
+  {
+    auto nestedModel = this->GetNestedModel(i);
+    if (nestedModel)
+    {
+      nestedModel->SetGravityEnabled(_enabled);
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+bool ModelGravityEnabled::Model<PolicyT, FeaturesT>::GetGravityEnabled() const
+{
+  const std::size_t linkCount = this->GetLinkCount();
+  for (std::size_t i = 0; i < linkCount; ++i)
+  {
+    auto link = this->GetLink(i);
+    if (link && !link->GetGravityEnabled())
+    {
+      return false;
+    }
+  }
+
+  const std::size_t nestedModelCount = this->GetNestedModelCount();
+  for (std::size_t i = 0; i < nestedModelCount; ++i)
+  {
+    auto nestedModel = this->GetNestedModel(i);
+    if (nestedModel && !nestedModel->GetGravityEnabled())
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+}
+}
+
+#endif

--- a/include/gz/physics/detail/Gravity.hh
+++ b/include/gz/physics/detail/Gravity.hh
@@ -46,23 +46,33 @@ template <typename PolicyT, typename FeaturesT>
 void ModelGravityEnabled::Model<PolicyT, FeaturesT>::SetGravityEnabled(
     bool _enabled)
 {
-  const std::size_t linkCount = this->GetLinkCount();
-  for (std::size_t i = 0; i < linkCount; ++i)
+  if (auto * linkIface = this->template Interface<GetLinkFromModel>())
   {
-    auto link = this->GetLink(i);
-    if (link)
+    const std::size_t linkCount = linkIface->GetLinkCount(this->identity);
+    for (std::size_t i = 0; i < linkCount; ++i)
     {
-      link->SetGravityEnabled(_enabled);
+      auto link = LinkPtr<PolicyT, FeaturesT>(
+          this->pimpl, linkIface->GetLink(this->identity, i));
+      if (link)
+      {
+        link->SetGravityEnabled(_enabled);
+      }
     }
   }
 
-  const std::size_t nestedModelCount = this->GetNestedModelCount();
-  for (std::size_t i = 0; i < nestedModelCount; ++i)
+  if (auto * nestedIface =
+      this->template Interface<GetNestedModelFromModel>())
   {
-    auto nestedModel = this->GetNestedModel(i);
-    if (nestedModel)
+    const std::size_t nestedModelCount =
+        nestedIface->GetNestedModelCount(this->identity);
+    for (std::size_t i = 0; i < nestedModelCount; ++i)
     {
-      nestedModel->SetGravityEnabled(_enabled);
+      auto nestedModel = ModelPtr<PolicyT, FeaturesT>(
+          this->pimpl, nestedIface->GetNestedModel(this->identity, i));
+      if (nestedModel)
+      {
+        nestedModel->SetGravityEnabled(_enabled);
+      }
     }
   }
 }
@@ -71,23 +81,33 @@ void ModelGravityEnabled::Model<PolicyT, FeaturesT>::SetGravityEnabled(
 template <typename PolicyT, typename FeaturesT>
 bool ModelGravityEnabled::Model<PolicyT, FeaturesT>::GetGravityEnabled() const
 {
-  const std::size_t linkCount = this->GetLinkCount();
-  for (std::size_t i = 0; i < linkCount; ++i)
+  if (auto * linkIface = this->template Interface<GetLinkFromModel>())
   {
-    auto link = this->GetLink(i);
-    if (link && !link->GetGravityEnabled())
+    const std::size_t linkCount = linkIface->GetLinkCount(this->identity);
+    for (std::size_t i = 0; i < linkCount; ++i)
     {
-      return false;
+      auto link = LinkPtr<PolicyT, FeaturesT>(
+          this->pimpl, linkIface->GetLink(this->identity, i));
+      if (link && !link->GetGravityEnabled())
+      {
+        return false;
+      }
     }
   }
 
-  const std::size_t nestedModelCount = this->GetNestedModelCount();
-  for (std::size_t i = 0; i < nestedModelCount; ++i)
+  if (auto * nestedIface =
+      this->template Interface<GetNestedModelFromModel>())
   {
-    auto nestedModel = this->GetNestedModel(i);
-    if (nestedModel && !nestedModel->GetGravityEnabled())
+    const std::size_t nestedModelCount =
+        nestedIface->GetNestedModelCount(this->identity);
+    for (std::size_t i = 0; i < nestedModelCount; ++i)
     {
-      return false;
+      auto nestedModel = ModelPtr<PolicyT, FeaturesT>(
+          this->pimpl, nestedIface->GetNestedModel(this->identity, i));
+      if (nestedModel && !nestedModel->GetGravityEnabled())
+      {
+        return false;
+      }
     }
   }
 

--- a/include/gz/physics/detail/Gravity.hh
+++ b/include/gz/physics/detail/Gravity.hh
@@ -26,35 +26,35 @@ namespace physics
 {
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
-void LinkGravityEnabled::Link<PolicyT, FeaturesT>::SetGravityEnabled(
+void GravityEnabled::Link<PolicyT, FeaturesT>::SetGravityEnabled(
     bool _enabled)
 {
-  this->template Interface<LinkGravityEnabled>()
+  this->template Interface<GravityEnabled>()
       ->SetLinkGravityEnabled(this->identity, _enabled);
 }
 
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
-bool LinkGravityEnabled::Link<PolicyT, FeaturesT>::GetGravityEnabled() const
+bool GravityEnabled::Link<PolicyT, FeaturesT>::GetGravityEnabled() const
 {
-  return this->template Interface<LinkGravityEnabled>()
+  return this->template Interface<GravityEnabled>()
       ->GetLinkGravityEnabled(this->identity);
 }
 
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
-void ModelGravityEnabled::Model<PolicyT, FeaturesT>::SetGravityEnabled(
+void GravityEnabled::Model<PolicyT, FeaturesT>::SetGravityEnabled(
     bool _enabled)
 {
-  this->template Interface<ModelGravityEnabled>()
+  this->template Interface<GravityEnabled>()
       ->SetModelGravityEnabled(this->identity, _enabled);
 }
 
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
-bool ModelGravityEnabled::Model<PolicyT, FeaturesT>::GetGravityEnabled() const
+bool GravityEnabled::Model<PolicyT, FeaturesT>::GetGravityEnabled() const
 {
-  return this->template Interface<ModelGravityEnabled>()
+  return this->template Interface<GravityEnabled>()
       ->GetModelGravityEnabled(this->identity);
 }
 

--- a/include/gz/physics/detail/Model.hh
+++ b/include/gz/physics/detail/Model.hh
@@ -40,22 +40,6 @@ bool ModelStaticState::Model<PolicyT, FeaturesT>::GetStatic() const
       ->GetModelStatic(this->identity);
 }
 
-/////////////////////////////////////////////////
-template <typename PolicyT, typename FeaturesT>
-void ModelGravityEnabled::Model<PolicyT, FeaturesT>::SetGravityEnabled(
-    bool _enabled)
-{
-  this->template Interface<ModelGravityEnabled>()
-      ->SetModelGravityEnabled(this->identity, _enabled);
-}
-
-/////////////////////////////////////////////////
-template <typename PolicyT, typename FeaturesT>
-bool ModelGravityEnabled::Model<PolicyT, FeaturesT>::GetGravityEnabled() const
-{
-  return this->template Interface<ModelGravityEnabled>()
-      ->GetModelGravityEnabled(this->identity);
-}
 }
 }
 

--- a/test/common_test/link_features.cc
+++ b/test/common_test/link_features.cc
@@ -33,6 +33,7 @@
 #include <gz/physics/RequestEngine.hh>
 #include <gz/physics/ForwardStep.hh>
 #include <gz/physics/FrameSemantics.hh>
+#include <gz/physics/Gravity.hh>
 #include <gz/physics/GetBoundingBox.hh>
 #include <gz/physics/Link.hh>
 #include <gz/physics/World.hh>
@@ -289,6 +290,110 @@ TYPED_TEST(LinkFeaturesTest, JointSetCommand)
       EXPECT_PRED_FORMAT2(vectorPredicate,
                           frameData.pose.linear() * offset.cross(cmdLocalForce),
                           moi * frameData.angularAcceleration);
+    }
+  }
+}
+
+using LinkGravityFeaturesList = gz::physics::FeatureList<
+    gz::physics::ForwardStep,
+    gz::physics::Gravity,
+    gz::physics::GravityEnabled,
+    gz::physics::LinkFrameSemantics,
+    gz::physics::sdf::ConstructSdfWorld,
+    gz::physics::sdf::ConstructSdfModel,
+    gz::physics::sdf::ConstructSdfLink,
+    gz::physics::GetEntities
+>;
+
+using LinkGravityFeaturesTestTypes =
+  LinkFeaturesTest<LinkGravityFeaturesList>;
+
+TEST_F(LinkGravityFeaturesTestTypes, LinkGravityEnabled)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine = gz::physics::RequestEngine3d<
+        LinkGravityFeaturesList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    sdf::Root root;
+    const sdf::Errors errors = root.Load(common_test::worlds::kEmptySdf);
+    ASSERT_TRUE(errors.empty()) << errors.front();
+
+    auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+    EXPECT_NE(nullptr, world);
+    // Make sure the world gravity is enabled
+    world->SetGravity(Eigen::Vector3d(0, 0, -9.8));
+
+    // Add a sphere
+    sdf::Model modelSDF;
+    modelSDF.SetName("sphere");
+    modelSDF.SetRawPose(gz::math::Pose3d(0, 0, 2, 0, 0, 0));
+    auto model = world->ConstructModel(modelSDF);
+
+    sdf::Link linkSDF;
+    linkSDF.SetName("sphere_link");
+    auto link = model->ConstructLink(linkSDF);
+
+    gz::physics::ForwardStep::Input input;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Output output;
+
+    AssertVectorApprox vectorPredicate(1e-4);
+
+    // By default, link gravity should be enabled
+    EXPECT_TRUE(link->GetGravityEnabled());
+
+    // Disable gravity for link
+    link->SetGravityEnabled(false);
+    EXPECT_FALSE(link->GetGravityEnabled());
+
+    const Eigen::Vector3d initialPos =
+        link->FrameDataRelativeToWorld().pose.translation();
+
+    world->Step(output, state, input);
+
+    // Link should not move (zero acceleration, velocity and same position)
+    {
+      const auto frameData = link->FrameDataRelativeToWorld();
+      EXPECT_PRED_FORMAT2(vectorPredicate, Eigen::Vector3d::Zero(),
+                          frameData.linearAcceleration);
+      EXPECT_PRED_FORMAT2(vectorPredicate, Eigen::Vector3d::Zero(),
+                          frameData.linearVelocity);
+      EXPECT_PRED_FORMAT2(vectorPredicate, initialPos,
+                          frameData.pose.translation());
+    }
+
+    // Enable gravity
+    link->SetGravityEnabled(true);
+    EXPECT_TRUE(link->GetGravityEnabled());
+
+    // Step a few times to let velocity and position build up
+    const int steps = 10;
+    // Assuming default step size of 0.001
+    const double dt = 0.001;
+
+    for (int i = 0; i < steps; ++i)
+      world->Step(output, state, input);
+
+    // Link should accelerate downwards
+    {
+      const auto frameData = link->FrameDataRelativeToWorld();
+
+      // Acceleration should be gravity
+      EXPECT_PRED_FORMAT2(vectorPredicate, Eigen::Vector3d(0, 0, -9.8),
+                          frameData.linearAcceleration);
+
+      // Velocity should be g * t
+      double expectedVel = -9.8 * steps * dt;
+      EXPECT_NEAR(expectedVel, frameData.linearVelocity.z(), 1e-3);
+
+      // Position should be z0 + 0.5 * g * t^2
+      double expectedPos = initialPos.z() + 0.5 * -9.8 * pow(steps * dt, 2);
+      EXPECT_NEAR(expectedPos, frameData.pose.translation().z(), 1e-3);
     }
   }
 }

--- a/test/common_test/model_features.cc
+++ b/test/common_test/model_features.cc
@@ -28,6 +28,7 @@
 #include <gz/physics/FrameSemantics.hh>
 #include <gz/physics/FreeGroup.hh>
 #include <gz/physics/GetEntities.hh>
+#include <gz/physics/Gravity.hh>
 #include <gz/physics/Model.hh>
 #include <gz/physics/RequestEngine.hh>
 #include <gz/physics/sdf/ConstructWorld.hh>

--- a/test/common_test/model_features.cc
+++ b/test/common_test/model_features.cc
@@ -46,7 +46,7 @@ struct ModelFeaturesFeatureList : gz::physics::FeatureList<
   gz::physics::GetNestedModelFromModel,
   gz::physics::LinkFrameSemantics,
   gz::physics::ModelStaticState,
-  gz::physics::ModelGravityEnabled,
+  gz::physics::GravityEnabled,
   gz::physics::sdf::ConstructSdfWorld
 > { };
 

--- a/test/common_test/model_features.cc
+++ b/test/common_test/model_features.cc
@@ -225,7 +225,8 @@ TYPED_TEST(ModelFeaturesTest, ModelStaticStatePreventsMotion)
     // Re-enable mobility: gravity now integrates and the sphere falls.
     model->SetStatic(false);
     // Re-apply angular velocity after the static→dynamic transition
-    // (DART resets velocity state when the skeleton becomes mobile again).
+    // (Some physics engines may reset velocity state when the model becomes
+    // mobile again).
     const Eigen::Vector3d angVel(0.0, 0.0, 1.0);
     freeGroup->SetWorldAngularVelocity(angVel);
 
@@ -482,11 +483,11 @@ TYPED_TEST(ModelFeaturesTest, GravityPreservedAcrossStaticToggle)
 
 //////////////////////////////////////////////////
 // GetModelGravityEnabled must return true for a model whose only link has
-// fluid added mass configured, even though SetLinkAddedMass forces DART
-// gravity off internally on that body node.
+// fluid added mass configured, even though SetLinkAddedMass forces the physics
+// engine's gravity off internally on that entity.
 // SetModelGravityEnabled skips added-mass links entirely, so for an
 // all-added-mass model calling Set has no effect and the getter stays true.
-TYPED_TEST(ModelFeaturesTest, AddedMassLinkDoesNotPollutGravityGetter)
+TYPED_TEST(ModelFeaturesTest, AddedMassLinkDoesNotPolluteGravityGetter)
 {
   for (const std::string &name : this->pluginNames)
   {
@@ -503,13 +504,13 @@ TYPED_TEST(ModelFeaturesTest, AddedMassLinkDoesNotPollutGravityGetter)
     auto model = world->GetModel("sphere_added_mass");
     ASSERT_NE(nullptr, model);
 
-    // Despite the added-mass link having DART gravity mode = false internally,
+    // Despite the added-mass link having internal gravity mode = false,
     // the user-visible flag must read as enabled (user never called
     // SetGravityEnabled(false)).
     EXPECT_TRUE(model->GetGravityEnabled());
 
     // All links are added-mass links so SetGravityEnabled is a no-op;
-    // the getter must not be corrupted by the internal DART flag.
+    // the getter must not be corrupted by the internal engine flag.
     model->SetGravityEnabled(false);
     EXPECT_TRUE(model->GetGravityEnabled());
 
@@ -519,8 +520,8 @@ TYPED_TEST(ModelFeaturesTest, AddedMassLinkDoesNotPollutGravityGetter)
 }
 
 //////////////////////////////////////////////////
-// SetModelGravityEnabled(true) must not re-enable DART's built-in gravity on
-// an added-mass link. If it did, gravity would be applied twice (DART's
+// SetModelGravityEnabled(true) must not re-enable internal built-in gravity on
+// an added-mass link. If it did, gravity would be applied twice (engine's
 // built-in pass + the manual F=ma in SimulationFeatures) and the model would
 // fall faster than a plain sphere of the same mass.
 TYPED_TEST(ModelFeaturesTest, AddedMassLinkGravityInvariantPreserved)
@@ -550,7 +551,7 @@ TYPED_TEST(ModelFeaturesTest, AddedMassLinkGravityInvariantPreserved)
     ASSERT_NE(nullptr, amLink);
 
     // Explicitly call SetGravityEnabled(true) to exercise the code path that
-    // must NOT re-enable DART's built-in gravity on the added-mass body node.
+    // must NOT re-enable internal built-in gravity on the added-mass link.
     amModel->SetGravityEnabled(true);
     EXPECT_TRUE(amModel->GetGravityEnabled());
 
@@ -558,7 +559,7 @@ TYPED_TEST(ModelFeaturesTest, AddedMassLinkGravityInvariantPreserved)
     // body mass=1, effective inertial mass for vertical motion is 2 kg, so the
     // added-mass sphere falls more slowly (a = F/m_eff = 10/2 = 5 m/s^2)
     // compared to the plain sphere (a = 10 m/s^2). If SetGravityEnabled(true)
-    // incorrectly re-enabled DART's built-in gravity, the added-mass sphere
+    // incorrectly re-enabled internal built-in gravity, the added-mass sphere
     // would receive gravity twice and fall faster than the plain one.
     const std::size_t steps = 100;
     gz::physics::ForwardStep::Input input;
@@ -576,7 +577,7 @@ TYPED_TEST(ModelFeaturesTest, AddedMassLinkGravityInvariantPreserved)
     // (If the invariant is broken, amZ < plainZ.)
     EXPECT_GE(amZ, plainZ)
         << "Added-mass sphere fell faster than plain sphere, suggesting "
-           "SetGravityEnabled(true) incorrectly re-enabled DART built-in "
+           "SetGravityEnabled(true) incorrectly re-enabled built-in "
            "gravity on the added-mass link (double gravity applied).";
   }
 }


### PR DESCRIPTION


# 🎉 New feature

Targets https://github.com/gazebosim/gz-physics/pull/919

## Summary

Refactored so that both `Model` and `Link` both have a `SetGravityEnabled` feature. The one in `Model` does not have an engine-specific implementation. Instead it just calls the functions from `Link`.

I also updated the test's comments to be less dart specific

## Test it

```
ctest -R model_features
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

