### PR TITLE
Fix building tests when using a custom install location

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,22 @@ ExternalProject_Add(
     "-DBUILD_TESTING=OFF"
     "-DCMAKE_INSTALL_PREFIX=${FAKE_INSTALL_PREFIX}"
     "-DSKIP_mujoco=${SKIP_mujoco}"
+    "-Dgz-cmake_DIR=${gz-cmake_DIR}"
+    "-Dgz-common_DIR=${gz-common_DIR}"
+    "-Dgz-common-geospatial_DIR=${gz-common-geospatial_DIR}"
+    "-Dgz-common-testing_DIR=${gz-common-testing_DIR}"
+    "-Dgz-common-graphics_DIR=${gz-common-graphics_DIR}"
+    "-Dgz-common-profiler_DIR=${gz-common-profiler_DIR}"
+    "-Dgz-math_DIR=${gz-math_DIR}"
+    "-Dgz-math-eigen3_DIR=${gz-math-eigen3_DIR}"
+    "-Dgz-plugin_DIR=${gz-plugin_DIR}"
+    "-Dgz-plugin-all_DIR=${gz-plugin-all_DIR}"
+    "-Dgz-plugin-loader_DIR=${gz-plugin-loader_DIR}"
+    "-Dgz-plugin-register_DIR=${gz-plugin-register_DIR}"
+    "-Dgz-utils_DIR=${gz-utils_DIR}"
+    "-Dgz-utils-log_DIR=${gz-utils-log_DIR}"
+    "-Dgz-utils-cli_DIR=${gz-utils-cli_DIR}"
+    "-Dsdformat_DIR=${sdformat_DIR}"
 )
 
 add_library(gz-physics-test INTERFACE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,22 +18,7 @@ ExternalProject_Add(
     "-DBUILD_TESTING=OFF"
     "-DCMAKE_INSTALL_PREFIX=${FAKE_INSTALL_PREFIX}"
     "-DSKIP_mujoco=${SKIP_mujoco}"
-    "-Dgz-cmake_DIR=${gz-cmake_DIR}"
-    "-Dgz-common_DIR=${gz-common_DIR}"
-    "-Dgz-common-geospatial_DIR=${gz-common-geospatial_DIR}"
-    "-Dgz-common-testing_DIR=${gz-common-testing_DIR}"
-    "-Dgz-common-graphics_DIR=${gz-common-graphics_DIR}"
-    "-Dgz-common-profiler_DIR=${gz-common-profiler_DIR}"
-    "-Dgz-math_DIR=${gz-math_DIR}"
-    "-Dgz-math-eigen3_DIR=${gz-math-eigen3_DIR}"
-    "-Dgz-plugin_DIR=${gz-plugin_DIR}"
-    "-Dgz-plugin-all_DIR=${gz-plugin-all_DIR}"
-    "-Dgz-plugin-loader_DIR=${gz-plugin-loader_DIR}"
-    "-Dgz-plugin-register_DIR=${gz-plugin-register_DIR}"
-    "-Dgz-utils_DIR=${gz-utils_DIR}"
-    "-Dgz-utils-log_DIR=${gz-utils-log_DIR}"
-    "-Dgz-utils-cli_DIR=${gz-utils-cli_DIR}"
-    "-Dsdformat_DIR=${sdformat_DIR}"
+    "-DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}"
 )
 
 add_library(gz-physics-test INTERFACE)


### PR DESCRIPTION
Superseeds #984 

Fixes #983

Otherwise when dependencies are installed in a custom location they won't get noticed even when `PKG_CONFIG_PATH` is given.

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #983

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the   ##PR.-->

When dependencies are installed in a custom path and CMake is configured with environment variable PKG_CONFIG_PATH set to this path, initial configuration finds the packages without any issues. However, testing with FAKE_INSTALL via ExternalProject_Add cannot find these packages.

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

GenAI is NOT used.
