### PR TITLE
Remove hash map allocation on every update step

### DIFF
--- a/bullet-featherstone/src/Base.hh
+++ b/bullet-featherstone/src/Base.hh
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -48,6 +49,7 @@
 
 #include <gz/common/Console.hh>
 #include <gz/math/eigen3/Conversions.hh>
+#include <gz/math/Pose3.hh>
 #include <gz/math/SemanticVersion.hh>
 #include <gz/physics/Implements.hh>
 
@@ -236,6 +238,8 @@ struct LinkInfo
   std::unordered_map<std::string, std::size_t> collisionNameToEntityId = {};
   // Link is either static, fixed to world, or has zero dofs
   bool isStaticOrFixed = false;
+  // Cached pose from the previous physics step for performance optimization
+  mutable std::optional<math::Pose3d> prevPose = std::nullopt;
 };
 
 struct CollisionInfo

--- a/bullet-featherstone/src/SimulationFeatures.cc
+++ b/bullet-featherstone/src/SimulationFeatures.cc
@@ -370,8 +370,6 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
   _changedPoses.entries.clear();
   _changedPoses.entries.reserve(this->links.size());
 
-  std::unordered_map<std::size_t, math::Pose3d> newPoses;
-
   for (const auto &[id, info] : this->links)
   {
     const auto &model = this->ReferenceInterface<ModelInfo>(info->model);
@@ -385,16 +383,27 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
         !iter->second.Rot().Equal(wp.pose.Rot(), 1e-6))
     {
       _changedPoses.entries.push_back(wp);
-      newPoses[id] = wp.pose;
+      this->prevLinkPoses[id] = wp.pose;
     }
-    else
-      newPoses[id] = iter->second;
   }
 
-  // Save the new poses so that they can be used to check for updates in the
-  // next iteration. Re-setting this->prevLinkPoses with the contents of
-  // newPoses ensures that we aren't caching data for links that were removed
-  this->prevLinkPoses = std::move(newPoses);
+  if (this->prevLinkPoses.size() > this->links.size())
+  {
+    // Clear all the removed links
+    auto it = this->prevLinkPoses.begin();
+    while (it != this->prevLinkPoses.end())
+    {
+      if (this->links.find(prevPose.first) == this->links.end())
+      {
+        // Link was removed, clear from cache
+        it = this->prevLinkPoses.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
 }
 }  // namespace bullet_featherstone
 }  // namespace physics

--- a/bullet-featherstone/src/SimulationFeatures.cc
+++ b/bullet-featherstone/src/SimulationFeatures.cc
@@ -377,31 +377,12 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
     wp.pose = gz::math::eigen3::convert(GetWorldTransformOfLink(*model, *info));
     wp.body = id;
 
-    auto iter = this->prevLinkPoses.find(id);
-    if ((iter == this->prevLinkPoses.end()) ||
-        !iter->second.Pos().Equal(wp.pose.Pos(), 1e-6) ||
-        !iter->second.Rot().Equal(wp.pose.Rot(), 1e-6))
+    if (!info->prevPose.has_value() ||
+        !info->prevPose->Pos().Equal(wp.pose.Pos(), 1e-6) ||
+        !info->prevPose->Rot().Equal(wp.pose.Rot(), 1e-6))
     {
       _changedPoses.entries.push_back(wp);
-      this->prevLinkPoses[id] = wp.pose;
-    }
-  }
-
-  if (this->prevLinkPoses.size() > this->links.size())
-  {
-    // Clear all the removed links
-    auto it = this->prevLinkPoses.begin();
-    while (it != this->prevLinkPoses.end())
-    {
-      if (this->links.find(it->first) == this->links.end())
-      {
-        // Link was removed, clear from cache
-        it = this->prevLinkPoses.erase(it);
-      }
-      else
-      {
-        ++it;
-      }
+      info->prevPose = wp.pose;
     }
   }
 }

--- a/bullet-featherstone/src/SimulationFeatures.cc
+++ b/bullet-featherstone/src/SimulationFeatures.cc
@@ -393,7 +393,7 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
     auto it = this->prevLinkPoses.begin();
     while (it != this->prevLinkPoses.end())
     {
-      if (this->links.find(prevPose.first) == this->links.end())
+      if (this->links.find(it->first) == this->links.end())
       {
         // Link was removed, clear from cache
         it = this->prevLinkPoses.erase(it);

--- a/bullet-featherstone/src/SimulationFeatures.hh
+++ b/bullet-featherstone/src/SimulationFeatures.hh
@@ -57,10 +57,6 @@ class SimulationFeatures :
 
   public: std::vector<ContactInternal> GetContactsFromLastStep(
       const Identity &_worldID) const override;
-
-  /// \brief link poses from the most recent pose change/update.
-  /// The key is the link's ID, and the value is the link's pose
-  private: mutable std::unordered_map<std::size_t, math::Pose3d> prevLinkPoses;
 };
 
 }  // namespace bullet_featherstone

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -37,6 +37,7 @@
 #include <gz/common/Console.hh>
 #include <gz/math/eigen3/Conversions.hh>
 #include <gz/math/Inertial.hh>
+#include <gz/math/Pose3.hh>
 #include <gz/math/SemanticVersion.hh>
 #include <gz/physics/detail/EntityStorage.hh>
 #include <gz/physics/Implements.hh>
@@ -82,6 +83,9 @@ struct LinkInfo
   /// \brief The total link inertia, which may be split between the `link` and
   /// `weldedNodes` body nodes.
   std::optional<math::Inertiald> inertial;
