### PR TITLE
[bazel] Fix build for //dartsim under clang

### DIFF
--- a/dartsim/BUILD.bazel
+++ b/dartsim/BUILD.bazel
@@ -48,7 +48,7 @@ cc_library(
         "//:heightmap",
         "//:mesh",
         "//:sdf",
-	"@bullet//:BulletCollisionDoublePrecision",
+        "@bullet//:BulletCollisionDoublePrecision",
         "@dartsim//:dart-collision-bullet",
         "@dartsim//:dart-collision-core",
         "@dartsim//:dart-collision-dart",

--- a/dartsim/BUILD.bazel
+++ b/dartsim/BUILD.bazel
@@ -48,6 +48,7 @@ cc_library(
         "//:heightmap",
         "//:mesh",
         "//:sdf",
+	"@bullet//:BulletCollisionDoublePrecision",
         "@dartsim//:dart-collision-bullet",
         "@dartsim//:dart-collision-core",
         "@dartsim//:dart-collision-dart",


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes the following bazel build error in clang:

```
$ bazel build --action_env=CC=/usr/bin/clang dartsim
...
dartsim/src/GzCollisionDetector.cc:26:10: error: module //dartsim:dartsim does not depend on a module exporting 'BulletCollision/CollisionDispatch/btCollisionWorld.h'
   26 | #include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.