### PR TITLE
Pass found package directories to FAKE_INSTALL

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,22 @@ ExternalProject_Add(
   CMAKE_ARGS
     "-DBUILD_TESTING=OFF"
     "-DCMAKE_INSTALL_PREFIX=${FAKE_INSTALL_PREFIX}"
+    "-Dgz-cmake_DIR=${gz-cmake_DIR}"
+    "-Dgz-common_DIR=${gz-common_DIR}"
+    "-Dgz-common-geospatial_DIR=${gz-common-geospatial_DIR}"
+    "-Dgz-common-testing_DIR=${gz-common-testing_DIR}"
+    "-Dgz-common-graphics_DIR=${gz-common-graphics_DIR}"
+    "-Dgz-common-profiler_DIR=${gz-common-profiler_DIR}"
+    "-Dgz-math_DIR=${gz-math_DIR}"
+    "-Dgz-math-eigen3_DIR=${gz-math-eigen3_DIR}"
+    "-Dgz-plugin_DIR=${gz-plugin_DIR}"
+    "-Dgz-plugin-all_DIR=${gz-plugin-all_DIR}"
+    "-Dgz-plugin-loader_DIR=${gz-plugin-loader_DIR}"
+    "-Dgz-plugin-register_DIR=${gz-plugin-register_DIR}"
+    "-Dgz-utils_DIR=${gz-utils_DIR}"
+    "-Dgz-utils-log_DIR=${gz-utils-log_DIR}"
+    "-Dgz-utils-cli_DIR=${gz-utils-cli_DIR}"
+    "-Dsdformat_DIR=${sdformat_DIR}"
 )
 
 add_library(gz-physics-test INTERFACE)


### PR DESCRIPTION
Edit: superseeded by #999

Otherwise when dependencies are installed in a custom location they won't get noticed even when `PKG_CONFIG_PATH` is given.

# 🦟 Bug fix

Fixes #983

## Summary
When dependencies are installed in a custom path and CMake is configured with environment variable `PKG_CONFIG_PATH` set to this path, initial configuration finds the packages without any issues. However, testing with FAKE_INSTALL via ExternalProject_Add cannot find these packages.