### PR TITLE
mujoco: Fix joint limits parsing in MuJoCo plugin

### DIFF
--- a/mujoco/src/EntityManagementFeatures.cc
+++ b/mujoco/src/EntityManagementFeatures.cc
@@ -99,6 +99,7 @@ Identity EntityManagementFeatures::ConstructEmptyWorld(
   worldInfo->mjSpecObj->option.timestep = 0.001;
   // The Mujoco docs recommend the implicitfast integrator
   worldInfo->mjSpecObj->option.integrator = mjtIntegrator::mjINT_IMPLICITFAST;
+  worldInfo->mjSpecObj->compiler.degree = false;
   worldInfo->mjModelObj = mj_compile(spec, nullptr);
   worldInfo->mjDataObj = mj_makeData(worldInfo->mjModelObj);
   worldInfo->body = mjs_findBody(spec, "world");

--- a/mujoco/src/SDFFeatures_TEST.cc
+++ b/mujoco/src/SDFFeatures_TEST.cc
@@ -218,6 +218,19 @@ TEST_P(SDFFeatures_TEST, CheckMujocoData)
   }
 
   {
+    int j1Id = mj_name2id(m, mjOBJ_JOINT,
+                          Base::JoinNames("joint_limit_test", "j1").c_str());
+    ASSERT_NE(-1, j1Id);
+
+    // Verify compiled joint limits in mjModel
+    // If compiler.degree was true, the input -0.5 would be interpreted as -0.5
+    // degrees, which compiles to -0.0087 radians.
+    // With compiler.degree = false, it is interpreted as -0.5 radians.
+    EXPECT_NEAR(-0.5, m->jnt_range[2 * j1Id], 1e-4);
+    EXPECT_NEAR(0.5, m->jnt_range[2 * j1Id + 1], 1e-4);
+  }
+
+  {
     auto freeBodyLink =
         mjs_findChild(worldBody, Base::JoinNames("free_body", "link").c_str());
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
Before this PR, joint limits specified in SDFormat (which are in radians) were interpreted by MuJoCo's compiler as degrees. This happened because the default `compiler.degree` option in MuJoCo's spec is `true`. As a result, limits like `[-0.5, 0.5]` radians were compiled to `[-0.0087, 0.0087]` radians.

This PR sets `worldInfo->mjSpecObj->compiler.degree = false;` so that MuJoCo compiles all angles and limits directly as radians.

The existing `CheckMujocoData` test case in `SDFFeatures_TEST.cc` has been updated to assert that the compiled `jnt_range` for `joint_limit_test` correctly holds `[-0.5, 0.5]` instead of the incorrect degree-converted values.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.5 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
