### PR TITLE
mujoco: Implement AttachFixedJointFeature and DetachJointFeature

### DIFF
--- a/mujoco/src/Base.cc
+++ b/mujoco/src/Base.cc
@@ -43,6 +43,16 @@ void resolveJointIndices(WorldInfo &_worldInfo)
       if (!jointInfo->joint)
       {
         // Fixed joint
+        // Resolve weld constraint compiled ID
+        jointInfo->weldEqIndex = std::nullopt;
+        if (jointInfo->weldConstraintSpec)
+        {
+          int eqId = mjs_getId(jointInfo->weldConstraintSpec->element);
+          if (eqId >= 0 && eqId < m->neq)
+          {
+            jointInfo->weldEqIndex = eqId;
+          }
+        }
         continue;
       }
       // Reset in case we encounter errors

--- a/mujoco/src/Base.hh
+++ b/mujoco/src/Base.hh
@@ -228,6 +228,10 @@ struct JointInfo
   // 2. O(num_followers) keyframe updates, avoiding expensive
   //    O(total_joints) global searches across the entire model.
   std::vector<MimicConstraintInfo> mimicConstraints;
+  // Pointer to the weld joint equality constraint in the spec
+  mjsEquality* weldConstraintSpec{nullptr};
+  // Compiled weld joint equality constraint index in mjModel (max 1)
+  std::optional<int> weldEqIndex{std::nullopt};
 };
 
 

--- a/mujoco/src/FreeGroupFeatures.cc
+++ b/mujoco/src/FreeGroupFeatures.cc
@@ -79,6 +79,8 @@ void FreeGroupFeatures::SetFreeGroupWorldAngularVelocity(
   auto *m = worldInfo->mjModelObj;
   const auto bodyId = mjs_getId(modelInfo->body->element);
   const auto jntadr = m->body_jntadr[bodyId];
+  if (jntadr < 0)
+    return;
   const auto qveladr = m->jnt_dofadr[jntadr];
   mju_copy3(&d->qvel[qveladr] + 3, _angularVelocity.data());
   mj_forward(m, d);
@@ -96,6 +98,8 @@ void FreeGroupFeatures::SetFreeGroupWorldLinearVelocity(
   auto *m = worldInfo->mjModelObj;
   const auto bodyId = mjs_getId(modelInfo->body->element);
   const auto jntadr = m->body_jntadr[bodyId];
+  if (jntadr < 0)
+    return;
   const auto qveladr = m->jnt_dofadr[jntadr];
   mju_copy3(&d->qvel[qveladr], _linearVelocity.data());
   mj_forward(m, d);
@@ -114,6 +118,8 @@ void FreeGroupFeatures::SetFreeGroupWorldPose(
   auto *m = worldInfo->mjModelObj;
   const auto bodyId = mjs_getId(modelInfo->body->element);
   const auto jntadr = m->body_jntadr[bodyId];
+  if (jntadr < 0)
+    return;
   const auto qposadr = m->jnt_qposadr[jntadr];
   const Eigen::Quaterniond quat(_pose.rotation());
   const double quatCoeffs[] = {quat.w(), quat.x(), quat.y(), quat.z()};

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstddef>
 #include <memory>
+#include <string_view>
 #include <Eigen/Geometry>
 #include <gz/common/Console.hh>
 #include <gz/math/Helpers.hh>
@@ -705,6 +706,274 @@ bool JointFeatures::SetJointMimicConstraint(
   this->RecompileSpec(*worldInfo);
   return true;
 }
+void JointFeatures::SetJointTransformFromParent(const Identity &_id,
+                                                const Pose3d &_pose)
+{
+  auto jointInfo = this->ReferenceInterface<JointInfo>(_id);
+  if (!jointInfo)
+  {
+    gzerr << "Failed to find JointInfo when setting transform from parent.\n";
+    return;
+  }
+
+  if (jointInfo->weldConstraintSpec)
+  {
+    auto weldSpec = jointInfo->weldConstraintSpec;
+
+    // Note: The memory layout of `weldSpec->data` (mjNEQDATA=11 elements) for
+    // mjEQ_WELD is:
+    // data[0..2]: anchor (3 elements)
+    // data[3..9]: relpose (7 elements)
+    // data[10]: torquescale (1 element)
+
+    // We choose the anchor point to be the origin of the child link.
+    // Therefore, the anchor in the child frame (data[3..5]) is (0, 0, 0).
+    std::fill(weldSpec->data + 3, weldSpec->data + 6, 0.0);
+
+    // The anchor in the parent frame (data[0..2]) is the origin of the child
+    // link expressed in the parent frame, which is _pose.translation()
+    copyPos(_pose.translation(), weldSpec->data);
+
+    // The relative orientation (data[6..9]) is the parent orientation in the
+    // child frame, which is exactly _pose.inverse().rotation()
+    copyQuat(Eigen::Quaterniond(_pose.inverse().rotation()),
+             weldSpec->data + 6);
+
+    auto m = jointInfo->worldInfo->mjModelObj;
+    if (m)
+    {
+      int eqId = jointInfo->weldEqIndex.value_or(mjs_getId(weldSpec->element));
+      if (eqId >= 0 && eqId < m->neq)
+      {
+        jointInfo->weldEqIndex = eqId;
+        double *eqData = m->eq_data + eqId * mjNEQDATA;
+        std::copy(weldSpec->data, weldSpec->data + mjNEQDATA, eqData);
+      }
+    }
+  }
+  else
+  {
+    auto it = this->frames.find(_id);
+    if (it != this->frames.end())
+    {
+      const Pose3d jointInChild =
+          convertPose(it->second->site->pos, it->second->site->quat);
+      const Pose3d childInParent = _pose * jointInChild.inverse();
+
+      copyPos(childInParent.translation(), jointInfo->childBody->pos);
+      copyQuat(Eigen::Quaterniond(childInParent.linear()),
+               jointInfo->childBody->quat);
+
+      jointInfo->worldInfo->specDirty = true;
+    }
+    else
+    {
+      gzerr << "Failed to find FrameInfo when setting transform from parent.\n";
+    }
+  }
 }
+
+/////////////////////////////////////////////////
+void JointFeatures::DetachJoint(const Identity &_jointId)
+{
+  auto jointInfo = this->ReferenceInterface<JointInfo>(_jointId);
+  if (!jointInfo)
+  {
+    gzerr << "Failed to find JointInfo when detaching joint.\n";
+    return;
+  }
+
+  auto worldInfo = jointInfo->worldInfo;
+  auto modelInfo = jointInfo->modelInfo.lock();
+  if (!worldInfo || !modelInfo)
+  {
+    gzerr << "Invalid worldInfo or modelInfo when detaching joint.\n";
+    return;
+  }
+
+  if (jointInfo->weldConstraintSpec)
+  {
+    jointInfo->weldConstraintSpec->active = 0;
+    if (jointInfo->weldEqIndex && worldInfo->mjDataObj)
+    {
+      worldInfo->mjDataObj->eq_active[jointInfo->weldEqIndex.value()] = 0;
+    }
+    jointInfo->weldConstraintSpec = nullptr;
+
+    if (this->frames.find(jointInfo->entityId) != this->frames.end())
+    {
+      this->frames.erase(jointInfo->entityId);
+    }
+
+    modelInfo->joints.RemoveEntity(jointInfo->name);
+  }
 }
+
+/////////////////////////////////////////////////
+Identity JointFeatures::CastToFixedJoint(const Identity &_jointID) const
+{
+  auto jointInfo = this->ReferenceInterface<JointInfo>(_jointID);
+  if (jointInfo && jointInfo->weldConstraintSpec)
+  {
+    return _jointID;
+  }
+  return this->GenerateInvalidId();
 }
+
+/////////////////////////////////////////////////
+// Performance Optimization for AttachFixedJoint & DetachJoint:
+// Instead of creating and deleting weld constraints via the mjSpec API (which
+// triggers an expensive full model recompilation `mj_compile` each time a
+// joint is attached or detached), we implement constraint caching/reuse.
+//
+// In DetachJoint, we simply deactivate the constraint (`active = 0`).
+// In AttachFixedJoint, we first use `mjs_findElement` to efficiently look up
+// an existing inactive weld constraint by its name. If found, we reuse it by
+// setting `active = 1` in both the spec and live mjData, updating bodies if
+// necessary.
+// This avoids recompilation entirely for repetitive attach/detach operations.
+Identity JointFeatures::AttachFixedJoint(
+    const Identity &_childID,
+    const BaseLink3dPtr &_parent,
+    const std::string &_name)
+{
+  auto childLinkInfo = this->ReferenceInterface<LinkInfo>(_childID);
+  if (!childLinkInfo)
+  {
+    gzerr << "Failed to find LinkInfo for child entity when attaching fixed "
+          << "joint.\n";
+    return this->GenerateInvalidId();
+  }
+
+  LinkInfo* parentLinkInfo = nullptr;
+  if (_parent)
+  {
+    parentLinkInfo =
+      this->ReferenceInterface<LinkInfo>(_parent->FullIdentity());
+    if (!parentLinkInfo)
+    {
+      gzerr << "Failed to find LinkInfo for parent entity when attaching "
+            << "fixed joint.\n";
+      return this->GenerateInvalidId();
+    }
+  }
+
+  auto worldInfo = childLinkInfo->worldInfo;
+  auto modelInfo = childLinkInfo->modelInfo.lock();
+  if (!worldInfo || !modelInfo)
+  {
+    gzerr << "Invalid worldInfo or modelInfo when attaching fixed joint.\n";
+    return this->GenerateInvalidId();
+  }
+  if (modelInfo->joints.HasEntity(_name))
+  {
+    gzerr << "There's already a joint with the same name [ " << _name
+          << " ].\n";
+    return this->GenerateInvalidId();
+  }
+
+  const char* childBodyName
+      = mjs_getString(mjs_getName(childLinkInfo->body->element));
+  const char* parentBodyName
+      = parentLinkInfo
+            ? mjs_getString(mjs_getName(parentLinkInfo->body->element))
+            : "";
+
+  const std::string mjJointName = ::sdf::JoinName(modelInfo->name, _name);
+
+  mjsEquality *eqSpec = mjs_asEquality(mjs_findElement(
+      worldInfo->mjSpecObj, mjOBJ_EQUALITY, mjJointName.c_str()));
+
+  bool requireRecompile = false;
+  if (eqSpec)
+  {
+    if (eqSpec->type != mjEQ_WELD)
+    {
+      gzerr
+          << "Found a matching equality constraint, but with incorrect type.\n";
+      return this->GenerateInvalidId();
+    }
+    // If the bodies changed, update the constraint with the new bodies and
+    // force a recompile.
+    // We assume the previous fixed joint with the same name has been detached
+    // (i.e. removed) since the HasEntity check above would have failed
+    // otherwise.
+    const char *n1 = mjs_getString(eqSpec->name1);
+    const char *n2 = mjs_getString(eqSpec->name2);
+    if (!n1 || !n2 || std::string_view(childBodyName) != n1 ||
+        std::string_view(parentBodyName) != n2)
+    {
+      mjs_setString(eqSpec->name1, childBodyName);
+      mjs_setString(eqSpec->name2, parentBodyName);
+      requireRecompile = true;
+    }
+  }
+  if (!eqSpec)
+  {
+    eqSpec = mjs_addEquality(worldInfo->mjSpecObj, nullptr);
+    if (!eqSpec)
+    {
+      gzerr << "Failed to add equality constraint element to the spec.\n";
+      return this->GenerateInvalidId();
+    }
+    mjs_setName(eqSpec->element, mjJointName.c_str());
+    eqSpec->type = mjEQ_WELD;
+    eqSpec->objtype = mjOBJ_BODY;
+    mjs_setString(eqSpec->name1, childBodyName);
+    mjs_setString(eqSpec->name2, parentBodyName);
+
+    // Stiffen the constraint solver parameters to make the weld constraint
+    // virtually rigid
+    eqSpec->solref[0] = 0.0001;  // 100 microseconds time constant
+    eqSpec->solimp[0] = 0.999;   // highly rigid compliance bounds
+    eqSpec->solimp[1] = 0.9999;
+
+    // Fill data with zeros so MuJoCo computes initial relative pose at
+    // compilation. Note that the memory layout for mjEQ_WELD is:
+    // data[0..2] = anchor, data[3..9] = relpose, data[10] = torquescale.
+    std::fill(std::begin(eqSpec->data), std::end(eqSpec->data), 0.0);
+    // Default value for torquescale
+    eqSpec->data[10] = 1.0;
+
+    requireRecompile = true;
+  }
+
+  auto jointInfo =
+    std::make_shared<JointInfo>(this->GetNextEntity(), modelInfo);
+  jointInfo->name = _name;
+  jointInfo->childBody = childLinkInfo->body;
+  jointInfo->worldInfo = worldInfo;
+  jointInfo->weldConstraintSpec = eqSpec;
+
+  eqSpec->active = 1;
+
+  if (!requireRecompile && worldInfo->mjModelObj)
+  {
+    int eqId = mjs_getId(eqSpec->element);
+    if (eqId >= 0 && eqId < worldInfo->mjModelObj->neq)
+    {
+      jointInfo->weldEqIndex = eqId;
+      worldInfo->mjDataObj->eq_active[eqId] = 1;
+    }
+  }
+
+  auto childFrameIt = this->frames.find(childLinkInfo->entityId);
+  if (childFrameIt != this->frames.end())
+  {
+    this->frames[jointInfo->entityId] = childFrameIt->second;
+  }
+
+  modelInfo->joints.AddEntity(
+    jointInfo->entityId, jointInfo, jointInfo->name, modelInfo->entityId);
+
+  if (requireRecompile)
+  {
+    worldInfo->specDirty = true;
+  }
+
+  return this->GenerateIdentity(jointInfo->entityId, jointInfo);
+}
+
+}  // namespace mujoco
+}  // namespace physics
+}  // namespace gz

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -800,10 +800,7 @@ void JointFeatures::DetachJoint(const Identity &_jointId)
     }
     jointInfo->weldConstraintSpec = nullptr;
 