+  /// \brief Cached pose from the previous physics step, used for performance
+  /// optimization.
+  std::optional<math::Pose3d> prevPose;
 };
 
 struct JointInfo

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -181,32 +181,12 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
 
       // If the link's pose is new or has changed, save this new pose and
       // add it to the output poses. Otherwise, keep the existing link pose
-      auto iter = this->prevLinkPoses.find(id);
-      if ((iter == this->prevLinkPoses.end()) ||
-          !iter->second.Pos().Equal(wp.pose.Pos(), 1e-6) ||
-          !iter->second.Rot().Equal(wp.pose.Rot(), 1e-6))
+      if (!info->prevPose.has_value() ||
+          !info->prevPose->Pos().Equal(wp.pose.Pos(), 1e-6) ||
+          !info->prevPose->Rot().Equal(wp.pose.Rot(), 1e-6))
       {
         _changedPoses.entries.push_back(wp);
-        this->prevLinkPoses[id] = wp.pose;
-      }
-    }
-  }
-
-  if (this->prevLinkPoses.size() > this->links.size())
-  {
-    // Clear all the removed links
-    auto it = this->prevLinkPoses.begin();
-    while (it != this->prevLinkPoses.end())
-    {
-      if (this->links.idToObject.find(it->first) ==
-          this->links.idToObject.end())
-      {
-        // Link was removed, clear from cache
-        it = this->prevLinkPoses.erase(it);
-      }
-      else
-      {
-        ++it;
+        info->prevPose = wp.pose;
       }
     }
   }

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -169,8 +169,6 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
   _changedPoses.entries.clear();
   _changedPoses.entries.reserve(this->links.size());
 
-  std::unordered_map<std::size_t, math::Pose3d> newPoses;
-
   for (const auto &[id, info] : this->links.idToObject)
   {
     // make sure the link exists
@@ -189,17 +187,29 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
           !iter->second.Rot().Equal(wp.pose.Rot(), 1e-6))
       {
         _changedPoses.entries.push_back(wp);
-        newPoses[id] = wp.pose;
+        this->prevLinkPoses[id] = wp.pose;
       }
-      else
-        newPoses[id] = iter->second;
     }
   }
 
-  // Save the new poses so that they can be used to check for updates in the
-  // next iteration. Re-setting this->prevLinkPoses with the contents of
-  // newPoses ensures that we aren't caching data for links that were removed
-  this->prevLinkPoses = std::move(newPoses);
+  if (this->prevLinkPoses.size() > this->links.size())
+  {
+    // Clear all the removed links
+    auto it = this->prevLinkPoses.begin();
+    while (it != this->prevLinkPoses.end())
+    {
+      if (this->links.idToObject.find(it->first) ==
+          this->links.idToObject.end())
+      {
+        // Link was removed, clear from cache
+        it = this->prevLinkPoses.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
 }
 
 SimulationFeatures::RayIntersectionInternal

--- a/dartsim/src/SimulationFeatures.hh
+++ b/dartsim/src/SimulationFeatures.hh
@@ -142,10 +142,6 @@ class SimulationFeatures :
       const std::vector<BatchRayQuery> &_rays,
       BatchedRayIntersectionData &_output) const override;
 
-  /// \brief link poses from the most recent pose change/update.
-  /// The key is the link's ID, and the value is the link's pose
-  private: mutable std::unordered_map<std::size_t, math::Pose3d> prevLinkPoses;
-
   private: std::optional<ContactInternal> convertContact(
     const dart::collision::Contact& _contact) const;
 


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Part of https://github.com/gazebosim/gz-sim/issues/3608
Improve performance by removing allocation + deallocation of a hash map for all link poses in each update step.

## Summary
Guided by the [profiling report](https://caguero.github.io/gz-profiling/2026-04-21/findings_report.pdf) by @caguero, Priority 2.
Building and destroying a hash map, where each node needs to call malloc / free, is an expensive operation.
I tried the quick recommendation to reserve the hash map but found out it didn't help much and I thought the "best" approach of not sending updates for static links might be a bit tricky (and still, it is not mutually exclusive, we can still do it in a followup).
Thus the approach is to remove the extra map and make sure we use the preexisting `prevLinkPoses` hash map instead.

Before there was an

```
declare empty map
if (pose changed)  -> add new pose to map
else -> add old pose to map
```

By caching the pose through iterations, we can get rid of the else statement (since it will be just set to the value in the previous iteration).
Finding out which links have been removed is a bit trickier. I thought since removing links is something that happens fairly rarely, we could do a fast check where, if at any point in time the size of our cache is larger than the size of our links map, we trigger a full traversal and delete stale links.
I believe this should be robust even to cases where we add and remove a link in the same iteration. Adding a link with a new ID will make the cache allocate a new element and thus it will become larger than the links array, triggering the reallocation.
At the same time, this approach will do virtually no work at all iterations, instead of having to do expensive lookups / traversal at every step for, again, something I believe happens very rarely (link deletion).

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
## Test it

Run gz-sim with and without this PR:

```
$ gz sim -v3 3k_shapes.sdf -r --physics-engine gz-physics-dartsim-plugin -s
$ gz sim -v3 3k_shapes.sdf -r --physics-engine gz-physics-bullet-featherstone-plugin -s
```

On my machine I actually don't observe a noticeable improvement under `dartsim` since it's already very slow (~1% RTF, I'm open to revert the commit that makes this change there https://github.com/gazebosim/gz-physics/pull/1005/commits/1a78c624df2c8b382e37b62ff64067b385d550de), but on bullet-featherstone the RTF goes from ~10-20% to 20-30%, so about 75% increase.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.