### PR TITLE
Mujoco: fix qvelAddr bounds-checked against m->nq instead of m->nv

### DIFF
--- a/mujoco/src/Base.cc
+++ b/mujoco/src/Base.cc
@@ -68,7 +68,7 @@ void resolveJointIndices(WorldInfo &_worldInfo)
       // in the Mujoco documentation states: "jnt_dofadr: start addr in 'qvel'
       // for joint's data".
       int qvelAddr = m->jnt_dofadr[jointId];
-      if (qvelAddr < 0 || qvelAddr >= m->nq)
+      if (qvelAddr < 0 || qvelAddr >= m->nv)
       {
         gzerr << "Error resolving the velocity index of joint ["
               << jointInfo->name << "] in the mjData \n";


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Probably a typo. `jnt_dofadr` is an offset into `qvel`/`qacc`/`qfrc_actuator`, which have size `m->nv`, not `m->nq`. For free/ball joints `nq > nv` (7 vs 6), making this check allow out-of-bounds access. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus Sonnet 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead