### PR TITLE
feat: Raycast implementation for ODE

### DIFF
--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -244,7 +244,7 @@ void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
     const double sqrDist = (*data->origin - contactPoint).squaredNorm();
     if(sqrDist > data->curContactDistSqr)
     {
-      // ignore nearer contacts
+      // ignore farther contacts
       return;
     }
 
@@ -257,6 +257,7 @@ void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
     {
       setResult(data->result->mRayHits.front());
     }
+    data->curContactDistSqr = sqrDist;
   }
 }
 

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -319,7 +319,7 @@ bool GzOdeCollisionDetector::raycast(
   auto odeGroup = static_cast<GzOdeCollisionGroup *>(group);
   const dSpaceID spaceId = odeGroup->getOdeSpaceId();
 
-  const dGeomID rayId = dCreateRay(spaceId, 1.0);
+  const dGeomID rayId = dCreateRay(nullptr, 1.0);
   dGeomRaySetClosestHit(rayId, 1);
 
   doSingleRaycastODE(from, to, result, rayId, spaceId);
@@ -338,7 +338,7 @@ bool GzOdeCollisionDetector::BatchRaycast(
   auto odeGroup = static_cast<GzOdeCollisionGroup *>(_group);
   const dSpaceID spaceId = odeGroup->getOdeSpaceId();
 
-  const dGeomID rayId = dCreateRay(spaceId, 1.0);
+  const dGeomID rayId = dCreateRay(nullptr, 1.0);
   dGeomRaySetClosestHit(rayId, 1);
 
   _results.clear();

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -124,7 +124,6 @@ bool GzCollisionDetector::BatchRaycast(
 GzOdeCollisionDetector::GzOdeCollisionDetector()
   : OdeCollisionDetector(), GzCollisionDetector()
 {
-
 }
 
 /////////////////////////////////////////////////
@@ -186,6 +185,13 @@ bool GzOdeCollisionDetector::collide(
   return ret;
 }
 
+struct ODERayCastData
+{
+  RaycastResult* result;
+  const Eigen::Vector3d *origin;
+  double curContactDistSqr = std::numeric_limits<double>::max();
+};
+
 void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
 {
   // Check space
@@ -218,10 +224,11 @@ void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
 
   dContactGeom contact;
 
-  RaycastResult* result = static_cast<RaycastResult*>(_data);
+  ODERayCastData* data = static_cast<ODERayCastData*>(_data);
 
   auto setResult = [&](dart::collision::RayHit &rayHit)
   {
+
       auto geomData = dGeomGetData(other);
       rayHit.mNormal = Eigen::Vector3d(contact.normal);
       rayHit.mPoint = Eigen::Vector3d(contact.pos);
@@ -232,13 +239,23 @@ void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
   // param 3 makes sure that we only generate one collision per call
   if(dCollide(ray, other, 1, &contact, sizeof(dContactGeom)) > 0)
   {
-    if(result->mRayHits.empty())
+    Eigen::Vector3d contactPoint(contact.pos);
+
+    const double sqrDist = (*data->origin - contactPoint).squaredNorm();
+    if(sqrDist > data->curContactDistSqr)
     {
-      setResult(result->mRayHits.emplace_back());
+      // ignore nearer contacts
+      return;
+    }
+
+    if(data->result->mRayHits.empty())
+    {
+      setResult(data->result->mRayHits.emplace_back());
+
     }
     else
     {
-      setResult(result->mRayHits.front());
+      setResult(data->result->mRayHits.front());
     }
   }
 }
@@ -263,9 +280,13 @@ static void doSingleRaycastODE(const Eigen::Vector3d& origin,
               dir.x(), dir.y(), dir.z());
   dGeomRaySetLength(rayId, length);
 
+  ODERayCastData data;
+  data.result = result;
+  data.origin = &origin;
+
   dSpaceCollide2(rayId,
                   reinterpret_cast<dGeomID>(spaceId),
-                  result, &NearCallbackODE);
+                  &data, &NearCallbackODE);
 
   if(!result->mRayHits.empty())
   {

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -22,6 +22,8 @@
 
 #include <dart/collision/CollisionObject.hpp>
 #include <dart/collision/bullet/BulletCollisionGroup.hpp>
+#include <dart/collision/ode/OdeCollisionGroup.hpp>
+#include <gz/common/Console.hh>
 
 #include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
 
@@ -124,6 +126,7 @@ bool GzCollisionDetector::BatchRaycast(
 GzOdeCollisionDetector::GzOdeCollisionDetector()
   : OdeCollisionDetector(), GzCollisionDetector()
 {
+
 }
 
 /////////////////////////////////////////////////
@@ -147,6 +150,21 @@ std::shared_ptr<GzOdeCollisionDetector> GzOdeCollisionDetector::create()
   return std::shared_ptr<GzOdeCollisionDetector>(new GzOdeCollisionDetector());
 }
 
+class GzOdeCollisionGroup : public OdeCollisionGroup
+{
+  friend class GzOdeCollisionDetector;
+public:
+  /// Constructor
+  using OdeCollisionGroup::OdeCollisionGroup;
+
+  using OdeCollisionGroup::getOdeSpaceId;
+};
+
+std::unique_ptr<CollisionGroup> GzOdeCollisionDetector::createCollisionGroup()
+{
+  return std::make_unique<GzOdeCollisionGroup>(shared_from_this());
+}
+
 /////////////////////////////////////////////////
 bool GzOdeCollisionDetector::collide(
     CollisionGroup *_group,
@@ -168,6 +186,148 @@ bool GzOdeCollisionDetector::collide(
   bool ret = OdeCollisionDetector::collide(_group1, _group2, _option, _result);
   this->LimitCollisionPairMaxContacts(_result);
   return ret;
+}
+
+void NearCallback(void *_data, dGeomID _o1, dGeomID _o2)
+{
+  // Check space
+  if (dGeomIsSpace(_o1) || dGeomIsSpace(_o2))
+  {
+    dSpaceCollide2(_o1, _o2, _data, &NearCallback);
+    return;
+  }
+
+  // Identify the ray
+  dGeomID ray = nullptr;
+  dGeomID other = nullptr;
+
+  if (dGeomGetClass(_o1) == dRayClass)
+  {
+    ray = _o1;
+    other = _o2;
+  }
+  if (dGeomGetClass(_o2) == dRayClass)
+  {
+    ray = _o2;
+    other = _o1;
+  }
+
+  if(ray == nullptr)
+  {
+    // should not happen, but to be safe...
+    return;
+  }
+
+  dContactGeom contact;
+
+  RaycastResult* result = static_cast<RaycastResult*>(_data);
+
+  auto setResult = [&](dart::collision::RayHit &rayHit)
+  {
+      auto geomData = dGeomGetData(other);
+      rayHit.mFraction = contact.depth;
+      rayHit.mNormal = Eigen::Vector3d(contact.normal);
+      rayHit.mPoint = Eigen::Vector3d(contact.pos);
+      rayHit.mCollisionObject = static_cast<dart::collision::CollisionObject*>(geomData);
+  };
+
+  // param 3 makes sure that we only generate one collision per call
+  if(dCollide(ray, other, 1, &contact, sizeof(dContactGeom)) > 0)
+  {
+    if(result->mRayHits.empty())
+    {
+      setResult(result->mRayHits.emplace_back());
+    }
+    else
+    {
+      setResult(result->mRayHits.front());
+    }
+  }
+}
+
+bool GzOdeCollisionDetector::raycast(
+      CollisionGroup* group,
+      const Eigen::Vector3d& from,
+      const Eigen::Vector3d& to,
+      const RaycastOption& option,
+      RaycastResult* result)
+{
+  if(option.mEnableAllHits)
+  {
+      gzwarn << "raycast multihit support is not implemented for ODE" << std::endl;
+      return false;
+  }
+
+  auto odeGroup = static_cast<GzOdeCollisionGroup *>(group);
+
+  dGeomID rayId = dCreateRay(odeGroup->getOdeSpaceId(), 1.0);
+
+  const Eigen::Vector3d dirNonNormalized(to - from);
+  const double length = dirNonNormalized.norm();
+  if(length <= 1e-7)
+  {
+    return false;
+  }
+
+  const Eigen::Vector3d dir(dirNonNormalized / length);
+
+  dGeomRaySet(rayId, from.x(), from.y(), from.z(), dir.x(), dir.y(), dir.z());
+  dGeomRaySetLength(rayId, length);
+
+  dGeomRaySetClosestHit(rayId, 1);
+
+  dSpaceCollide2(rayId, reinterpret_cast<dGeomID>(odeGroup->getOdeSpaceId()), result,
+         &NearCallback);
+
+  dGeomDestroy(rayId);
+
+  // near callback updated our ray hit result now (or not)
+  return !result->mRayHits.empty();
+}
+
+bool GzOdeCollisionDetector::BatchRaycast(
+      CollisionGroup *_group,
+      const std::vector<GzRay> &_rays,
+      std::vector<GzRayResult> &_results) const
+{
+  auto odeGroup = static_cast<GzOdeCollisionGroup *>(_group);
+
+  dGeomID rayId = dCreateRay(odeGroup->getOdeSpaceId(), 1.0);
+  dGeomRaySetClosestHit(rayId, 1);
+
+  _results.reserve(_rays.size());
+  RaycastResult result;
+  for(const GzRay &ray : _rays)
+  {
+    const Eigen::Vector3d dirNonNormalized(ray.target - ray.origin);
+    const double length = dirNonNormalized.norm();
+    result.clear();
+    if(length > 1e-7)
+    {
+      const Eigen::Vector3d dir(dirNonNormalized / length);
+
+      dGeomRaySet(rayId, ray.origin.x(), ray.origin.y(), ray.origin.z(), dir.x(), dir.y(), dir.z());
+      dGeomRaySetLength(rayId, length);
+
+      dSpaceCollide2(rayId, reinterpret_cast<dGeomID>(odeGroup->getOdeSpaceId()), &result,
+            &NearCallback);
+    }
+
+    // near callback updated our ray hit result now (or not)
+    if(result.hasHit())
+    {
+      RayHit &rayHit(result.mRayHits.front());
+      _results.emplace_back(GzRayResult{rayHit.mPoint, rayHit.mFraction , rayHit.mNormal});
+    }
+    else
+    {
+      _results.emplace_back(GzRayResult{Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()), std::numeric_limits<double>::infinity() , Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())});
+    }
+  }
+
+  dGeomDestroy(rayId);
+
+  return true;
 }
 
 /// \brief Exposes BulletCollisionGroup::getBulletCollisionWorld() which

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -320,6 +320,7 @@ bool GzOdeCollisionDetector::BatchRaycast(
   const dGeomID rayId = dCreateRay(spaceId, 1.0);
   dGeomRaySetClosestHit(rayId, 1);
 
+  _results.clear();
   _results.reserve(_rays.size());
   RaycastResult result;
   for(const GzRay &ray : _rays)

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -27,8 +27,6 @@
 
 #include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
 
-#include <gz/common/Console.hh>
-
 #include "GzCollisionDetector.hh"
 
 using namespace dart;
@@ -188,12 +186,12 @@ bool GzOdeCollisionDetector::collide(
   return ret;
 }
 
-void NearCallback(void *_data, dGeomID _o1, dGeomID _o2)
+void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
 {
   // Check space
   if (dGeomIsSpace(_o1) || dGeomIsSpace(_o2))
   {
-    dSpaceCollide2(_o1, _o2, _data, &NearCallback);
+    dSpaceCollide2(_o1, _o2, _data, &NearCallbackODE);
     return;
   }
 
@@ -225,10 +223,10 @@ void NearCallback(void *_data, dGeomID _o1, dGeomID _o2)
   auto setResult = [&](dart::collision::RayHit &rayHit)
   {
       auto geomData = dGeomGetData(other);
-      rayHit.mFraction = contact.depth;
       rayHit.mNormal = Eigen::Vector3d(contact.normal);
       rayHit.mPoint = Eigen::Vector3d(contact.pos);
-      rayHit.mCollisionObject = static_cast<dart::collision::CollisionObject*>(geomData);
+      rayHit.mCollisionObject =
+        static_cast<dart::collision::CollisionObject*>(geomData);
   };
 
   // param 3 makes sure that we only generate one collision per call
@@ -245,6 +243,39 @@ void NearCallback(void *_data, dGeomID _o1, dGeomID _o2)
   }
 }
 
+static void doSingleRaycastODE(const Eigen::Vector3d& origin,
+      const Eigen::Vector3d& target,
+      RaycastResult* result,
+      const dGeomID &rayId,
+      const dSpaceID &spaceId)
+{
+  const Eigen::Vector3d dirNonNormalized(target - origin);
+  const double length = dirNonNormalized.norm();
+  result->clear();
+  if(length < 1e-7)
+  {
+    return;
+  }
+
+  const Eigen::Vector3d dir(dirNonNormalized / length);
+
+  dGeomRaySet(rayId, origin.x(), origin.y(), origin.z(),
+              dir.x(), dir.y(), dir.z());
+  dGeomRaySetLength(rayId, length);
+
+  dSpaceCollide2(rayId,
+                  reinterpret_cast<dGeomID>(spaceId),
+                  result, &NearCallbackODE);
+
+  if(!result->mRayHits.empty())
+  {
+    // compute fraction, we need to do it here, as we need
+    // length and orgin
+    RayHit &rayHit(result->mRayHits.front());
+    rayHit.mFraction = (rayHit.mPoint - origin).norm() / length;
+  }
+}
+
 bool GzOdeCollisionDetector::raycast(
       CollisionGroup* group,
       const Eigen::Vector3d& from,
@@ -252,32 +283,25 @@ bool GzOdeCollisionDetector::raycast(
       const RaycastOption& option,
       RaycastResult* result)
 {
-  if(option.mEnableAllHits)
-  {
-      gzwarn << "raycast multihit support is not implemented for ODE" << std::endl;
-      return false;
-  }
-
-  auto odeGroup = static_cast<GzOdeCollisionGroup *>(group);
-
-  dGeomID rayId = dCreateRay(odeGroup->getOdeSpaceId(), 1.0);
-
-  const Eigen::Vector3d dirNonNormalized(to - from);
-  const double length = dirNonNormalized.norm();
-  if(length <= 1e-7)
+  if(!result)
   {
     return false;
   }
 
-  const Eigen::Vector3d dir(dirNonNormalized / length);
+  if(option.mEnableAllHits)
+  {
+      gzwarn << "raycast multihit support is not"
+             << " implemented for ODE" << std::endl;
+      return false;
+  }
 
-  dGeomRaySet(rayId, from.x(), from.y(), from.z(), dir.x(), dir.y(), dir.z());
-  dGeomRaySetLength(rayId, length);
+  auto odeGroup = static_cast<GzOdeCollisionGroup *>(group);
+  const dSpaceID spaceId = odeGroup->getOdeSpaceId();
 
+  const dGeomID rayId = dCreateRay(spaceId, 1.0);
   dGeomRaySetClosestHit(rayId, 1);
 
-  dSpaceCollide2(rayId, reinterpret_cast<dGeomID>(odeGroup->getOdeSpaceId()), result,
-         &NearCallback);
+  doSingleRaycastODE(from, to, result, rayId, spaceId);
 
   dGeomDestroy(rayId);
 
@@ -291,37 +315,30 @@ bool GzOdeCollisionDetector::BatchRaycast(
       std::vector<GzRayResult> &_results) const
 {
   auto odeGroup = static_cast<GzOdeCollisionGroup *>(_group);
+  const dSpaceID spaceId = odeGroup->getOdeSpaceId();
 
-  dGeomID rayId = dCreateRay(odeGroup->getOdeSpaceId(), 1.0);
+  const dGeomID rayId = dCreateRay(spaceId, 1.0);
   dGeomRaySetClosestHit(rayId, 1);
 
   _results.reserve(_rays.size());
   RaycastResult result;
   for(const GzRay &ray : _rays)
   {
-    const Eigen::Vector3d dirNonNormalized(ray.target - ray.origin);
-    const double length = dirNonNormalized.norm();
-    result.clear();
-    if(length > 1e-7)
-    {
-      const Eigen::Vector3d dir(dirNonNormalized / length);
-
-      dGeomRaySet(rayId, ray.origin.x(), ray.origin.y(), ray.origin.z(), dir.x(), dir.y(), dir.z());
-      dGeomRaySetLength(rayId, length);
-
-      dSpaceCollide2(rayId, reinterpret_cast<dGeomID>(odeGroup->getOdeSpaceId()), &result,
-            &NearCallback);
-    }
+    doSingleRaycastODE(ray.origin, ray.target, &result, rayId, spaceId);
 
     // near callback updated our ray hit result now (or not)
     if(result.hasHit())
     {
       RayHit &rayHit(result.mRayHits.front());
-      _results.emplace_back(GzRayResult{rayHit.mPoint, rayHit.mFraction , rayHit.mNormal});
+      _results.emplace_back(GzRayResult{rayHit.mPoint, rayHit.mFraction,
+                            rayHit.mNormal});
     }
     else
     {
-      _results.emplace_back(GzRayResult{Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()), std::numeric_limits<double>::infinity() , Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())});
+      _results.emplace_back(GzRayResult{
+          Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()),
+          std::numeric_limits<double>::infinity(),
+          Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())});
     }
   }
 

--- a/dartsim/src/GzCollisionDetector.hh
+++ b/dartsim/src/GzCollisionDetector.hh
@@ -104,8 +104,31 @@ class GzOdeCollisionDetector :
       const CollisionOption& option = CollisionOption(false, 1u, nullptr),
       CollisionResult* result = nullptr) override;
 
+  /// Performs raycast to a collision group.
+  ///
+  /// \param[in] group The collision group the ray will be casted onto.
+  /// \param[in] from The start point of the ray in world coordinates.
+  /// \param[in] to The end point of the ray in world coordinates.
+  /// \param[in] option The raycast option.
+  /// \param[in] result The raycast result.
+  /// \return True if the ray hit an collision object.
+  public: bool raycast(
+      CollisionGroup* group,
+      const Eigen::Vector3d& from,
+      const Eigen::Vector3d& to,
+      const RaycastOption& option = RaycastOption(),
+      RaycastResult* result = nullptr) override;
+
+  public: virtual bool BatchRaycast(
+      CollisionGroup *_group,
+      const std::vector<GzRay> &_rays,
+      std::vector<GzRayResult> &_results) const override;
+
   /// \brief Create the GzOdeCollisionDetector
   public: static std::shared_ptr<GzOdeCollisionDetector> create();
+
+  // Documentation inherited
+  public: std::unique_ptr<CollisionGroup> createCollisionGroup() override;
 
   /// Constructor
   protected: GzOdeCollisionDetector();

--- a/test/common_test/Worlds.hh
+++ b/test/common_test/Worlds.hh
@@ -71,5 +71,7 @@ const auto kWorldWithNestedModelSdf =
   CommonTestWorld("world_with_nested_model.sdf");
 const auto kNestedModelSelfCollideSdf =
   CommonTestWorld("nested_model_self_collide.sdf");
+const auto kMultipleObjectsComplexSdf =
+  CommonTestWorld("multiple_objects_complex.sdf");
 }  // namespace common_test::worlds
 #endif  // COMMON_TEST_WORLDS_WORLDS_HH_

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -2347,6 +2347,52 @@ TYPED_TEST(SimulationFeaturesRayIntersectionTest, UnsupportedRayIntersections)
   }
 }
 