-    if (this->frames.find(jointInfo->entityId) != this->frames.end())
-    {
-      this->frames.erase(jointInfo->entityId);
-    }
+    this->frames.erase(jointInfo->entityId);
 
     modelInfo->joints.RemoveEntity(jointInfo->name);
   }
@@ -845,7 +842,7 @@ Identity JointFeatures::AttachFixedJoint(
     return this->GenerateInvalidId();
   }
 
-  LinkInfo* parentLinkInfo = nullptr;
+  LinkInfo *parentLinkInfo = nullptr;
   if (_parent)
   {
     parentLinkInfo =
@@ -872,9 +869,9 @@ Identity JointFeatures::AttachFixedJoint(
     return this->GenerateInvalidId();
   }
 
-  const char* childBodyName
+  const char *childBodyName
       = mjs_getString(mjs_getName(childLinkInfo->body->element));
-  const char* parentBodyName
+  const char *parentBodyName
       = parentLinkInfo
             ? mjs_getString(mjs_getName(parentLinkInfo->body->element))
             : "";

--- a/mujoco/src/JointFeatures.hh
+++ b/mujoco/src/JointFeatures.hh
@@ -36,10 +36,11 @@ struct JointFeatureList : FeatureList<
   GetBasicJointState,
   GetBasicJointProperties,
   SetBasicJointState,
-  SetMimicConstraintFeature
+  SetMimicConstraintFeature,
+  AttachFixedJointFeature,
+  DetachJointFeature,
+  SetJointTransformFromParentFeature
 
-  // AttachFixedJointFeature,
-  // DetachJointFeature,
   // GetJointTransmittedWrench,
   // GetPrismaticJointProperties,
   // GetRevoluteJointProperties,
@@ -50,7 +51,6 @@ struct JointFeatureList : FeatureList<
   // SetJointPositionLimitsFeature,
   // SetJointSpringReferenceFeature,
   // SetJointSpringStiffnessFeature,
-  // SetJointTransformFromParentFeature,
   // SetJointVelocityCommandFeature,
   // SetJointVelocityLimitsFeature,
   // SetPrismaticJointProperties,
@@ -117,7 +117,6 @@ class JointFeatures :
       double _offset,
       double _reference) override;
 
