### PR TITLE
Publish small DART pose deltas

### DIFF
--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -182,8 +182,8 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
       // add it to the output poses. Otherwise, keep the existing link pose
       auto iter = this->prevLinkPoses.find(id);
       if ((iter == this->prevLinkPoses.end()) ||
-          !iter->second.Pos().Equal(wp.pose.Pos(), 1e-6) ||
-          !iter->second.Rot().Equal(wp.pose.Rot(), 1e-6))
+          !iter->second.Pos().Equal(wp.pose.Pos(), 0.0) ||
+          !iter->second.Rot().Equal(wp.pose.Rot(), 0.0))
       {
         _changedPoses.entries.push_back(wp);
         newPoses[id] = wp.pose;

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -1279,6 +1279,53 @@ TYPED_TEST(SimulationFeaturesTestFreeGroup, FreeGroup)
   }
 }
 
+TYPED_TEST(SimulationFeaturesTestFreeGroup, ChangedWorldPosesPublishesSmallDelta)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    if (name.find("dartsim") == std::string::npos)
+      continue;
+
+    auto world = LoadPluginAndWorld<FreeGroupFeatures>(
+      this->loader,
+      name,
+      common_test::worlds::kSphereSdf);
+
+    auto model = world->GetModel("sphere");
+    ASSERT_NE(nullptr, model);
+    auto freeGroup = model->FindFreeGroup();
+    ASSERT_NE(nullptr, freeGroup);
+    ASSERT_NE(nullptr, freeGroup->RootLink());
+
+    StepWorld<FreeGroupFeatures>(world, true);
+
+    const gz::math::Pose3d firstPose{0, 0, 2, 0, 0, 0};
+    freeGroup->SetWorldPose(gz::math::eigen3::convert(firstPose));
+    StepWorld<FreeGroupFeatures>(world, false);
+
+    const gz::math::Pose3d smallDeltaPose{5e-7, 0, 2, 0, 0, 0};
+    freeGroup->SetWorldPose(gz::math::eigen3::convert(smallDeltaPose));
+
+    auto [checkedOutput, output] =
+      StepWorld<FreeGroupFeatures>(world, false);
+    EXPECT_FALSE(checkedOutput);
+
+    const auto changedWorldPoses =
+      output.template Get<gz::physics::ChangedWorldPoses>().entries;
+    const auto rootLinkId = freeGroup->RootLink()->EntityID();
+    auto changedPoseIt = std::find_if(changedWorldPoses.begin(),
+      changedWorldPoses.end(),
+      [rootLinkId](const auto &_worldPose)
+      {
+        return _worldPose.body == rootLinkId;
+      });
+
+    ASSERT_NE(changedWorldPoses.end(), changedPoseIt)
+        << "ChangedWorldPoses must publish real pose deltas below 1e-6";
+    EXPECT_EQ(smallDeltaPose, changedPoseIt->pose);
+  }
+}
+
 template <class T>
 class SimulationFeaturesTestBasic :
   public SimulationFeaturesTest<T>{};


### PR DESCRIPTION
# Bug fix

Backport of https://github.com/gazebosim/gz-physics/pull/1008 for the gz-physics8 line.

Fixes the root cause behind https://github.com/gazebosim/gz-sim/issues/3697.

## Summary

The DART engine plugin was treating link pose deltas smaller than 1e-6 as unchanged in ChangedWorldPoses. gz-sim diff-drive command tests can legitimately produce first-step motion below that threshold, so downstream pose consumers miss a real update.

This changes ChangedWorldPoses to publish every real pose delta and adds a DART-plugin regression that moves a free group by 5e-7 m and verifies the changed pose is emitted.

## Testing

- Configured this branch against the source-built DART 6.19 Gazebo environment.
- Built `COMMON_TEST_simulation_features`.
- Built `gz-physics8-dartsim-plugin`.
- `ctest --test-dir build/dart619 --output-on-failure --parallel 1 -R '^(COMMON_TEST_simulation_features_dartsim|check_COMMON_TEST_simulation_features_dartsim)$'` passed.
- DART downstream validation: `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz` passed, including gz-sim INTEGRATION_entity_system against the source-built DART plugin.

## Backport Policy

- [x] This is a backport to gz-physics8.
- [ ] This should not be backported
- [ ] I am not sure

## Related Issues / PRs

- https://github.com/gazebosim/gz-sim/issues/3697
- Main PR: https://github.com/gazebosim/gz-physics/pull/1008
- DART validation PR: https://github.com/dartsim/dart/pull/3068