### PR TITLE
Enable/Disable collisions at runtime 

### DIFF
--- a/dartsim/src/ModelFeatures.cc
+++ b/dartsim/src/ModelFeatures.cc
@@ -57,6 +57,54 @@ bool ModelFeatures::GetModelStatic(const Identity &_id) const
 }
 
 /////////////////////////////////////////////////
+void ModelFeatures::SetModelCollisionEnabled(
+    const Identity &_id, bool _enabled)
+{
+  auto modelInfo = this->GetModelInfo(_id);
+  if (!modelInfo || !modelInfo->model)
+    return;
+
+  for (const auto &linkInfo : modelInfo->links)
+  {
+    if (linkInfo->link)
+      linkInfo->link->setCollidable(_enabled);
+  }
+
+  // Also apply to nested models recursively.
+  for (const std::size_t nestedID : modelInfo->nestedModels)
+  {
+    this->SetModelCollisionEnabled(this->GenerateIdentity(
+        nestedID, this->GetModelInfo(nestedID)), _enabled);
+  }
+}
+
+/////////////////////////////////////////////////
+bool ModelFeatures::GetModelCollisionEnabled(const Identity &_id) const
+{
+  const auto modelInfo = this->GetModelInfo(_id);
+  if (!modelInfo || !modelInfo->model)
+    return true;
+
+  for (const auto &linkInfo : modelInfo->links)
+  {
+    if (linkInfo->link && !linkInfo->link->isCollidable())
+      return false;
+  }
+
+  // Also check nested models.
+  for (const std::size_t nestedID : modelInfo->nestedModels)
+  {
+    if (!this->GetModelCollisionEnabled(this->GenerateIdentity(
+        nestedID, this->GetModelInfo(nestedID))))
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/////////////////////////////////////////////////
 void ModelFeatures::SetModelGravityEnabled(
     const Identity &_id, bool _enabled)
 {

--- a/dartsim/src/ModelFeatures.hh
+++ b/dartsim/src/ModelFeatures.hh
@@ -30,6 +30,7 @@ namespace dartsim {
 
 struct ModelFeatureList : FeatureList<
   ModelStaticState,
+  ModelCollisionEnabled,
   GravityEnabled
 > { };
 
@@ -43,6 +44,12 @@ class ModelFeatures :
 
   // Documentation inherited
   public: bool GetModelStatic(const Identity &_id) const override;
+
+  // ----- Model Collision Enabled -----
+  public: void SetModelCollisionEnabled(
+      const Identity &_id, bool _enabled) override;
+
+  public: bool GetModelCollisionEnabled(const Identity &_id) const override;
 
   // ----- Model Gravity Enabled -----
   public: void SetModelGravityEnabled(

--- a/include/gz/physics/Model.hh
+++ b/include/gz/physics/Model.hh
@@ -59,6 +59,43 @@ namespace gz
       };
     };
 
+    /////////////////////////////////////////////////
+    /// \brief Feature for enabling and disabling collisions on a model.
+    /// When collisions are disabled, the model's links will not collide with
+    /// other entities in the world.
+    class GZ_PHYSICS_VISIBLE ModelCollisionEnabled : public virtual Feature
+    {
+      /// \brief The Model API for enabling and disabling collisions.
+      public: template <typename PolicyT, typename FeaturesT>
+      class Model : public virtual Feature::Model<PolicyT, FeaturesT>
+      {
+        /// \brief Enable or disable collisions for this model.
+        /// \param[in] _enabled True to enable collisions, false to disable.
+        public: void SetCollisionEnabled(bool _enabled);
+
+        /// \brief Get whether collisions are enabled for this model.
+        /// \return True if collisions are enabled, false otherwise.
+        public: bool GetCollisionEnabled() const;
+      };
+
+      /// \private The implementation API for model collision enabled state.
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        /// \brief Implementation API for enabling/disabling model collisions.
+        /// \param[in] _id Identity of the model.
+        /// \param[in] _enabled True to enable collisions, false to disable.
+        public: virtual void SetModelCollisionEnabled(
+            const Identity &_id, bool _enabled) = 0;
+
+        /// \brief Implementation API for getting the model collision state.
+        /// \param[in] _id Identity of the model.
+        /// \return True if collisions are enabled for the model.
+        public: virtual bool GetModelCollisionEnabled(
+            const Identity &_id) const = 0;
+      };
+    };
+
   }
 }
 