-  #if 0
   // ----- Set Basic Joint Properties -----
   public: void SetJointTransformFromParent(
       const Identity &_id, const Pose3d &_pose) override;
@@ -136,7 +135,7 @@ class JointFeatures :
       const BaseLink3dPtr &_parent,
       const std::string &_name) override;
 
-
+  #if 0
   // ----- Free Joint -----
   public: Identity CastToFreeJoint(
       const Identity &_jointID) const override;

--- a/test/common_test/detachable_joint.cc
+++ b/test/common_test/detachable_joint.cc
@@ -193,6 +193,254 @@ TYPED_TEST(DetachableJointTest, CorrectAttachmentPoints)
   }
 }
 
+TYPED_TEST(DetachableJointTest, DetachableJointHeavyPayloadWeld)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<TypeParam>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    std::string worldStr = R"(
+    <sdf version="1.9">
+      <world name="weld_test_world">
+        <model name="M1">
+          <static>true</static>
+          <link name="parent_link">
+            <inertial>
+              <mass>1.0</mass>
+              <inertia>
+                <ixx>0.1</ixx><iyy>0.1</iyy><izz>0.1</izz>
+              </inertia>
+            </inertial>
+          </link>
+        </model>
+        <model name="M2">
+          <pose>1.0 0 1.0 0 0 0</pose>
+          <link name="child_link">
+            <inertial>
+              <mass>1000.0</mass>
+              <inertia>
+                <ixx>100.0</ixx><iyy>100.0</iyy><izz>100.0</izz>
+              </inertia>
+            </inertial>
+          </link>
+        </model>
+      </world>
+    </sdf>)";
+
+    sdf::Root root;
+    const sdf::Errors errors = root.LoadSdfString(worldStr);
+    ASSERT_TRUE(errors.empty()) << errors;
+
+    auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    auto model1 = world->GetModel("M1");
+    auto model2 = world->GetModel("M2");
+    ASSERT_NE(nullptr, model1);
+    ASSERT_NE(nullptr, model2);
+
+    auto parentLink = model1->GetLink("parent_link");
+    auto childLink = model2->GetLink("child_link");
+    ASSERT_NE(nullptr, parentLink);
+    ASSERT_NE(nullptr, childLink);
+
+    const auto frameDataParent = parentLink->FrameDataRelativeToWorld();
+    const auto frameDataChild = childLink->FrameDataRelativeToWorld();
+
+    const auto poseParent = frameDataParent.pose;
+    const auto poseChild = frameDataChild.pose;
+    const auto poseParentChild = poseParent.inverse() * poseChild;
+
+    auto fixedJoint = childLink->AttachFixedJoint(parentLink);
+    ASSERT_NE(nullptr, fixedJoint);
+    fixedJoint->SetTransformFromParent(poseParentChild);
+
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+
+    // Step 2000 times (2.0 seconds of simulation time)
+    for (std::size_t i = 0; i < 2000; ++i)
+    {
+      world->Step(output, state, input);
+    }
+
+    // Verify the relative pose is preserved with a very strict tolerance
+    const auto newFrameDataParent = parentLink->FrameDataRelativeToWorld();
+    const auto newFrameDataChild = childLink->FrameDataRelativeToWorld();
+
+    const auto newPoseParentChild =
+        newFrameDataParent.pose.inverse() * newFrameDataChild.pose;
+    const gz::math::Pose3d gzPoseParentChild =
+        gz::math::eigen3::convert(poseParentChild);
+    const gz::math::Pose3d gzNewPoseParentChild =
+        gz::math::eigen3::convert(newPoseParentChild);
+
+    EXPECT_NEAR(gzPoseParentChild.Pos().X(), gzNewPoseParentChild.Pos().X(),
+                1e-4);
+    EXPECT_NEAR(gzPoseParentChild.Pos().Y(), gzNewPoseParentChild.Pos().Y(),
+                1e-4);
+    EXPECT_NEAR(gzPoseParentChild.Pos().Z(), gzNewPoseParentChild.Pos().Z(),
+                1e-4);
+  }
+}
+
+
+struct DetachableJointResetFeatureList: gz::physics::FeatureList<
+    DetachableJointFeatureList,
+    gz::physics::FindFreeGroupFeature,
+    gz::physics::SetFreeGroupWorldPose,
+    gz::physics::SetFreeGroupWorldVelocity
+> { };
+
+template <class T>
+using DetachableJointResetTest = DetachableJointTest<T>;
+
+using DetachableJointResetTestTypes =
+  ::testing::Types<DetachableJointResetFeatureList>;
+TYPED_TEST_SUITE(DetachableJointResetTest,
+                 DetachableJointResetTestTypes);
+// This test verifies both the reset behavior and different relative pose
+// re-attachment of detachable joints.
+// The workflow is:
+// 1. Attach the joint initially at the default relative pose, step, and
+//    detach it.
+// 2. Step so that the child link falls.
+// 3. Reset the simulation: Move the child model back to its original pose and
+//    velocities, and re-attach the joint at the default relative pose.
+//    Verify stability.
+// 4. Detach again, manually move the child model to a different relative
+//    pose (offset Z = -0.8), and re-attach the joint at this new relative
+//    pose. Verify the constraint is correctly enforced at the new pose.
+TYPED_TEST(DetachableJointResetTest, DetachableJointResetAndReattach)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+      gz::physics::RequestEngine3d<TypeParam>::From(plugin);
+    ASSERT_NE(nullptr, engine);
+
+    sdf::Root root;
+    const sdf::Errors errors = root.Load(
+      common_test::worlds::kDetachableJointWorld);
+    ASSERT_TRUE(errors.empty()) << errors.front();
+
+    auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    auto cylinder1 = world->GetModel("cylinder1");
+    ASSERT_NE(nullptr, cylinder1);
+    auto cylinder1Link1 = cylinder1->GetLink("link1");
+
+    auto cylinder2 = world->GetModel("cylinder2");
+    ASSERT_NE(nullptr, cylinder2);
+    auto cylinder2Link2 = cylinder2->GetLink("link2");
+
+    // 1. Initial attachment
+    const auto poseParent =
+      cylinder1Link1->FrameDataRelativeToWorld().pose;
+    const auto poseChild =
+      cylinder2Link2->FrameDataRelativeToWorld().pose;
+    const auto poseParentChild = poseParent.inverse() * poseChild;
+    auto jointPtrPhys =
+      cylinder2Link2->AttachFixedJoint(cylinder1Link1);
+    ASSERT_NE(nullptr, jointPtrPhys);
+    jointPtrPhys->SetTransformFromParent(poseParentChild);
+
+    // Step 100 times
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+    for (std::size_t i = 0; i < 100; ++i)
+      world->Step(output, state, input);
+
+    // 2. Detach joint
+    jointPtrPhys->Detach();
+
+    // Step 100 times (cylinder 2 falls)
+    for (std::size_t i = 0; i < 100; ++i)
+      world->Step(output, state, input);
+
+    // Verify cylinder 2 has fallen
+    auto frameDataC2L2AfterFall =
+        cylinder2Link2->FrameDataRelativeToWorld();
+    EXPECT_LT(frameDataC2L2AfterFall.pose.translation().z(), 1.4);
+
+    // 3. Reset Simulation Poses & Velocities
+    // Reset cylinder 2 pose back to initial pose (z = 1.5) and velocities to 0
+    auto freeGroupC2 = cylinder2->FindFreeGroup();
+    ASSERT_NE(nullptr, freeGroupC2);
+    freeGroupC2->SetWorldPose(poseChild);
+    freeGroupC2->SetWorldLinearVelocity(Eigen::Vector3d::Zero());
+    freeGroupC2->SetWorldAngularVelocity(Eigen::Vector3d::Zero());
+
+    // Reset cylinder 1 base prismatic joint position and velocity to 0
+    auto baseJoint = cylinder1->GetJoint("base_joint");
+    ASSERT_NE(nullptr, baseJoint);
+    baseJoint->SetPosition(0, 0.0);
+    baseJoint->SetVelocity(0, 0.0);
+
+    // Verify cylinder 2 pose has been updated in the physics engine
+    auto frameDataC2L2AfterReset =
+        cylinder2Link2->FrameDataRelativeToWorld();
+    EXPECT_NEAR(1.5, frameDataC2L2AfterReset.pose.translation().z(), 1e-4);
+
+    // 4. Re-attach joint at initial relative pose
+    auto jointPtrPhysNew =
+      cylinder2Link2->AttachFixedJoint(cylinder1Link1);
+    ASSERT_NE(nullptr, jointPtrPhysNew);
+    jointPtrPhysNew->SetTransformFromParent(poseParentChild);
+
+    // Step simulation after reset. We expect reasonable velocities & stability
+    for (std::size_t i = 0; i < 10; ++i)
+    {
+      world->Step(output, state, input);
+      auto frameDataC1 = cylinder1Link1->FrameDataRelativeToWorld();
+      auto frameDataC2 = cylinder2Link2->FrameDataRelativeToWorld();
+      EXPECT_LT(frameDataC1.linearVelocity.norm(), 1.0);
+      EXPECT_LT(frameDataC2.linearVelocity.norm(), 1.0);
+    }
+
+    // 5. Detach and re-attach at a different pose
+    jointPtrPhysNew->Detach();
+
+    // Move cylinder 2 to a new offset (different relative pose)
+    // Initial z offset was -0.5. Let's make it -0.8 (z = 1.2)
+    Eigen::Isometry3d poseChildNew = poseChild;
+    poseChildNew.translation().z() = 1.2;
+    const auto poseParentChildNew = poseParent.inverse() * poseChildNew;
+
+    freeGroupC2->SetWorldPose(poseChildNew);
+    freeGroupC2->SetWorldLinearVelocity(Eigen::Vector3d::Zero());
+    freeGroupC2->SetWorldAngularVelocity(Eigen::Vector3d::Zero());
+
+    // Re-attach joint at NEW relative pose
+    auto jointPtrPhysDifferentPose =
+      cylinder2Link2->AttachFixedJoint(cylinder1Link1);
+    ASSERT_NE(nullptr, jointPtrPhysDifferentPose);
+    jointPtrPhysDifferentPose->SetTransformFromParent(poseParentChildNew);
+
+    // Step 10 times to let simulation stabilize
+    for (std::size_t i = 0; i < 10; ++i)
+      world->Step(output, state, input);
+
+    // Verify cylinder 2 is held at the new relative pose (offset z = -0.8)
+    auto frameDataC1Final = cylinder1Link1->FrameDataRelativeToWorld();
+    auto frameDataC2Final = cylinder2Link2->FrameDataRelativeToWorld();
+    double currentZOffset = frameDataC2Final.pose.translation().z() -
+        frameDataC1Final.pose.translation().z();
+    EXPECT_NEAR(-0.8, currentZOffset, 1e-3);
+  }
+}
+
 int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -3009,6 +3009,99 @@ TYPED_TEST(JointFeaturesScrewTest, ScrewJointLimits)
   }
 }
 
