### PR TITLE
mujoco: Disable `-Werror` for discarded-qualifiers warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,3 @@ jobs:
           gzdev-project-name: rotary
           cppcheck-enabled: true
           cpplint-enabled: true
-          cmake-args: '-DSKIP_mujoco=ON'

--- a/third_party/mujoco_vendor/CMakeLists.txt
+++ b/third_party/mujoco_vendor/CMakeLists.txt
@@ -25,7 +25,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 set(MUJOCO_EXTRA_CMAKE_ARGS "")
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   list(APPEND MUJOCO_EXTRA_CMAKE_ARGS
     -DCMAKE_C_FLAGS=-Wno-error=discarded-qualifiers
     -DCMAKE_CXX_FLAGS=-Wno-error=discarded-qualifiers

--- a/third_party/mujoco_vendor/CMakeLists.txt
+++ b/third_party/mujoco_vendor/CMakeLists.txt
@@ -24,6 +24,14 @@ if(UNIX AND NOT APPLE)
     set(MUJOCO_LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/mujoco.map")
 endif()
 
+set(MUJOCO_EXTRA_CMAKE_ARGS "")
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+  list(APPEND MUJOCO_EXTRA_CMAKE_ARGS
+    -DCMAKE_C_FLAGS=-Wno-error=discarded-qualifiers
+    -DCMAKE_CXX_FLAGS=-Wno-error=discarded-qualifiers
+  )
+endif()
+
 ExternalProject_Add(
   mujoco_ext
   GIT_REPOSITORY https://github.com/google-deepmind/mujoco
@@ -43,6 +51,7 @@ ExternalProject_Add(
     -DMUJOCO_BUILD_SIMULATE=OFF
     -DMUJOCO_TEST_PYTHON_UTIL=OFF
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    ${MUJOCO_EXTRA_CMAKE_ARGS}
 )
 
 # Create the IMPORTED target for gz-physics to link against


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Under newer compilers in Ubuntu Resolute, a pointer type mismatch in `engine_print.c` causes a warning. Since `-Werror` is hardcoded in MuJoCo's build settings, it results in a fatal compilation failure.

This change conditionally appends `-Wno-error=discarded-qualifiers` to CMAKE_C_FLAGS and CMAKE_CXX_FLAGS passed to the MuJoCo ExternalProject. In GCC, this successfully overrides the fatal -Werror behavior for this warning, allowing the build to compile successfully.
## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


Generated-by: Gemini 3.0 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