--- a/include/gz/physics/detail/Model.hh
+++ b/include/gz/physics/detail/Model.hh
@@ -40,6 +40,24 @@ bool ModelStaticState::Model<PolicyT, FeaturesT>::GetStatic() const
       ->GetModelStatic(this->identity);
 }
 
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+void ModelCollisionEnabled::Model<PolicyT, FeaturesT>::SetCollisionEnabled(
+    bool _enabled)
+{
+  this->template Interface<ModelCollisionEnabled>()
+      ->SetModelCollisionEnabled(this->identity, _enabled);
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+bool ModelCollisionEnabled::Model<PolicyT, FeaturesT>::GetCollisionEnabled()
+    const
+{
+  return this->template Interface<ModelCollisionEnabled>()
+      ->GetModelCollisionEnabled(this->identity);
+}
+
 }
 }
 

--- a/test/common_test/model_features.cc
+++ b/test/common_test/model_features.cc
@@ -64,6 +64,11 @@ using ModelGravityStaticFeaturesList = gz::physics::FeatureList<
   gz::physics::GravityEnabled
 >;
 
+using ModelCollisionFeaturesList = gz::physics::FeatureList<
+  ModelBaseFeaturesList,
+  gz::physics::ModelCollisionEnabled
+>;
+
 // ---------------------------------------------------------------------------
 // Typed test fixture
 // ---------------------------------------------------------------------------
@@ -95,6 +100,8 @@ class ModelFeaturesTest :
 template <typename T> class ModelStaticTest : public ModelFeaturesTest<T> {};
 template <typename T> class ModelGravityTest : public ModelFeaturesTest<T> {};
 template <typename T> class ModelGravityStaticTest
+    : public ModelFeaturesTest<T> {};
+template <typename T> class ModelCollisionTest
     : public ModelFeaturesTest<T> {};
 
 // ---------------------------------------------------------------------------
@@ -150,6 +157,9 @@ TYPED_TEST_SUITE(ModelGravityTest, ModelGravityTestTypes);
 using ModelGravityStaticTestTypes =
   ::testing::Types<ModelGravityStaticFeaturesList>;
 TYPED_TEST_SUITE(ModelGravityStaticTest, ModelGravityStaticTestTypes);
+
+using ModelCollisionTestTypes = ::testing::Types<ModelCollisionFeaturesList>;
+TYPED_TEST_SUITE(ModelCollisionTest, ModelCollisionTestTypes);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -702,6 +712,135 @@ TYPED_TEST(ModelGravityTest, AddedMassLinkGravityInvariantPreserved)
         << "Added-mass sphere fell faster than plain sphere, suggesting "
            "SetGravityEnabled(true) incorrectly re-enabled built-in "
            "gravity on the added-mass link (double gravity applied).";