+struct JointTransformFromParentFeatureList : gz::physics::FeatureList<
+    gz::physics::ForwardStep,
+    gz::physics::GetEngineInfo,
+    gz::physics::GetWorldFromEngine,
+    gz::physics::GetModelFromWorld,
+    gz::physics::GetLinkFromModel,
+    gz::physics::GetJointFromModel,
+    gz::physics::GetBasicJointProperties,
+    gz::physics::LinkFrameSemantics,
+    gz::physics::SetJointTransformFromParentFeature,
+    gz::physics::sdf::ConstructSdfWorld
+> { };
+
+template <class T>
+class JointTransformFromParentTest:
+  public JointFeaturesTest<T>{};
+
+using JointTransformFromParentTestTypes =
+  ::testing::Types<JointTransformFromParentFeatureList>;
+TYPED_TEST_SUITE(JointTransformFromParentTest,
+                 JointTransformFromParentTestTypes);
+
+TYPED_TEST(JointTransformFromParentTest, SetJointTransformFromParent)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet-featherstone")
+
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<JointTransformFromParentFeatureList>::From(
+            plugin);
+    ASSERT_NE(nullptr, engine);
+
+    sdf::Root root;
+    const sdf::Errors errors = root.Load(common_test::worlds::kTestWorld);
+    ASSERT_TRUE(errors.empty()) << errors.front();
+
+    auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    auto model = world->GetModel("double_pendulum_with_base");
+    ASSERT_NE(nullptr, model);
+
+    auto joint = model->GetJoint("upper_joint");
+    ASSERT_NE(nullptr, joint);
+
+    const gz::math::Pose3d initialTransform =
+        gz::math::eigen3::convert(joint->GetTransformFromParent());
+    EXPECT_EQ(gz::math::Pose3d(0, 0, 2.1, -1.5708, 0, 0), initialTransform);
+
+    auto childLink = model->GetLink("upper_link");
+    ASSERT_NE(nullptr, childLink);
+
+    // Initial child pose
+    gz::physics::FrameData3d initialChildFrameData =
+      childLink->FrameDataRelativeToWorld();
+    gz::math::Pose3d initialChildPose =
+      gz::math::eigen3::convert(initialChildFrameData.pose);
+
+    const gz::math::Pose3d newTransform(0.2, -0.3, 1.4, 0.1, 0.2, 0.3);
+    joint->SetTransformFromParent(gz::math::eigen3::convert(newTransform));
+
+    const gz::math::Pose3d updatedTransform =
+        gz::math::eigen3::convert(joint->GetTransformFromParent());
+    EXPECT_EQ(newTransform, updatedTransform);
+
+    // This checks that the use of SetJointTransformFromParent keeps the
+    // child-to-joint transform fixed. This implies that the child's absolute
+    // pose is actually what's changed when using that API.
+
+    // Step the world so physics engines that use constraint solvers for joints
+    // (like mujoco) will resolve the constraint and teleport the child body.
+    // Because it's a dynamic constraint, we need enough steps for it to move.
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+    for (int i = 0; i < 1000; ++i)
+      world->Step(output, state, input);
+
+    // New child pose
+    gz::physics::FrameData3d newChildFrameData =
+      childLink->FrameDataRelativeToWorld();
+    gz::math::Pose3d newChildPose =
+      gz::math::eigen3::convert(newChildFrameData.pose);
+
+    // We expect the child pose to change if the child body is teleported.
+    EXPECT_NE(initialChildPose, newChildPose);
+  }
+}
+
 int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
# 🎉 New feature

Part of #299 

## Summary
- Implemented `AttachFixedJoint` using MuJoCo equality weld constraints.
- Optimized `AttachFixedJoint` and `DetachJoint` to reuse and toggle constraints (`active = 0/1`) to avoid expensive `mjModel` recompilations.
- Implemented `CastToFixedJoint` to identify fixed joints.
- Added comprehensive unit tests in `detachable_joint.cc`.


## Test it
```
ctest -R detachable_joint
```

## Screenshot

<img width="800" height="673" alt="centrifuge" src="https://github.com/user-attachments/assets/06614821-b73b-4241-90b6-bd44c4bc17b9" />

**Orbital Centrifuge Target Game**  (gist [`detachable_joint_space.sdf`](https://gist.github.com/azeey/af7bff91b2d707209556197000ecdf62#file-detachable_joint_space-sdf))
A physics-based timing game in Gazebo Sim using the MuJoCo plugin. Players must trigger the detach command at the perfect millisecond to launch the rotating payloads through the target gate. 

*Note: Developing this demo exposed a reset bug where dynamic weld constraints failed to update their relative offsets after a simulation reset. The recording demonstrates that this is now resolved and working properly.*

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
