### PR TITLE
mujoco: Add support for setting external forces and torques on a link

### DIFF
--- a/mujoco/src/Base.hh
+++ b/mujoco/src/Base.hh
@@ -51,6 +51,13 @@ inline void copyPos(const math::Vector3d &_src,  mjtNum *_dst)
   _dst[2] = _src.Z();
 }
 
+inline void copyPos(const Eigen::Vector3d &_src,  mjtNum *_dst)
+{
+  _dst[0] = _src.x();
+  _dst[1] = _src.y();
+  _dst[2] = _src.z();
+}
+
 inline void copyQuat(const math::Quaterniond &_src,  mjtNum *_dst)
 {
   _dst[0] = _src.W();

--- a/mujoco/src/Base.hh
+++ b/mujoco/src/Base.hh
@@ -44,21 +44,21 @@ namespace physics
 namespace mujoco
 {
 
-inline void copyPos(const math::Vector3d &_src,  mjtNum *_dst)
+inline void copyPos(const math::Vector3d &_src, mjtNum *_dst)
 {
   _dst[0] = _src.X();
   _dst[1] = _src.Y();
   _dst[2] = _src.Z();
 }
 
-inline void copyPos(const Eigen::Vector3d &_src,  mjtNum *_dst)
+inline void copyPos(const Eigen::Vector3d &_src, mjtNum *_dst)
 {
   _dst[0] = _src.x();
   _dst[1] = _src.y();
   _dst[2] = _src.z();
 }
 
-inline void copyQuat(const math::Quaterniond &_src,  mjtNum *_dst)
+inline void copyQuat(const math::Quaterniond &_src, mjtNum *_dst)
 {
   _dst[0] = _src.W();
   _dst[1] = _src.X();
@@ -66,7 +66,7 @@ inline void copyQuat(const math::Quaterniond &_src,  mjtNum *_dst)
   _dst[3] = _src.Z();
 }
 
-inline void copyQuat(const Eigen::Quaterniond &_src,  mjtNum *_dst)
+inline void copyQuat(const Eigen::Quaterniond &_src, mjtNum *_dst)
 {
   _dst[0] = _src.w();
   _dst[1] = _src.x();

--- a/mujoco/src/LinkFeatures.cc
+++ b/mujoco/src/LinkFeatures.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "LinkFeatures.hh"
+
+#include <Eigen/Geometry>
+
+namespace gz {
+namespace physics {
+namespace mujoco {
+
+/////////////////////////////////////////////////
+void LinkFeatures::AddLinkExternalForceInWorld(
+    const Identity &_id,
+    const LinearVectorType &_force,
+    const LinearVectorType &_position)
+{
+  auto linkInfo = this->ReferenceInterface<LinkInfo>(_id);
+  if (!linkInfo || !linkInfo->body)
+    return;
+
+  auto worldInfo = linkInfo->worldInfo;
+  if (!worldInfo || !worldInfo->mjModelObj || !worldInfo->mjDataObj)
+    return;
+
+  int bodyId = mjs_getId(linkInfo->body->element);
+  if (bodyId < 0 || bodyId >= worldInfo->mjModelObj->nbody)
+    return;
+
+  auto *d = worldInfo->mjDataObj;
+  Eigen::Vector3d com = convertPos(&d->xipos[3 * bodyId]);
+  Eigen::Vector3d torque = (_position - com).cross(_force);
+
+  Eigen::Vector3d currentForce = convertPos(&d->xfrc_applied[6 * bodyId]);
+  copyPos(currentForce + _force, &d->xfrc_applied[6 * bodyId]);
+
+  Eigen::Vector3d currentTorque = convertPos(&d->xfrc_applied[6 * bodyId + 3]);
+  copyPos(currentTorque + torque, &d->xfrc_applied[6 * bodyId + 3]);
+}
+
+/////////////////////////////////////////////////
+void LinkFeatures::AddLinkExternalTorqueInWorld(
+    const Identity &_id,
+    const AngularVectorType &_torque)
+{
+  auto linkInfo = this->ReferenceInterface<LinkInfo>(_id);
+  if (!linkInfo || !linkInfo->body)
+    return;
+
+  auto worldInfo = linkInfo->worldInfo;
+  if (!worldInfo || !worldInfo->mjModelObj || !worldInfo->mjDataObj)
+    return;
+
+  int bodyId = mjs_getId(linkInfo->body->element);
+  if (bodyId < 0 || bodyId >= worldInfo->mjModelObj->nbody)
+    return;
+
+  auto *d = worldInfo->mjDataObj;
+
+  Eigen::Vector3d currentTorque = convertPos(&d->xfrc_applied[6 * bodyId + 3]);
+  copyPos(currentTorque + _torque, &d->xfrc_applied[6 * bodyId + 3]);
+}
+
+}
+}
+}

--- a/mujoco/src/LinkFeatures.hh
+++ b/mujoco/src/LinkFeatures.hh
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GZ_PHYSICS_MUJOCO_SRC_LINKFEATURES_HH_
+#define GZ_PHYSICS_MUJOCO_SRC_LINKFEATURES_HH_
+
+#include <gz/physics/Implements.hh>
+#include <gz/physics/Link.hh>
+
+#include "Base.hh"
+
+namespace gz {
+namespace physics {
+namespace mujoco {
+
+struct LinkFeatureList : FeatureList<
+  AddLinkExternalForceTorque
+> { };
+
+class LinkFeatures :
+    public virtual Base,
+    public virtual Implements3d<LinkFeatureList>
+{
+  // Documentation inherited
+  public: void AddLinkExternalForceInWorld(
+      const Identity &_id,
+      const LinearVectorType &_force,
+      const LinearVectorType &_position) override;
+
+  // Documentation inherited
+  public: void AddLinkExternalTorqueInWorld(
+      const Identity &_id,
+      const AngularVectorType &_torque) override;
+};
+
+}
+}
+}
+
+#endif

--- a/mujoco/src/SimulationFeatures.cc
+++ b/mujoco/src/SimulationFeatures.cc
@@ -62,9 +62,24 @@ void SimulationFeatures::WorldForwardStep(const Identity &_worldID,
 
   mj_step(m, d);
 
+  // Synchronize Cartesian position and velocity kinematics for the new state.
+  // In MuJoCo, the numerical integrator in mj_step (Stage 24) advances the
+  // joint space variables (qpos/qvel) to the new state, but does not recompute
+  // the corresponding Cartesian kinematic and frame variables (e.g. xpos,
+  // xipos, site_xpos, cvel, xvel). These are normally computed lazily at the
+  // start of the next step. Synchronizing them here ensures that immediate
+  // downstream state queries (like Link::FrameDataRelativeToWorld) return
+  // accurate, lag-free results for the current timestep.
+  mj_fwdPosition(m, d);
+  mj_fwdVelocity(m, d);
+
   // Clear joint control forces so that they are not applied in the next
   // timestep, which is the expected behavior in Gazebo.
   std::fill(d->ctrl, d->ctrl + m->nu, 0.0);
+
+  // Clear external forces/torques applied to links so that they are not applied
+  // in the next timestep, which is the expected behavior in Gazebo.
+  std::fill(d->xfrc_applied, d->xfrc_applied + 6 * m->nbody, 0.0);
 
   this->WriteRequiredData(_h);
   this->Write(_h.Get<ChangedWorldPoses>());

--- a/mujoco/src/plugin.cc
+++ b/mujoco/src/plugin.cc
@@ -21,6 +21,7 @@
 #include "FreeGroupFeatures.hh"
 #include "JointFeatures.hh"
 #include "KinematicsFeatures.hh"
+#include "LinkFeatures.hh"
 #include "SDFFeatures.hh"
 #include "ShapeFeatures.hh"
 #include "SimulationFeatures.hh"
@@ -38,7 +39,7 @@ struct MujocoFeatures : FeatureList<
   FreeGroupFeatureList,
   JointFeatureList,
   KinematicsFeatureList,
-  // LinkFeatureList,
+  LinkFeatureList,
   SDFFeatureList,
   ShapeFeatureList,
   SimulationFeatureList,
@@ -51,7 +52,7 @@ class Plugin :
     public virtual FreeGroupFeatures,
     public virtual JointFeatures,
     public virtual KinematicsFeatures,
-    // public virtual LinkFeatures,
+    public virtual LinkFeatures,
     public virtual SDFFeatures,
     public virtual ShapeFeatures,
     public virtual SimulationFeatures,


### PR DESCRIPTION
# 🎉 New feature

Part of #299 

## Summary
This PR implements the `AddLinkExternalForceTorque` feature for the MuJoCo plugin. It maps external forces and torques to the body center of mass and stores them in the `xfrc_applied` buffer for one timestep. It also runs mj_fwdPosition and mj_fwdVelocity after each step to prevent a 1-step Cartesian state reporting lag.

## Test it
```
ctest -R COMMON_TEST_addexternalforcetoreque`
```


https://github.com/user-attachments/assets/06d0281e-ff99-4f12-93b1-1a3d700be8e2

`AddLinkExternalForceTorque` feature used in the `Mouse Drag` plugin to interactively apply forces on objects.

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.0 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