+/////////////////////////////////////////////////
+TYPED_TEST(SimulationFeaturesRayIntersectionTest, ClosestRayIntersection)
+{
+  std::vector<std::string> supportedCollisionDetectors = {"ode"};
+
+  for (const std::string &name : this->pluginNames)
+  {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet", "bullet-featherstone", "tpe")
+
+    for (const std::string &collisionDetector : supportedCollisionDetectors) {
+      auto world = LoadPluginAndWorld<FeaturesRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kMultipleObjectsComplexSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput = StepWorld<FeaturesRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
+
+      // Test ray along X axis, should hit closest sphere at x=1
+      // Objects are at different Y positions to confuse spatial traversal
+      gzerr << "[TEST DEBUG] About to call GetRayIntersectionFromLastStep" << std::endl;
+      auto result =
+        world->GetRayIntersectionFromLastStep(
+            Eigen::Vector3d(-2, 0, 0), Eigen::Vector3d(10, 0, 0));
+      gzerr << "[TEST DEBUG] GetRayIntersectionFromLastStep returned" << std::endl;
+
+      auto rayIntersection =
+          result.template
+            Get<gz::physics::World3d<FeaturesRayIntersections>::RayIntersection>();
+
+      gzerr << "[TEST DEBUG] Ray intersection point: " << rayIntersection.point.transpose() << std::endl;
+      gzerr << "[TEST DEBUG] Ray intersection fraction: " << rayIntersection.fraction << std::endl;
+      gzerr << "[TEST DEBUG] Ray intersection normal: " << rayIntersection.normal.transpose() << std::endl;
+
+      double epsilon = 1e-3;
+
+      // The sphere at x=1 has radius 0.3, so the ray should hit at x=0.7
+      // Ray goes from -2 to 10, total length = 12
+      // Hit point at x=0.7 is 2.7 units from start, fraction = 2.7/12 = 0.225
+      EXPECT_TRUE(
+          rayIntersection.point.isApprox(Eigen::Vector3d(0.7, 0, 0), epsilon));
+      EXPECT_NEAR(rayIntersection.fraction, 0.225, epsilon);
+    }
+  }
+}
+
 // The features that an engine must have to be loaded by this loader.
 struct FeaturesBatchRayIntersections : gz::physics::FeatureList<
   gz::physics::sdf::ConstructSdfWorld,

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -2367,19 +2367,13 @@ TYPED_TEST(SimulationFeaturesRayIntersectionTest, ClosestRayIntersection)
 
       // Test ray along X axis, should hit closest sphere at x=1
       // Objects are at different Y positions to confuse spatial traversal