+  }
+}
+
+//////////////////////////////////////////////////
+TYPED_TEST(ModelCollisionTest, ModelCollisionEnabledDefault)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<ModelCollisionFeaturesList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    auto world = LoadWorld<ModelCollisionFeaturesList>(
+        engine, common_test::worlds::kSphereGravitySdf);
+    ASSERT_NE(nullptr, world);
+
+    auto model = world->GetModel("sphere");
+    ASSERT_NE(nullptr, model);
+
+    // Default: collisions are enabled.
+    EXPECT_TRUE(model->GetCollisionEnabled());
+  }
+}
+
+//////////////////////////////////////////////////
+TYPED_TEST(ModelCollisionTest, ModelCollisionEnabledSetGet)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<ModelCollisionFeaturesList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    auto world = LoadWorld<ModelCollisionFeaturesList>(
+        engine, common_test::worlds::kSphereGravitySdf);
+    ASSERT_NE(nullptr, world);
+
+    auto model = world->GetModel("sphere");
+    ASSERT_NE(nullptr, model);
+
+    EXPECT_TRUE(model->GetCollisionEnabled());
+
+    model->SetCollisionEnabled(false);
+    EXPECT_FALSE(model->GetCollisionEnabled());
+
+    model->SetCollisionEnabled(true);
+    EXPECT_TRUE(model->GetCollisionEnabled());
+  }
+}
+
+//////////////////////////////////////////////////
+TYPED_TEST(ModelCollisionTest, NestedModelCollisionPropagates)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<ModelCollisionFeaturesList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    auto world = LoadWorld<ModelCollisionFeaturesList>(
+        engine, common_test::worlds::kWorldSingleNestedModelSdf);
+    ASSERT_NE(nullptr, world);
+
+    auto parentModel = world->GetModel("parent_model");
+    ASSERT_NE(nullptr, parentModel);
+
+    auto nestedModel = parentModel->GetNestedModel("nested_model");
+    ASSERT_NE(nullptr, nestedModel);
+
+    // Disable collisions on the parent: nested model must follow.
+    parentModel->SetCollisionEnabled(false);
+    EXPECT_FALSE(parentModel->GetCollisionEnabled());
+    EXPECT_FALSE(nestedModel->GetCollisionEnabled());
+
+    // Re-enable collisions on the parent: nested model must follow.
+    parentModel->SetCollisionEnabled(true);
+    EXPECT_TRUE(parentModel->GetCollisionEnabled());
+    EXPECT_TRUE(nestedModel->GetCollisionEnabled());
+  }
+}
+
+//////////////////////////////////////////////////
+// With collisions disabled the falling sphere must pass through the static box
+// instead of resting on top of it.
+TYPED_TEST(ModelCollisionTest, ModelCollisionDisabledPassThrough)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<ModelCollisionFeaturesList>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    // falling.world: sphere (radius 1) at z=2 above a static box whose top
+    // surface is at z=0. Gravity is the default (~ -9.8).
+    auto world = LoadWorld<ModelCollisionFeaturesList>(
+        engine, common_test::worlds::kFallingWorld);
+    ASSERT_NE(nullptr, world);
+
+    auto sphere = world->GetModel("sphere");
+    ASSERT_NE(nullptr, sphere);
+
+    auto sphereLink = sphere->GetLink("sphere_link");
+    ASSERT_NE(nullptr, sphereLink);
+
+    EXPECT_TRUE(sphere->GetCollisionEnabled());
+
+    // Disable collisions and let the sphere fall for long enough that, in the
+    // presence of collisions, it would have already contacted the box.
+    sphere->SetCollisionEnabled(false);
+    EXPECT_FALSE(sphere->GetCollisionEnabled());
+
+    const double initialZ =
+        sphereLink->FrameDataRelativeToWorld().pose.translation().z();
+    const double afterZ =
+        StepAndGetPosition<ModelCollisionFeaturesList>(
+            world, sphereLink, 1000).z();
+
+    // Without collisions the sphere must keep falling well below the box top
+    // (z=0), which would be impossible if collisions were active.
+    EXPECT_LT(afterZ, 0.0);
+    EXPECT_LT(afterZ, initialZ);
   }
 }
 

--- a/test/common_test/model_features.cc
+++ b/test/common_test/model_features.cc
@@ -716,29 +716,6 @@ TYPED_TEST(ModelGravityTest, AddedMassLinkGravityInvariantPreserved)
 }
 
 //////////////////////////////////////////////////
-TYPED_TEST(ModelCollisionTest, ModelCollisionEnabledDefault)
-{
-  for (const std::string &name : this->pluginNames)
-  {
-    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
-
-    auto engine =
-        gz::physics::RequestEngine3d<ModelCollisionFeaturesList>::From(plugin);
-    ASSERT_NE(nullptr, engine);
-
-    auto world = LoadWorld<ModelCollisionFeaturesList>(
-        engine, common_test::worlds::kSphereGravitySdf);
-    ASSERT_NE(nullptr, world);
-
-    auto model = world->GetModel("sphere");
-    ASSERT_NE(nullptr, model);
-
-    // Default: collisions are enabled.
-    EXPECT_TRUE(model->GetCollisionEnabled());
-  }
-}
-
-//////////////////////////////////////////////////
 TYPED_TEST(ModelCollisionTest, ModelCollisionEnabledSetGet)
 {
   for (const std::string &name : this->pluginNames)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Similar to gravity and static. This will allow to enable or disable collisions in runtime.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
