### PR TITLE
package.xml: remove mujoco for now

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,8 @@
   <depend>gz-math</depend>
   <depend>gz-plugin</depend>
   <depend>gz-utils</depend>
+  <!-- Add mujoco as dependency once it has a rosdep key <depend>mujoco</depend> -->
   <depend>sdformat</depend>
-  <depend>mujoco</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes rosdep resolution for colcon CI

## Summary

A recent colcon CI build for https://github.com/gazebosim/gz-math/pull/780#issuecomment-4626341311 failed during rosdep resolution:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ci__colcon_gpu_any-manual_ubuntu_noble_amd64&build=27)](https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/27/) https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/27/

~~~
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/ros_buildfarm/scripts/ci/generate_install_lists.py", line 278, in resolve_names
# END SUBSECTION
    resolved_names = resolve_for_os(
                     ^^^^^^^^^^^^^^^
...
KeyError: 'mujoco'
...
RuntimeError: Could not resolve the rosdep key 'mujoco'
~~~

This comments out the mujoco dependency from `package.xml` until it has a rosdep key.

testing again with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ci__colcon_gpu_any-manual_ubuntu_noble_amd64&build=28)](https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/28/) https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/28/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