-      gzerr << "[TEST DEBUG] About to call GetRayIntersectionFromLastStep" << std::endl;
       auto result =
         world->GetRayIntersectionFromLastStep(
             Eigen::Vector3d(-2, 0, 0), Eigen::Vector3d(10, 0, 0));
-      gzerr << "[TEST DEBUG] GetRayIntersectionFromLastStep returned" << std::endl;
 
       auto rayIntersection =
           result.template
             Get<gz::physics::World3d<FeaturesRayIntersections>::RayIntersection>();
-
-      gzerr << "[TEST DEBUG] Ray intersection point: " << rayIntersection.point.transpose() << std::endl;
-      gzerr << "[TEST DEBUG] Ray intersection fraction: " << rayIntersection.fraction << std::endl;
-      gzerr << "[TEST DEBUG] Ray intersection normal: " << rayIntersection.normal.transpose() << std::endl;
 
       double epsilon = 1e-3;
 

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -2252,7 +2252,7 @@ TYPED_TEST_SUITE(SimulationFeaturesRayIntersectionTest,
 
 TYPED_TEST(SimulationFeaturesRayIntersectionTest, SupportedRayIntersections)
 {
-  std::vector<std::string> supportedCollisionDetectors = {"bullet"};
+  std::vector<std::string> supportedCollisionDetectors = {"ode", "bullet"};
 
   for (const std::string &name : this->pluginNames)
   {
@@ -2311,7 +2311,7 @@ TYPED_TEST(SimulationFeaturesRayIntersectionTest, SupportedRayIntersections)
 
 TYPED_TEST(SimulationFeaturesRayIntersectionTest, UnsupportedRayIntersections)
 {
-  std::vector<std::string> unsupportedCollisionDetectors = {"ode", "dart", "fcl", "banana"};
+  std::vector<std::string> unsupportedCollisionDetectors = {"dart", "fcl"};
 
   for (const std::string &name : this->pluginNames)
   {
@@ -2367,54 +2367,60 @@ TYPED_TEST_SUITE(SimulationFeaturesBatchRayIntersectionTest,
 TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            SupportedBatchRayIntersections)
 {
+  std::vector<std::string> supportedCollisionDetectors =
+    {"ode", "bullet"};
+
   for (const std::string &name : this->pluginNames)
   {
-    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
-        this->loader,
-        name,
-        common_test::worlds::kSphereSdf);
-    world->SetCollisionDetector("bullet");
-    auto checkedOutput =
-      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
-    EXPECT_TRUE(checkedOutput);
-
-    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
-    using RayQuery = World::RayQuery;
-    using RayIntersection = World::RayIntersection;
-    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
-
-    // Build a batch: first ray hits the sphere, second misses
-    std::vector<RayQuery> rays = {
-      {Eigen::Vector3d(-2, 0, 2), Eigen::Vector3d(2, 0, 2)},   // hit
-      {Eigen::Vector3d(2, 0, 10), Eigen::Vector3d(-2, 0, 10)},  // miss
-    };
-
-    BatchedRayIntersectionData output;
-    world->GetBatchRayIntersectionFromLastStep(rays, output);
-    const auto &results = output.Get<std::vector<RayIntersection>>();
-
-    ASSERT_EQ(2u, results.size());
-
-    // Ray 0 - hits the unit sphere centred at (0,0,2)
+    for (const std::string &collisionDetector : supportedCollisionDetectors)
     {
-      const auto &hit = results[0];
-      EXPECT_TRUE(hit.IsHit());
-      double epsilon = 1e-3;
-      EXPECT_TRUE(hit.point.isApprox(Eigen::Vector3d(-1, 0, 2), epsilon))
-        << "hit point: " << hit.point.transpose();
-      EXPECT_TRUE(hit.normal.isApprox(Eigen::Vector3d(-1, 0, 0), epsilon))
-        << "hit normal: " << hit.normal.transpose();
-      EXPECT_DOUBLE_EQ(0.25, hit.fraction);
-    }
+      auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kSphereSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput =
+        StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
 
-    // Ray 1 - misses; +INF fraction, NaN point/normal.
-    {
-      const auto &miss = results[1];
-      EXPECT_FALSE(miss.IsHit());
-      EXPECT_TRUE(miss.point.array().isNaN().all())
-        << "miss point should be NaN: " << miss.point.transpose();
-      EXPECT_TRUE(miss.normal.array().isNaN().all())
-        << "miss normal should be NaN: " << miss.normal.transpose();
+      using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+      using RayQuery = World::RayQuery;
+      using RayIntersection = World::RayIntersection;
+      using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+      // Build a batch: first ray hits the sphere, second misses
+      std::vector<RayQuery> rays = {
+        {Eigen::Vector3d(-2, 0, 2), Eigen::Vector3d(2, 0, 2)},   // hit
+        {Eigen::Vector3d(2, 0, 10), Eigen::Vector3d(-2, 0, 10)},  // miss
+      };
+
+      BatchedRayIntersectionData output;
+      world->GetBatchRayIntersectionFromLastStep(rays, output);
+      const auto &results = output.Get<std::vector<RayIntersection>>();
+
+      ASSERT_EQ(2u, results.size());
+
+      // Ray 0 - hits the unit sphere centred at (0,0,2)
+      {
+        const auto &hit = results[0];
+        EXPECT_TRUE(hit.IsHit());
+        double epsilon = 1e-3;
+        EXPECT_TRUE(hit.point.isApprox(Eigen::Vector3d(-1, 0, 2), epsilon))
+          << "hit point: " << hit.point.transpose();
+        EXPECT_TRUE(hit.normal.isApprox(Eigen::Vector3d(-1, 0, 0), epsilon))
+          << "hit normal: " << hit.normal.transpose();
+        EXPECT_DOUBLE_EQ(0.25, hit.fraction);
+      }
+
+      // Ray 1 - misses; +INF fraction, NaN point/normal.
+      {
+        const auto &miss = results[1];
+        EXPECT_FALSE(miss.IsHit());
+        EXPECT_TRUE(miss.point.array().isNaN().all())
+          << "miss point should be NaN: " << miss.point.transpose();
+        EXPECT_TRUE(miss.normal.array().isNaN().all())
+          << "miss normal should be NaN: " << miss.normal.transpose();
+      }
     }
   }
 }
@@ -2423,26 +2429,32 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            EmptyBatchRayIntersections)
 {
+  std::vector<std::string> supportedCollisionDetectors =
+    {"ode", "bullet"};
+
   for (const std::string &name : this->pluginNames)
   {
-    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
-        this->loader,
-        name,
-        common_test::worlds::kSphereSdf);
-    world->SetCollisionDetector("bullet");
-    auto checkedOutput =
-      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
-    EXPECT_TRUE(checkedOutput);
+    for (const std::string &collisionDetector : supportedCollisionDetectors)
+    {
+      auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kSphereSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput =
+        StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
 
-    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
-    using RayQuery = World::RayQuery;
-    using RayIntersection = World::RayIntersection;
-    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+      using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+      using RayQuery = World::RayQuery;
+      using RayIntersection = World::RayIntersection;
+      using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
 
-    std::vector<RayQuery> rays;  // intentionally empty
-    BatchedRayIntersectionData output;
-    world->GetBatchRayIntersectionFromLastStep(rays, output);
-    EXPECT_TRUE(output.Get<std::vector<RayIntersection>>().empty());
+      std::vector<RayQuery> rays;  // intentionally empty
+      BatchedRayIntersectionData output;
+      world->GetBatchRayIntersectionFromLastStep(rays, output);
+      EXPECT_TRUE(output.Get<std::vector<RayIntersection>>().empty());
+    }
   }
 }
 
@@ -2451,7 +2463,7 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            UnsupportedBatchRayIntersections)
 {
   std::vector<std::string> unsupportedCollisionDetectors =
-    {"ode", "dart", "fcl", "banana"};
+    {"dart", "fcl"};
 
   for (const std::string &name : this->pluginNames)
   {
@@ -2493,59 +2505,65 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            LargeBatchRayIntersections)
 {
+  std::vector<std::string> supportedCollisionDetectors =
+    {"ode", "bullet"};
+
   for (const std::string &name : this->pluginNames)
   {
-    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
-        this->loader,
-        name,
-        common_test::worlds::kSphereSdf);
-    world->SetCollisionDetector("bullet");
-    auto checkedOutput =
-      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
-    EXPECT_TRUE(checkedOutput);
-
-    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
-    using RayQuery = World::RayQuery;
-    using RayIntersection = World::RayIntersection;
-    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
-
-    // Sphere is centred at (0, 0, 2) with radius 1.
-    struct RayCase { RayQuery ray; bool expectedHit; };
-    const std::vector<RayCase> cases = {
-      // equator crossings
-      {{Eigen::Vector3d(-2, 0, 2),    Eigen::Vector3d(2, 0, 2)},    true},
-      {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
-      // chords above/below equator
-      {{Eigen::Vector3d(-2, 0, 2.5),  Eigen::Vector3d(2, 0, 2.5)},  true},
-      {{Eigen::Vector3d(-2, 0, 1.5),  Eigen::Vector3d(2, 0, 1.5)},  true},
-      // vertical shots
-      {{Eigen::Vector3d(0, 0, 5),     Eigen::Vector3d(0, 0, 1)},    true},
-      {{Eigen::Vector3d(0, 0, 10),    Eigen::Vector3d(0, 0, 2)},    true},
-      // repeat of first hit — verifies multiple hits in sequence
-      {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
-      // misses
-      {{Eigen::Vector3d(2, 0, 10),    Eigen::Vector3d(-2, 0, 10)},  false},
-      {{Eigen::Vector3d(0, 2, 20),    Eigen::Vector3d(0, -2, 20)},  false},
-      {{Eigen::Vector3d(5, 5, 2),     Eigen::Vector3d(10, 5, 2)},   false},
-      {{Eigen::Vector3d(3, 3, 2),     Eigen::Vector3d(5, 3, 2)},    false},
-      {{Eigen::Vector3d(-2, 1.5, 2),  Eigen::Vector3d(2, 1.5, 2)},  false},
-    };
-
-    std::vector<RayQuery> rays;
-    rays.reserve(cases.size());
-    for (const auto &c : cases)
-      rays.push_back(c.ray);
-
-    BatchedRayIntersectionData output;
-    world->GetBatchRayIntersectionFromLastStep(rays, output);
-    const auto &results = output.Get<std::vector<RayIntersection>>();
-
-    ASSERT_EQ(cases.size(), results.size());
-
-    for (std::size_t i = 0; i < cases.size(); ++i)
+    for (const std::string &collisionDetector : supportedCollisionDetectors)
     {
-      EXPECT_EQ(cases[i].expectedHit, results[i].IsHit())
-        << "ray index " << i << " hit mismatch";
+      auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kSphereSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput =
+        StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
+
+      using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+      using RayQuery = World::RayQuery;
+      using RayIntersection = World::RayIntersection;
+      using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+      // Sphere is centred at (0, 0, 2) with radius 1.
+      struct RayCase { RayQuery ray; bool expectedHit; };
+      const std::vector<RayCase> cases = {
+        // equator crossings
+        {{Eigen::Vector3d(-2, 0, 2),    Eigen::Vector3d(2, 0, 2)},    true},
+        {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
+        // chords above/below equator
+        {{Eigen::Vector3d(-2, 0, 2.5),  Eigen::Vector3d(2, 0, 2.5)},  true},
+        {{Eigen::Vector3d(-2, 0, 1.5),  Eigen::Vector3d(2, 0, 1.5)},  true},
+        // vertical shots
+        {{Eigen::Vector3d(0, 0, 5),     Eigen::Vector3d(0, 0, 1)},    true},
+        {{Eigen::Vector3d(0, 0, 10),    Eigen::Vector3d(0, 0, 2)},    true},
+        // repeat of first hit — verifies multiple hits in sequence
+        {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
+        // misses
+        {{Eigen::Vector3d(2, 0, 10),    Eigen::Vector3d(-2, 0, 10)},  false},
+        {{Eigen::Vector3d(0, 2, 20),    Eigen::Vector3d(0, -2, 20)},  false},
+        {{Eigen::Vector3d(5, 5, 2),     Eigen::Vector3d(10, 5, 2)},   false},
+        {{Eigen::Vector3d(3, 3, 2),     Eigen::Vector3d(5, 3, 2)},    false},
+        {{Eigen::Vector3d(-2, 1.5, 2),  Eigen::Vector3d(2, 1.5, 2)},  false},
+      };
+
+      std::vector<RayQuery> rays;
+      rays.reserve(cases.size());
+      for (const auto &c : cases)
+        rays.push_back(c.ray);
+
+      BatchedRayIntersectionData output;
+      world->GetBatchRayIntersectionFromLastStep(rays, output);
+      const auto &results = output.Get<std::vector<RayIntersection>>();
+
+      ASSERT_EQ(cases.size(), results.size());
+
+      for (std::size_t i = 0; i < cases.size(); ++i)
+      {
+        EXPECT_EQ(cases[i].expectedHit, results[i].IsHit())
+          << "ray index " << i << " hit mismatch";
+      }
     }
   }
 }

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -2350,11 +2350,11 @@ TYPED_TEST(SimulationFeaturesRayIntersectionTest, UnsupportedRayIntersections)
 /////////////////////////////////////////////////
 TYPED_TEST(SimulationFeaturesRayIntersectionTest, ClosestRayIntersection)
 {
-  std::vector<std::string> supportedCollisionDetectors = {"ode"};
+  std::vector<std::string> supportedCollisionDetectors = {"ode", "bullet"};
 
   for (const std::string &name : this->pluginNames)
   {
-    CHECK_UNSUPPORTED_ENGINE(name, "bullet", "bullet-featherstone", "tpe")
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet-featherstone", "tpe")
 
     for (const std::string &collisionDetector : supportedCollisionDetectors) {
       auto world = LoadPluginAndWorld<FeaturesRayIntersections>(

--- a/test/common_test/worlds/multiple_objects_complex.sdf
+++ b/test/common_test/worlds/multiple_objects_complex.sdf
@@ -1,0 +1,204 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="multiple_objects_complex">
+    <gravity>0 0 0</gravity>
+    <physics name="default_physics" type="ode">
+    </physics>
+
+    <!-- Far object first in SDF so it is inserted into ODE's linked list first.
+         ODE's hash space processes the linked list from head (last inserted) to
+         tail (first inserted), so the first inserted object is processed last.
+         With the buggy ODE raycast, the last processed object overwrites the
+         closest hit. This should cause the test to fail when the bug is not fixed.
+    -->
+    <model name="far_box">
+      <pose>8 0 1.5 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>4 4 4</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Many objects along the X axis to confuse spatial traversal -->
+    <model name="box_1">
+      <pose>2 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.6 0.6 0.6</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_1">
+      <pose>2.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="cylinder_1">
+      <pose>3 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="cylinder_link">
+        <collision name="cylinder_collision">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>0.5</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="box_2">
+      <pose>3.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_2">
+      <pose>4 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="cylinder_2">
+      <pose>4.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="cylinder_link">
+        <collision name="cylinder_collision">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.4</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="box_3">
+      <pose>5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_3">
+      <pose>5.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.15</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="cylinder_3">
+      <pose>6 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="cylinder_link">
+        <collision name="cylinder_collision">
+          <geometry>
+            <cylinder>
+              <radius>0.15</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="box_4">
+      <pose>6.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_4">
+      <pose>7 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Closest object last in SDF so it is inserted into ODE's linked list last.
+         It will be processed first, allowing a later processed (far) object to
+         overwrite the closest hit with the ODE raycast bug.
+    -->
+    <model name="sphere_close">
+      <pose>1 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Followup to https://github.com/gazebosim/gz-physics/pull/880

This adds support for ODE for the raycast implementation, and therefore to the CPU-Lidar implementation.

## Checklist
- [x ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)