### PR TITLE
Backport CPU-lidar raycast (#880, #976) to gz-physics9 without the NaN->+INF breaking change

### DIFF
--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -359,7 +359,8 @@ bool GzOdeCollisionDetector::BatchRaycast(
     else
     {
       // No hit: NaN fraction/point/normal. NaN (not +INF as on gz-physics10
-      // per REP-117) preserves gz-physics9's released miss value on this branch.
+      // per REP-117) preserves gz-physics9's released miss value on this
+      // branch.
       _results.emplace_back(GzRayResult{
           Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()),
           std::numeric_limits<double>::quiet_NaN(),

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -21,6 +21,11 @@
 #include <utility>
 
 #include <dart/collision/CollisionObject.hpp>
+#include <dart/collision/bullet/BulletCollisionGroup.hpp>
+
+#include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
+
+#include <gz/common/Console.hh>
 
 #include "GzCollisionDetector.hh"
 
@@ -100,6 +105,22 @@ void GzCollisionDetector::LimitCollisionPairMaxContacts(
 }
 
 /////////////////////////////////////////////////
+bool GzCollisionDetector::BatchRaycast(
+    CollisionGroup */*_group*/,
+    const std::vector<GzRay> &/*_rays*/,
+    std::vector<GzRayResult> &/*_output*/) const
+{
+  static bool warned = false;
+  if (!warned)
+  {
+    warned = true;
+    gzwarn << "BatchRaycast: collision detector does not support batch "
+           << "raycasting. All ray results will be NaN." << std::endl;
+  }
+  return false;
+}
+
+/////////////////////////////////////////////////
 GzOdeCollisionDetector::GzOdeCollisionDetector()
   : OdeCollisionDetector(), GzCollisionDetector()
 {
@@ -149,10 +170,42 @@ bool GzOdeCollisionDetector::collide(
   return ret;
 }
 
+/// \brief Exposes BulletCollisionGroup::getBulletCollisionWorld() which
+/// is protected in the base class.
+class GzBulletCollisionGroup : public dart::collision::BulletCollisionGroup
+{
+  public: explicit GzBulletCollisionGroup(
+      const dart::collision::CollisionDetectorPtr &_detector);
+
+  /// \brief Return the underlying btCollisionWorld
+  public: const btCollisionWorld *getCollisionWorld() const;
+};
+
+/////////////////////////////////////////////////
+GzBulletCollisionGroup::GzBulletCollisionGroup(
+    const dart::collision::CollisionDetectorPtr &_detector)
+  : dart::collision::BulletCollisionGroup(_detector)
+{
+}
+
+/////////////////////////////////////////////////
+const btCollisionWorld *GzBulletCollisionGroup::getCollisionWorld() const
+{
+  // getBulletCollisionWorld() is protected in BulletCollisionGroup.
+  return this->getBulletCollisionWorld();
+}
+
 /////////////////////////////////////////////////
 GzBulletCollisionDetector::GzBulletCollisionDetector()
   : BulletCollisionDetector(), GzCollisionDetector()
 {
+}
+
+/////////////////////////////////////////////////
+std::unique_ptr<dart::collision::CollisionGroup>
+GzBulletCollisionDetector::createCollisionGroup()
+{
+  return std::make_unique<GzBulletCollisionGroup>(this->shared_from_this());
 }
 
 /////////////////////////////////////////////////
@@ -192,4 +245,58 @@ bool GzBulletCollisionDetector::collide(
       _group1, _group2, _option, _result);
   this->LimitCollisionPairMaxContacts(_result);
   return ret;
+}
+
+/////////////////////////////////////////////////
+bool GzBulletCollisionDetector::BatchRaycast(
+    CollisionGroup *_group,
+    const std::vector<GzRay> &_rays,
+    std::vector<GzRayResult> &_output) const
+{
+  auto *gzGroup = dynamic_cast<GzBulletCollisionGroup *>(_group);
+  if (!gzGroup)
+    return false;
+
+  const btCollisionWorld *btWorld = gzGroup->getCollisionWorld();
+  if (!btWorld)
+    return false;
+
+  _output.clear();
+  _output.reserve(_rays.size());
+
+  for (const auto &ray : _rays)
+  {
+    const btVector3 btFrom(
+      static_cast<btScalar>(ray.origin.x()),
+      static_cast<btScalar>(ray.origin.y()),
+      static_cast<btScalar>(ray.origin.z()));
+    const btVector3 btTo(
+      static_cast<btScalar>(ray.target.x()),
+      static_cast<btScalar>(ray.target.y()),
+      static_cast<btScalar>(ray.target.z()));
+
+    btCollisionWorld::ClosestRayResultCallback rayCallback(btFrom, btTo);
+    btWorld->rayTest(btFrom, btTo, rayCallback);
+
+    GzRayResult &result = _output.emplace_back();
+    if (rayCallback.hasHit())
+    {
+      const btVector3 &hp = rayCallback.m_hitPointWorld;
+      const btVector3 &hn = rayCallback.m_hitNormalWorld;
+      result.point << hp.x(), hp.y(), hp.z();
+      result.normal << hn.x(), hn.y(), hn.z();
+      result.fraction = static_cast<double>(rayCallback.m_closestHitFraction);
+    }
+    else
+    {
+      // No object in range: fraction is NaN.
+      // point and normal are undefined (NaN) when there is no hit.
+      constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+      result.point = Eigen::Vector3d::Constant(kNaN);
+      result.fraction = kNaN;
+      result.normal = Eigen::Vector3d::Constant(kNaN);
+    }
+  }
+
+  return true;
 }

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -22,10 +22,10 @@
 
 #include <dart/collision/CollisionObject.hpp>
 #include <dart/collision/bullet/BulletCollisionGroup.hpp>
+#include <dart/collision/ode/OdeCollisionGroup.hpp>
+#include <gz/common/Console.hh>
 
 #include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
-
-#include <gz/common/Console.hh>
 
 #include "GzCollisionDetector.hh"
 
@@ -147,6 +147,21 @@ std::shared_ptr<GzOdeCollisionDetector> GzOdeCollisionDetector::create()
   return std::shared_ptr<GzOdeCollisionDetector>(new GzOdeCollisionDetector());
 }
 
+class GzOdeCollisionGroup : public OdeCollisionGroup
+{
+  friend class GzOdeCollisionDetector;
+public:
+  /// Constructor
+  using OdeCollisionGroup::OdeCollisionGroup;
+
+  using OdeCollisionGroup::getOdeSpaceId;
+};
+
+std::unique_ptr<CollisionGroup> GzOdeCollisionDetector::createCollisionGroup()
+{
+  return std::make_unique<GzOdeCollisionGroup>(shared_from_this());
+}
+
 /////////////////////////////////////////////////
 bool GzOdeCollisionDetector::collide(
     CollisionGroup *_group,
@@ -168,6 +183,191 @@ bool GzOdeCollisionDetector::collide(
   bool ret = OdeCollisionDetector::collide(_group1, _group2, _option, _result);
   this->LimitCollisionPairMaxContacts(_result);
   return ret;
+}
+
+struct ODERayCastData
+{
+  RaycastResult* result;
+  const Eigen::Vector3d *origin;
+  double curContactDistSqr = std::numeric_limits<double>::max();
+};
+
+void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
+{
+  // Check space
+  if (dGeomIsSpace(_o1) || dGeomIsSpace(_o2))
+  {
+    dSpaceCollide2(_o1, _o2, _data, &NearCallbackODE);
+    return;
+  }
+
+  // Identify the ray
+  dGeomID ray = nullptr;
+  dGeomID other = nullptr;
+
+  if (dGeomGetClass(_o1) == dRayClass)
+  {
+    ray = _o1;
+    other = _o2;
+  }
+  if (dGeomGetClass(_o2) == dRayClass)
+  {
+    ray = _o2;
+    other = _o1;
+  }
+
+  if(ray == nullptr)
+  {
+    // should not happen, but to be safe...
+    return;
+  }
+
+  dContactGeom contact;
+
+  ODERayCastData* data = static_cast<ODERayCastData*>(_data);
+
+  auto setResult = [&](dart::collision::RayHit &rayHit)
+  {
+
+      auto geomData = dGeomGetData(other);
+      rayHit.mNormal = Eigen::Vector3d(contact.normal);
+      rayHit.mPoint = Eigen::Vector3d(contact.pos);
+      rayHit.mCollisionObject =
+        static_cast<dart::collision::CollisionObject*>(geomData);
+  };
+
+  // param 3 makes sure that we only generate one collision per call
+  if(dCollide(ray, other, 1, &contact, sizeof(dContactGeom)) > 0)
+  {
+    Eigen::Vector3d contactPoint(contact.pos);
+
+    const double sqrDist = (*data->origin - contactPoint).squaredNorm();
+    if(sqrDist > data->curContactDistSqr)
+    {
+      // ignore farther contacts
+      return;
+    }
+
+    if(data->result->mRayHits.empty())
+    {
+      setResult(data->result->mRayHits.emplace_back());
+
+    }
+    else
+    {
+      setResult(data->result->mRayHits.front());
+    }
+    data->curContactDistSqr = sqrDist;
+  }
+}
+
+static void doSingleRaycastODE(const Eigen::Vector3d& origin,
+      const Eigen::Vector3d& target,
+      RaycastResult* result,
+      const dGeomID &rayId,
+      const dSpaceID &spaceId)
+{
+  const Eigen::Vector3d dirNonNormalized(target - origin);
+  const double length = dirNonNormalized.norm();
+  result->clear();
+  if(length < 1e-7)
+  {
+    return;
+  }
+
+  const Eigen::Vector3d dir(dirNonNormalized / length);
+
+  dGeomRaySet(rayId, origin.x(), origin.y(), origin.z(),
+              dir.x(), dir.y(), dir.z());
+  dGeomRaySetLength(rayId, length);
+
+  ODERayCastData data;
+  data.result = result;
+  data.origin = &origin;
+
+  dSpaceCollide2(rayId,
+                  reinterpret_cast<dGeomID>(spaceId),
+                  &data, &NearCallbackODE);
+
+  if(!result->mRayHits.empty())
+  {
+    // compute fraction, we need to do it here, as we need
+    // length and orgin
+    RayHit &rayHit(result->mRayHits.front());
+    rayHit.mFraction = (rayHit.mPoint - origin).norm() / length;
+  }
+}
+
+bool GzOdeCollisionDetector::raycast(
+      CollisionGroup* group,
+      const Eigen::Vector3d& from,
+      const Eigen::Vector3d& to,
+      const RaycastOption& option,
+      RaycastResult* result)
+{
+  if(!result)
+  {
+    return false;
+  }
+
+  if(option.mEnableAllHits)
+  {
+      gzwarn << "raycast multihit support is not"
+             << " implemented for ODE" << std::endl;
+      return false;
+  }
+
+  auto odeGroup = static_cast<GzOdeCollisionGroup *>(group);
+  const dSpaceID spaceId = odeGroup->getOdeSpaceId();
+
+  const dGeomID rayId = dCreateRay(nullptr, 1.0);
+  dGeomRaySetClosestHit(rayId, 1);
+
+  doSingleRaycastODE(from, to, result, rayId, spaceId);
+
+  dGeomDestroy(rayId);
+
+  // near callback updated our ray hit result now (or not)
+  return !result->mRayHits.empty();
+}
+
+bool GzOdeCollisionDetector::BatchRaycast(
+      CollisionGroup *_group,
+      const std::vector<GzRay> &_rays,
+      std::vector<GzRayResult> &_results) const
+{
+  auto odeGroup = static_cast<GzOdeCollisionGroup *>(_group);
+  const dSpaceID spaceId = odeGroup->getOdeSpaceId();
+
+  const dGeomID rayId = dCreateRay(nullptr, 1.0);
+  dGeomRaySetClosestHit(rayId, 1);
+
+  _results.clear();
+  _results.reserve(_rays.size());
+  RaycastResult result;
+  for(const GzRay &ray : _rays)
+  {
+    doSingleRaycastODE(ray.origin, ray.target, &result, rayId, spaceId);
+
+    // near callback updated our ray hit result now (or not)
+    if(result.hasHit())
+    {
+      RayHit &rayHit(result.mRayHits.front());
+      _results.emplace_back(GzRayResult{rayHit.mPoint, rayHit.mFraction,
+                            rayHit.mNormal});
+    }
+    else
+    {
+      _results.emplace_back(GzRayResult{
+          Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()),
+          std::numeric_limits<double>::quiet_NaN(),
+          Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())});
+    }
+  }
+
+  dGeomDestroy(rayId);
+
+  return true;
 }
 
 /// \brief Exposes BulletCollisionGroup::getBulletCollisionWorld() which

--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -358,6 +358,8 @@ bool GzOdeCollisionDetector::BatchRaycast(
     }
     else
     {
+      // No hit: NaN fraction/point/normal. NaN (not +INF as on gz-physics10
+      // per REP-117) preserves gz-physics9's released miss value on this branch.
       _results.emplace_back(GzRayResult{
           Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()),
           std::numeric_limits<double>::quiet_NaN(),
@@ -489,8 +491,9 @@ bool GzBulletCollisionDetector::BatchRaycast(
     }
     else
     {
-      // No object in range: fraction is NaN.
-      // point and normal are undefined (NaN) when there is no hit.
+      // No object in range: NaN fraction; point/normal undefined (NaN).
+      // NaN (not +INF as on gz-physics10 per REP-117) preserves gz-physics9's
+      // released miss value on this branch.
       constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
       result.point = Eigen::Vector3d::Constant(kNaN);
       result.fraction = kNaN;

--- a/dartsim/src/GzCollisionDetector.hh
+++ b/dartsim/src/GzCollisionDetector.hh
@@ -104,8 +104,31 @@ class GzOdeCollisionDetector :
       const CollisionOption& option = CollisionOption(false, 1u, nullptr),
       CollisionResult* result = nullptr) override;
 
+  /// Performs raycast to a collision group.
+  ///
+  /// \param[in] group The collision group the ray will be casted onto.
+  /// \param[in] from The start point of the ray in world coordinates.
+  /// \param[in] to The end point of the ray in world coordinates.
+  /// \param[in] option The raycast option.
+  /// \param[in] result The raycast result.
+  /// \return True if the ray hit an collision object.
+  public: bool raycast(
+      CollisionGroup* group,
+      const Eigen::Vector3d& from,
+      const Eigen::Vector3d& to,
+      const RaycastOption& option = RaycastOption(),
+      RaycastResult* result = nullptr) override;
+
+  public: virtual bool BatchRaycast(
+      CollisionGroup *_group,
+      const std::vector<GzRay> &_rays,
+      std::vector<GzRayResult> &_results) const override;
+
   /// \brief Create the GzOdeCollisionDetector
   public: static std::shared_ptr<GzOdeCollisionDetector> create();
+
+  // Documentation inherited
+  public: std::unique_ptr<CollisionGroup> createCollisionGroup() override;
 
   /// Constructor
   protected: GzOdeCollisionDetector();

--- a/dartsim/src/GzCollisionDetector.hh
+++ b/dartsim/src/GzCollisionDetector.hh
@@ -21,13 +21,29 @@
 #include <cstdio>
 #include <limits>
 #include <memory>
+#include <vector>
+
+#include <Eigen/Core>
 
 #include <dart/collision/CollisionResult.hpp>
 #include <dart/collision/bullet/BulletCollisionDetector.hpp>
 #include <dart/collision/ode/OdeCollisionDetector.hpp>
 
+#include <gz/physics/FeaturePolicy.hh>
+#include <gz/physics/GetBatchRayIntersection.hh>
+
 namespace dart {
 namespace collision {
+
+using GzRay =
+    gz::physics::GetBatchRayIntersectionFromLastStepFeature
+    ::RayT<gz::physics::FeaturePolicy3d>;
+
+/// \brief Result of a single ray query.
+/// Alias for the gz-physics RayIntersection type to avoid redundant copies.
+using GzRayResult =
+    gz::physics::GetBatchRayIntersectionFromLastStepFeature
+    ::RayIntersectionT<gz::physics::FeaturePolicy3d>;
 
 class GzCollisionDetector
 {
@@ -41,6 +57,20 @@ class GzCollisionDetector
   /// objects
   /// \return Maximum number of contacts between a pair of collision objects.
   public: virtual std::size_t GetCollisionPairMaxContacts() const;
+
+  /// \brief Cast multiple rays against a collision group.
+  /// \param[in] _group The collision group to test against.
+  /// \param[in] _rays The rays to cast.
+  /// \param[out] _output Filled with one result per ray. Caller may
+  ///   preallocate and reuse across calls.
+  /// \return true if raycasting succeeded, false if unsupported.
+  public: virtual bool BatchRaycast(
+      CollisionGroup *_group,
+      const std::vector<GzRay> &_rays,
+      std::vector<GzRayResult> &_output) const;
+
+  /// Destructor
+  public: virtual ~GzCollisionDetector() = default;
 
   /// Constructor
   protected: GzCollisionDetector();
@@ -99,6 +129,15 @@ class GzBulletCollisionDetector :
       CollisionGroup* group2,
       const CollisionOption& option = CollisionOption(false, 1u, nullptr),
       CollisionResult* result = nullptr) override;
+
+  // Documentation inherited
+  public: std::unique_ptr<CollisionGroup> createCollisionGroup() override;
+
+  // Documentation inherited
+  public: bool BatchRaycast(
+      CollisionGroup *_group,
+      const std::vector<GzRay> &_rays,
+      std::vector<GzRayResult> &_output) const override;
 
   /// \brief Create the GzBulletCollisionDetector
   public: static std::shared_ptr<GzBulletCollisionDetector> create();

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 
 #include <dart/collision/CollisionObject.hpp>
@@ -38,8 +39,10 @@
 #include <gz/math/Pose3.hh>
 #include <gz/math/eigen3/Conversions.hh>
 
+#include "gz/physics/GetBatchRayIntersection.hh"
 #include "gz/physics/GetContacts.hh"
 
+#include "GzCollisionDetector.hh"
 #include "SimulationFeatures.hh"
 
 #if DART_VERSION_AT_LEAST(6, 13, 0)
@@ -218,14 +221,47 @@ SimulationFeatures::GetRayIntersectionFromLastStep(
   else
   {
     // Set invalid measurements to NaN according to REP-117
-    intersection.point =
-      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN());
-    intersection.normal =
-      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN());
+    constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+    intersection.point = Eigen::Vector3d::Constant(kNaN);
+    intersection.normal = Eigen::Vector3d::Constant(kNaN);
     intersection.fraction = std::numeric_limits<double>::quiet_NaN();
   }
 
   return intersection;
+}
+
+/////////////////////////////////////////////////
+bool SimulationFeatures::GetBatchRayIntersectionFromLastStep(
+  const Identity &_worldID,
+  const std::vector<SimulationFeatures::BatchRayQuery> &_rays,
+  SimulationFeatures::BatchedRayIntersectionData &_output) const
+{
+  auto &results = _output.Get<std::vector<BatchRayIntersection>>();
+
+  if (_rays.empty())
+  {
+    results.clear();
+    return true;
+  }
+
+  auto *const world = this->ReferenceInterface<DartWorld>(_worldID);
+  auto *const solver = world->getConstraintSolver();
+
+  auto detector = solver->getCollisionDetector();
+  auto *gzDetector =
+    dynamic_cast<dart::collision::GzCollisionDetector *>(detector.get());
+
+  if (gzDetector &&
+      gzDetector->BatchRaycast(
+          solver->getCollisionGroup().get(), _rays, results))
+    return true;
+
+  // Unsupported detector: fill with NaN fraction, NaN point/normal.
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+  const Eigen::Vector3d kNaNVec = Eigen::Vector3d::Constant(kNaN);
+  results.assign(_rays.size(),
+      {kNaNVec, kNaN, kNaNVec});
+  return false;
 }
 
 std::vector<SimulationFeatures::ContactInternal>

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -220,7 +220,9 @@ SimulationFeatures::GetRayIntersectionFromLastStep(
   }
   else
   {
-    // Set invalid measurements to NaN according to REP-117
+    // Miss: NaN fraction/point/normal. Kept as NaN (gz-physics10 switched the
+    // miss value to +INF per REP-117) to preserve gz-physics9's released
+    // behavior on this branch. See RayIntersectionT::IsHit().
     constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
     intersection.point = Eigen::Vector3d::Constant(kNaN);
     intersection.normal = Eigen::Vector3d::Constant(kNaN);
@@ -256,7 +258,9 @@ bool SimulationFeatures::GetBatchRayIntersectionFromLastStep(
           solver->getCollisionGroup().get(), _rays, results))
     return true;
 
-  // Unsupported detector: fill with NaN fraction, NaN point/normal.
+  // Unsupported detector: fill with NaN fraction, NaN point/normal. NaN (not
+  // +INF as on gz-physics10 per REP-117) preserves gz-physics9's released
+  // miss value on this branch.
   constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
   const Eigen::Vector3d kNaNVec = Eigen::Vector3d::Constant(kNaN);
   results.assign(_rays.size(),

--- a/dartsim/src/SimulationFeatures.hh
+++ b/dartsim/src/SimulationFeatures.hh
@@ -33,6 +33,7 @@
 #include <gz/physics/CanWriteData.hh>
 
 #include <gz/physics/ForwardStep.hh>
+#include <gz/physics/GetBatchRayIntersection.hh>
 #include <gz/physics/GetContacts.hh>
 #include <gz/physics/GetRayIntersection.hh>
 #include <gz/physics/ContactProperties.hh>
@@ -58,7 +59,8 @@ struct SimulationFeatureList : FeatureList<
   SetContactPropertiesCallbackFeature,
 #endif
   GetContactsFromLastStepFeature,
-  GetRayIntersectionFromLastStepFeature
+  GetRayIntersectionFromLastStepFeature,
+  GetBatchRayIntersectionFromLastStepFeature
 > { };
 
 #ifdef DART_HAS_CONTACT_SURFACE
@@ -102,6 +104,18 @@ class SimulationFeatures :
   public: using GetRayIntersectionFromLastStepFeature::Implementation<
     FeaturePolicy3d>::RayIntersection;
 
+  public: using BatchedRayIntersectionData =
+    GetBatchRayIntersectionFromLastStepFeature::Implementation<
+      FeaturePolicy3d>::BatchedRayIntersectionData;
+
+  public: using BatchRayQuery =
+    GetBatchRayIntersectionFromLastStepFeature::Implementation<
+      FeaturePolicy3d>::RayQuery;
+
+  public: using BatchRayIntersection =
+    GetBatchRayIntersectionFromLastStepFeature::Implementation<
+      FeaturePolicy3d>::RayIntersection;
+
   public: SimulationFeatures() = default;
   public: ~SimulationFeatures() override = default;
 
@@ -122,6 +136,15 @@ class SimulationFeatures :
       const Identity &_worldID,
       const LinearVector3d &_from,
       const LinearVector3d &_end) const override;
+
+  public: bool GetBatchRayIntersectionFromLastStep(
+      const Identity &_worldID,
+      const std::vector<BatchRayQuery> &_rays,
+      BatchedRayIntersectionData &_output) const override;
+
+  /// \brief link poses from the most recent pose change/update.
+  /// The key is the link's ID, and the value is the link's pose
+  private: mutable std::unordered_map<std::size_t, math::Pose3d> prevLinkPoses;
 
   private: std::optional<ContactInternal> convertContact(
     const dart::collision::Contact& _contact) const;

--- a/include/gz/physics/GetBatchRayIntersection.hh
+++ b/include/gz/physics/GetBatchRayIntersection.hh
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_GETBATCHRAYINTERSECTION_HH_
+#define GZ_PHYSICS_GETBATCHRAYINTERSECTION_HH_
+
+#include <vector>
+
+#include <gz/physics/FeatureList.hh>
+#include <gz/physics/ForwardStep.hh>
+#include <gz/physics/Geometry.hh>
+#include <gz/physics/RayIntersection.hh>
+#include <gz/physics/SpecifyData.hh>
+
+namespace gz
+{
+namespace physics
+{
+
+/// \brief GetBatchRayIntersectionFromLastStepFeature is a feature for
+/// retrieving multiple ray intersections generated in the previous simulation
+/// step in a single call.
+class GZ_PHYSICS_VISIBLE GetBatchRayIntersectionFromLastStepFeature
+    : public virtual FeatureWithRequirements<ForwardStep>
+{
+  /// \brief Alias to the shared ray intersection result type.
+  public: template <typename PolicyT>
+  using RayIntersectionT = gz::physics::RayIntersectionT<PolicyT>;
+
+  public: template <typename PolicyT>
+  struct RayT
+  {
+    public: using VectorType =
+      typename FromPolicy<PolicyT>::template Use<LinearVector>;
+
+    /// \brief Ray start point in world coordinates
+    VectorType origin;
+
+    /// \brief Ray end point in world coordinates
+    VectorType target;
+  };
+
+  /// \brief Extensible output type for batch ray queries. Using SpecifyData
+  /// allows additional fields to be added in the future without breaking
+  /// API or ABI for existing callers and plugin implementers.
+  public: template <typename PolicyT>
+  using BatchedRayIntersectionDataT =
+      SpecifyData<RequireData<std::vector<RayIntersectionT<PolicyT>>>>;
+
+  public: template <typename PolicyT, typename FeaturesT>
+  class World : public virtual Feature::World<PolicyT, FeaturesT>
+  {
+    public: using RayIntersection = RayIntersectionT<PolicyT>;
+    public: using RayQuery = RayT<PolicyT>;
+    public: using BatchedRayIntersectionData =
+        BatchedRayIntersectionDataT<PolicyT>;
+
+    /// \brief Cast multiple rays and write one result per ray into _output.
+    /// \param[in] _rays Ray queries (origin + target) in world coordinates.
+    /// \param[out] _output Filled with one result per input ray, in the same
+    ///   order. Caller may preallocate and reuse the inner vector across calls.
+    /// \return true if the underlying detector handled the batch; false if the
+    ///   detector does not support batch raycasting (results are NaN-filled).
+    public: bool GetBatchRayIntersectionFromLastStep(
+        const std::vector<RayQuery> &_rays,
+        BatchedRayIntersectionData &_output) const;
+  };
+
+  public: template <typename PolicyT>
+  class Implementation : public virtual Feature::Implementation<PolicyT>
+  {
+    public: using RayIntersection = RayIntersectionT<PolicyT>;
+    public: using RayQuery = RayT<PolicyT>;
+    public: using BatchedRayIntersectionData =
+        BatchedRayIntersectionDataT<PolicyT>;
+
+    public: virtual bool GetBatchRayIntersectionFromLastStep(
+        const Identity &_worldID,
+        const std::vector<RayQuery> &_rays,
+        BatchedRayIntersectionData &_output) const = 0;
+  };
+};
+
+}  // namespace physics
+}  // namespace gz
+
+#include "gz/physics/detail/GetBatchRayIntersection.hh"
+
+#endif  // GZ_PHYSICS_GETBATCHRAYINTERSECTION_HH_

--- a/include/gz/physics/GetRayIntersection.hh
+++ b/include/gz/physics/GetRayIntersection.hh
@@ -18,6 +18,8 @@
 #ifndef GZ_PHYSICS_GETRAYINTERSECTION_HH_
 #define GZ_PHYSICS_GETRAYINTERSECTION_HH_
 
+#include <cmath>
+
 #include <gz/physics/FeatureList.hh>
 #include <gz/physics/ForwardStep.hh>
 #include <gz/physics/Geometry.hh>
@@ -43,10 +45,17 @@ class GZ_PHYSICS_VISIBLE GetRayIntersectionFromLastStepFeature
     VectorType point;
 
     /// \brief The fraction of the ray length at the intersection/hit point.
+    /// NaN if no object in range.
+    /// Note: gz-physics10 changed the miss value to +INF (REP-117).
+    /// gz-physics9 intentionally retains NaN for API compatibility.
+    /// Use IsHit() — it is correct under both conventions.
     Scalar fraction;
 
     /// \brief The normal at the hit point in the world coordinates
     VectorType normal;
+
+    /// \brief Returns true if the ray intersected an object.
+    public: bool IsHit() const { return std::isfinite(fraction); }
   };
 
   public: template <typename PolicyT, typename FeaturesT>

--- a/include/gz/physics/RayIntersection.hh
+++ b/include/gz/physics/RayIntersection.hh
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_RAYINTERSECTION_HH_
+#define GZ_PHYSICS_RAYINTERSECTION_HH_
+
+#include <gz/physics/GetRayIntersection.hh>
+
+namespace gz
+{
+namespace physics
+{
+// On gz-physics10 this header defines RayIntersectionT at namespace scope.
+// On gz-physics9 the struct stays nested in GetRayIntersectionFromLastStepFeature
+// to preserve ABI, so this header aliases it instead. The include direction is
+// therefore inverted relative to gz-physics main.
+template <typename PolicyT>
+using RayIntersectionT =
+    GetRayIntersectionFromLastStepFeature::RayIntersectionT<PolicyT>;
+}  // namespace physics
+}  // namespace gz
+
+#endif  // GZ_PHYSICS_RAYINTERSECTION_HH_

--- a/include/gz/physics/RayIntersection.hh
+++ b/include/gz/physics/RayIntersection.hh
@@ -25,8 +25,9 @@ namespace gz
 namespace physics
 {
 // On gz-physics10 this header defines RayIntersectionT at namespace scope.
-// On gz-physics9 the struct stays nested in GetRayIntersectionFromLastStepFeature
-// to preserve ABI, so this header aliases it instead. The include direction is
+// On gz-physics9 the struct stays nested in
+// GetRayIntersectionFromLastStepFeature to preserve ABI, so this header
+// aliases it instead. The include direction is
 // therefore inverted relative to gz-physics main.
 template <typename PolicyT>
 using RayIntersectionT =

--- a/include/gz/physics/detail/GetBatchRayIntersection.hh
+++ b/include/gz/physics/detail/GetBatchRayIntersection.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_DETAIL_GETBATCHRAYINTERSECTION_HH_
+#define GZ_PHYSICS_DETAIL_GETBATCHRAYINTERSECTION_HH_
+
+#include <vector>
+
+#include <gz/physics/GetBatchRayIntersection.hh>
+
+namespace gz
+{
+namespace physics
+{
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+bool GetBatchRayIntersectionFromLastStepFeature::World<
+    PolicyT, FeaturesT>::GetBatchRayIntersectionFromLastStep(
+      const std::vector<RayQuery> &_rays,
+      BatchedRayIntersectionData &_output) const
+{
+  return this->template Interface<GetBatchRayIntersectionFromLastStepFeature>()
+      ->GetBatchRayIntersectionFromLastStep(this->identity, _rays, _output);
+}
+
+}  // namespace physics
+}  // namespace gz
+
+#endif  // GZ_PHYSICS_DETAIL_GETBATCHRAYINTERSECTION_HH_

--- a/test/common_test/Worlds.hh
+++ b/test/common_test/Worlds.hh
@@ -68,5 +68,7 @@ const auto kWorldSingleNestedModelSdf =
   CommonTestWorld("world_single_nested_model.sdf");
 const auto kWorldWithNestedModelSdf =
   CommonTestWorld("world_with_nested_model.sdf");
+const auto kMultipleObjectsComplexSdf =
+  CommonTestWorld("multiple_objects_complex.sdf");
 }  // namespace common_test::worlds
 #endif  // COMMON_TEST_WORLDS_WORLDS_HH_

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -2181,7 +2181,7 @@ TYPED_TEST_SUITE(SimulationFeaturesRayIntersectionTest,
 
 TYPED_TEST(SimulationFeaturesRayIntersectionTest, SupportedRayIntersections)
 {
-  std::vector<std::string> supportedCollisionDetectors = {"bullet"};
+  std::vector<std::string> supportedCollisionDetectors = {"ode", "bullet"};
 
   for (const std::string &name : this->pluginNames)
   {
@@ -2228,7 +2228,7 @@ TYPED_TEST(SimulationFeaturesRayIntersectionTest, SupportedRayIntersections)
 
 TYPED_TEST(SimulationFeaturesRayIntersectionTest, UnsupportedRayIntersections)
 {
-  std::vector<std::string> unsupportedCollisionDetectors = {"ode", "dart", "fcl", "banana"};
+  std::vector<std::string> unsupportedCollisionDetectors = {"dart", "fcl"};
 
   for (const std::string &name : this->pluginNames)
   {
@@ -2259,6 +2259,46 @@ TYPED_TEST(SimulationFeaturesRayIntersectionTest, UnsupportedRayIntersections)
   }
 }
 
+/////////////////////////////////////////////////
+TYPED_TEST(SimulationFeaturesRayIntersectionTest, ClosestRayIntersection)
+{
+  std::vector<std::string> supportedCollisionDetectors = {"ode", "bullet"};
+
+  for (const std::string &name : this->pluginNames)
+  {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet-featherstone", "tpe")
+
+    for (const std::string &collisionDetector : supportedCollisionDetectors) {
+      auto world = LoadPluginAndWorld<FeaturesRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kMultipleObjectsComplexSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput = StepWorld<FeaturesRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
+
+      // Test ray along X axis, should hit closest sphere at x=1
+      // Objects are at different Y positions to confuse spatial traversal
+      auto result =
+        world->GetRayIntersectionFromLastStep(
+            Eigen::Vector3d(-2, 0, 0), Eigen::Vector3d(10, 0, 0));
+
+      auto rayIntersection =
+          result.template
+            Get<gz::physics::World3d<FeaturesRayIntersections>::RayIntersection>();
+
+      double epsilon = 1e-3;
+
+      // The sphere at x=1 has radius 0.3, so the ray should hit at x=0.7
+      // Ray goes from -2 to 10, total length = 12
+      // Hit point at x=0.7 is 2.7 units from start, fraction = 2.7/12 = 0.225
+      EXPECT_TRUE(
+          rayIntersection.point.isApprox(Eigen::Vector3d(0.7, 0, 0), epsilon));
+      EXPECT_NEAR(rayIntersection.fraction, 0.225, epsilon);
+    }
+  }
+}
+
 // The features that an engine must have to be loaded by this loader.
 struct FeaturesBatchRayIntersections : gz::physics::FeatureList<
   gz::physics::sdf::ConstructSdfWorld,
@@ -2279,54 +2319,60 @@ TYPED_TEST_SUITE(SimulationFeaturesBatchRayIntersectionTest,
 TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            SupportedBatchRayIntersections)
 {
+  std::vector<std::string> supportedCollisionDetectors =
+    {"ode", "bullet"};
+
   for (const std::string &name : this->pluginNames)
   {
-    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
-        this->loader,
-        name,
-        common_test::worlds::kSphereSdf);
-    world->SetCollisionDetector("bullet");
-    auto checkedOutput =
-      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
-    EXPECT_TRUE(checkedOutput);
-
-    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
-    using RayQuery = World::RayQuery;
-    using RayIntersection = World::RayIntersection;
-    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
-
-    // Build a batch: first ray hits the sphere, second misses
-    std::vector<RayQuery> rays = {
-      {Eigen::Vector3d(-2, 0, 2), Eigen::Vector3d(2, 0, 2)},   // hit
-      {Eigen::Vector3d(2, 0, 10), Eigen::Vector3d(-2, 0, 10)},  // miss
-    };
-
-    BatchedRayIntersectionData output;
-    world->GetBatchRayIntersectionFromLastStep(rays, output);
-    const auto &results = output.Get<std::vector<RayIntersection>>();
-
-    ASSERT_EQ(2u, results.size());
-
-    // Ray 0 - hits the unit sphere centred at (0,0,2)
+    for (const std::string &collisionDetector : supportedCollisionDetectors)
     {
-      const auto &hit = results[0];
-      EXPECT_TRUE(hit.IsHit());
-      double epsilon = 1e-3;
-      EXPECT_TRUE(hit.point.isApprox(Eigen::Vector3d(-1, 0, 2), epsilon))
-        << "hit point: " << hit.point.transpose();
-      EXPECT_TRUE(hit.normal.isApprox(Eigen::Vector3d(-1, 0, 0), epsilon))
-        << "hit normal: " << hit.normal.transpose();
-      EXPECT_DOUBLE_EQ(0.25, hit.fraction);
-    }
+      auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kSphereSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput =
+        StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
 
-    // Ray 1 - misses; NaN fraction, NaN point/normal.
-    {
-      const auto &miss = results[1];
-      EXPECT_FALSE(miss.IsHit());
-      EXPECT_TRUE(miss.point.array().isNaN().all())
-        << "miss point should be NaN: " << miss.point.transpose();
-      EXPECT_TRUE(miss.normal.array().isNaN().all())
-        << "miss normal should be NaN: " << miss.normal.transpose();
+      using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+      using RayQuery = World::RayQuery;
+      using RayIntersection = World::RayIntersection;
+      using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+      // Build a batch: first ray hits the sphere, second misses
+      std::vector<RayQuery> rays = {
+        {Eigen::Vector3d(-2, 0, 2), Eigen::Vector3d(2, 0, 2)},   // hit
+        {Eigen::Vector3d(2, 0, 10), Eigen::Vector3d(-2, 0, 10)},  // miss
+      };
+
+      BatchedRayIntersectionData output;
+      world->GetBatchRayIntersectionFromLastStep(rays, output);
+      const auto &results = output.Get<std::vector<RayIntersection>>();
+
+      ASSERT_EQ(2u, results.size());
+
+      // Ray 0 - hits the unit sphere centred at (0,0,2)
+      {
+        const auto &hit = results[0];
+        EXPECT_TRUE(hit.IsHit());
+        double epsilon = 1e-3;
+        EXPECT_TRUE(hit.point.isApprox(Eigen::Vector3d(-1, 0, 2), epsilon))
+          << "hit point: " << hit.point.transpose();
+        EXPECT_TRUE(hit.normal.isApprox(Eigen::Vector3d(-1, 0, 0), epsilon))
+          << "hit normal: " << hit.normal.transpose();
+        EXPECT_DOUBLE_EQ(0.25, hit.fraction);
+      }
+
+      // Ray 1 - misses; NaN fraction, NaN point/normal.
+      {
+        const auto &miss = results[1];
+        EXPECT_FALSE(miss.IsHit());
+        EXPECT_TRUE(miss.point.array().isNaN().all())
+          << "miss point should be NaN: " << miss.point.transpose();
+        EXPECT_TRUE(miss.normal.array().isNaN().all())
+          << "miss normal should be NaN: " << miss.normal.transpose();
+      }
     }
   }
 }
@@ -2335,26 +2381,32 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            EmptyBatchRayIntersections)
 {
+  std::vector<std::string> supportedCollisionDetectors =
+    {"ode", "bullet"};
+
   for (const std::string &name : this->pluginNames)
   {
-    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
-        this->loader,
-        name,
-        common_test::worlds::kSphereSdf);
-    world->SetCollisionDetector("bullet");
-    auto checkedOutput =
-      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
-    EXPECT_TRUE(checkedOutput);
+    for (const std::string &collisionDetector : supportedCollisionDetectors)
+    {
+      auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kSphereSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput =
+        StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
 
-    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
-    using RayQuery = World::RayQuery;
-    using RayIntersection = World::RayIntersection;
-    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+      using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+      using RayQuery = World::RayQuery;
+      using RayIntersection = World::RayIntersection;
+      using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
 
-    std::vector<RayQuery> rays;  // intentionally empty
-    BatchedRayIntersectionData output;
-    world->GetBatchRayIntersectionFromLastStep(rays, output);
-    EXPECT_TRUE(output.Get<std::vector<RayIntersection>>().empty());
+      std::vector<RayQuery> rays;  // intentionally empty
+      BatchedRayIntersectionData output;
+      world->GetBatchRayIntersectionFromLastStep(rays, output);
+      EXPECT_TRUE(output.Get<std::vector<RayIntersection>>().empty());
+    }
   }
 }
 
@@ -2363,7 +2415,7 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            UnsupportedBatchRayIntersections)
 {
   std::vector<std::string> unsupportedCollisionDetectors =
-    {"ode", "dart", "fcl", "banana"};
+    {"dart", "fcl"};
 
   for (const std::string &name : this->pluginNames)
   {
@@ -2405,59 +2457,65 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
            LargeBatchRayIntersections)
 {
+  std::vector<std::string> supportedCollisionDetectors =
+    {"ode", "bullet"};
+
   for (const std::string &name : this->pluginNames)
   {
-    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
-        this->loader,
-        name,
-        common_test::worlds::kSphereSdf);
-    world->SetCollisionDetector("bullet");
-    auto checkedOutput =
-      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
-    EXPECT_TRUE(checkedOutput);
-
-    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
-    using RayQuery = World::RayQuery;
-    using RayIntersection = World::RayIntersection;
-    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
-
-    // Sphere is centred at (0, 0, 2) with radius 1.
-    struct RayCase { RayQuery ray; bool expectedHit; };
-    const std::vector<RayCase> cases = {
-      // equator crossings
-      {{Eigen::Vector3d(-2, 0, 2),    Eigen::Vector3d(2, 0, 2)},    true},
-      {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
-      // chords above/below equator
-      {{Eigen::Vector3d(-2, 0, 2.5),  Eigen::Vector3d(2, 0, 2.5)},  true},
-      {{Eigen::Vector3d(-2, 0, 1.5),  Eigen::Vector3d(2, 0, 1.5)},  true},
-      // vertical shots
-      {{Eigen::Vector3d(0, 0, 5),     Eigen::Vector3d(0, 0, 1)},    true},
-      {{Eigen::Vector3d(0, 0, 10),    Eigen::Vector3d(0, 0, 2)},    true},
-      // repeat of first hit — verifies multiple hits in sequence
-      {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
-      // misses
-      {{Eigen::Vector3d(2, 0, 10),    Eigen::Vector3d(-2, 0, 10)},  false},
-      {{Eigen::Vector3d(0, 2, 20),    Eigen::Vector3d(0, -2, 20)},  false},
-      {{Eigen::Vector3d(5, 5, 2),     Eigen::Vector3d(10, 5, 2)},   false},
-      {{Eigen::Vector3d(3, 3, 2),     Eigen::Vector3d(5, 3, 2)},    false},
-      {{Eigen::Vector3d(-2, 1.5, 2),  Eigen::Vector3d(2, 1.5, 2)},  false},
-    };
-
-    std::vector<RayQuery> rays;
-    rays.reserve(cases.size());
-    for (const auto &c : cases)
-      rays.push_back(c.ray);
-
-    BatchedRayIntersectionData output;
-    world->GetBatchRayIntersectionFromLastStep(rays, output);
-    const auto &results = output.Get<std::vector<RayIntersection>>();
-
-    ASSERT_EQ(cases.size(), results.size());
-
-    for (std::size_t i = 0; i < cases.size(); ++i)
+    for (const std::string &collisionDetector : supportedCollisionDetectors)
     {
-      EXPECT_EQ(cases[i].expectedHit, results[i].IsHit())
-        << "ray index " << i << " hit mismatch";
+      auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kSphereSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput =
+        StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
+
+      using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+      using RayQuery = World::RayQuery;
+      using RayIntersection = World::RayIntersection;
+      using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+      // Sphere is centred at (0, 0, 2) with radius 1.
+      struct RayCase { RayQuery ray; bool expectedHit; };
+      const std::vector<RayCase> cases = {
+        // equator crossings
+        {{Eigen::Vector3d(-2, 0, 2),    Eigen::Vector3d(2, 0, 2)},    true},
+        {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
+        // chords above/below equator
+        {{Eigen::Vector3d(-2, 0, 2.5),  Eigen::Vector3d(2, 0, 2.5)},  true},
+        {{Eigen::Vector3d(-2, 0, 1.5),  Eigen::Vector3d(2, 0, 1.5)},  true},
+        // vertical shots
+        {{Eigen::Vector3d(0, 0, 5),     Eigen::Vector3d(0, 0, 1)},    true},
+        {{Eigen::Vector3d(0, 0, 10),    Eigen::Vector3d(0, 0, 2)},    true},
+        // repeat of first hit — verifies multiple hits in sequence
+        {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
+        // misses
+        {{Eigen::Vector3d(2, 0, 10),    Eigen::Vector3d(-2, 0, 10)},  false},
+        {{Eigen::Vector3d(0, 2, 20),    Eigen::Vector3d(0, -2, 20)},  false},
+        {{Eigen::Vector3d(5, 5, 2),     Eigen::Vector3d(10, 5, 2)},   false},
+        {{Eigen::Vector3d(3, 3, 2),     Eigen::Vector3d(5, 3, 2)},    false},
+        {{Eigen::Vector3d(-2, 1.5, 2),  Eigen::Vector3d(2, 1.5, 2)},  false},
+      };
+
+      std::vector<RayQuery> rays;
+      rays.reserve(cases.size());
+      for (const auto &c : cases)
+        rays.push_back(c.ray);
+
+      BatchedRayIntersectionData output;
+      world->GetBatchRayIntersectionFromLastStep(rays, output);
+      const auto &results = output.Get<std::vector<RayIntersection>>();
+
+      ASSERT_EQ(cases.size(), results.size());
+
+      for (std::size_t i = 0; i < cases.size(); ++i)
+      {
+        EXPECT_EQ(cases[i].expectedHit, results[i].IsHit())
+          << "ray index " << i << " hit mismatch";
+      }
     }
   }
 }

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -2368,6 +2368,11 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
       {
         const auto &miss = results[1];
         EXPECT_FALSE(miss.IsHit());
+        // gz-physics9 preserves NaN-on-miss for the batch API; +INF is a
+        // gz-physics10 change. This assertion blocks a future cherry-pick from
+        // main silently reintroducing the breaking change.
+        EXPECT_TRUE(std::isnan(miss.fraction))
+            << "gz-physics9 batch raycast must return NaN on miss, not +INF";
         EXPECT_TRUE(miss.point.array().isNaN().all())
           << "miss point should be NaN: " << miss.point.transpose();
         EXPECT_TRUE(miss.normal.array().isNaN().all())

--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -48,6 +48,7 @@
 #include <gz/physics/FreeGroup.hh>
 #include <gz/physics/GetBoundingBox.hh>
 #include <gz/physics/GetContacts.hh>
+#include <gz/physics/GetBatchRayIntersection.hh>
 #include <gz/physics/GetRayIntersection.hh>
 #include <gz/physics/Joint.hh>
 #include "gz/physics/SphereShape.hh"
@@ -2254,6 +2255,209 @@ TYPED_TEST(SimulationFeaturesRayIntersectionTest, UnsupportedRayIntersections)
       ASSERT_TRUE(rayIntersection.point.array().isNaN().any());
       ASSERT_TRUE(rayIntersection.normal.array().isNaN().any());
       ASSERT_TRUE(std::isnan(rayIntersection.fraction));
+    }
+  }
+}
+
+// The features that an engine must have to be loaded by this loader.
+struct FeaturesBatchRayIntersections : gz::physics::FeatureList<
+  gz::physics::sdf::ConstructSdfWorld,
+  gz::physics::GetBatchRayIntersectionFromLastStepFeature,
+  gz::physics::CollisionDetector,
+  gz::physics::ForwardStep
+> {};
+
+template <class T>
+class SimulationFeaturesBatchRayIntersectionTest :
+  public SimulationFeaturesTest<T>{};
+using SimulationFeaturesBatchRayIntersectionTestTypes =
+    ::testing::Types<FeaturesBatchRayIntersections>;
+TYPED_TEST_SUITE(SimulationFeaturesBatchRayIntersectionTest,
+                 SimulationFeaturesBatchRayIntersectionTestTypes);
+
+/////////////////////////////////////////////////
+TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
+           SupportedBatchRayIntersections)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+        this->loader,
+        name,
+        common_test::worlds::kSphereSdf);
+    world->SetCollisionDetector("bullet");
+    auto checkedOutput =
+      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+    EXPECT_TRUE(checkedOutput);
+
+    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+    using RayQuery = World::RayQuery;
+    using RayIntersection = World::RayIntersection;
+    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+    // Build a batch: first ray hits the sphere, second misses
+    std::vector<RayQuery> rays = {
+      {Eigen::Vector3d(-2, 0, 2), Eigen::Vector3d(2, 0, 2)},   // hit
+      {Eigen::Vector3d(2, 0, 10), Eigen::Vector3d(-2, 0, 10)},  // miss
+    };
+
+    BatchedRayIntersectionData output;
+    world->GetBatchRayIntersectionFromLastStep(rays, output);
+    const auto &results = output.Get<std::vector<RayIntersection>>();
+
+    ASSERT_EQ(2u, results.size());
+
+    // Ray 0 - hits the unit sphere centred at (0,0,2)
+    {
+      const auto &hit = results[0];
+      EXPECT_TRUE(hit.IsHit());
+      double epsilon = 1e-3;
+      EXPECT_TRUE(hit.point.isApprox(Eigen::Vector3d(-1, 0, 2), epsilon))
+        << "hit point: " << hit.point.transpose();
+      EXPECT_TRUE(hit.normal.isApprox(Eigen::Vector3d(-1, 0, 0), epsilon))
+        << "hit normal: " << hit.normal.transpose();
+      EXPECT_DOUBLE_EQ(0.25, hit.fraction);
+    }
+
+    // Ray 1 - misses; NaN fraction, NaN point/normal.
+    {
+      const auto &miss = results[1];
+      EXPECT_FALSE(miss.IsHit());
+      EXPECT_TRUE(miss.point.array().isNaN().all())
+        << "miss point should be NaN: " << miss.point.transpose();
+      EXPECT_TRUE(miss.normal.array().isNaN().all())
+        << "miss normal should be NaN: " << miss.normal.transpose();
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
+           EmptyBatchRayIntersections)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+        this->loader,
+        name,
+        common_test::worlds::kSphereSdf);
+    world->SetCollisionDetector("bullet");
+    auto checkedOutput =
+      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+    EXPECT_TRUE(checkedOutput);
+
+    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+    using RayQuery = World::RayQuery;
+    using RayIntersection = World::RayIntersection;
+    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+    std::vector<RayQuery> rays;  // intentionally empty
+    BatchedRayIntersectionData output;
+    world->GetBatchRayIntersectionFromLastStep(rays, output);
+    EXPECT_TRUE(output.Get<std::vector<RayIntersection>>().empty());
+  }
+}
+
+/////////////////////////////////////////////////
+TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
+           UnsupportedBatchRayIntersections)
+{
+  std::vector<std::string> unsupportedCollisionDetectors =
+    {"ode", "dart", "fcl", "banana"};
+
+  for (const std::string &name : this->pluginNames)
+  {
+    for (const std::string &collisionDetector : unsupportedCollisionDetectors)
+    {
+      auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+          this->loader,
+          name,
+          common_test::worlds::kSphereSdf);
+      world->SetCollisionDetector(collisionDetector);
+      auto checkedOutput =
+        StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+      EXPECT_TRUE(checkedOutput);
+
+      using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+      using RayQuery = World::RayQuery;
+      using RayIntersection = World::RayIntersection;
+      using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+      // ray would hit the sphere, but the collision detector does not
+      // support ray intersection - results must be NaN
+      std::vector<RayQuery> rays = {
+        {Eigen::Vector3d(-2, 0, 2), Eigen::Vector3d(2, 0, 2)},
+      };
+
+      BatchedRayIntersectionData output;
+      world->GetBatchRayIntersectionFromLastStep(rays, output);
+      const auto &results = output.Get<std::vector<RayIntersection>>();
+
+      ASSERT_EQ(1u, results.size());
+      EXPECT_FALSE(results[0].IsHit());
+      EXPECT_TRUE(results[0].point.array().isNaN().all());
+      EXPECT_TRUE(results[0].normal.array().isNaN().all());
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
+           LargeBatchRayIntersections)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
+        this->loader,
+        name,
+        common_test::worlds::kSphereSdf);
+    world->SetCollisionDetector("bullet");
+    auto checkedOutput =
+      StepWorld<FeaturesBatchRayIntersections>(world, true, 1).first;
+    EXPECT_TRUE(checkedOutput);
+
+    using World = gz::physics::World3d<FeaturesBatchRayIntersections>;
+    using RayQuery = World::RayQuery;
+    using RayIntersection = World::RayIntersection;
+    using BatchedRayIntersectionData = World::BatchedRayIntersectionData;
+
+    // Sphere is centred at (0, 0, 2) with radius 1.
+    struct RayCase { RayQuery ray; bool expectedHit; };
+    const std::vector<RayCase> cases = {
+      // equator crossings
+      {{Eigen::Vector3d(-2, 0, 2),    Eigen::Vector3d(2, 0, 2)},    true},
+      {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
+      // chords above/below equator
+      {{Eigen::Vector3d(-2, 0, 2.5),  Eigen::Vector3d(2, 0, 2.5)},  true},
+      {{Eigen::Vector3d(-2, 0, 1.5),  Eigen::Vector3d(2, 0, 1.5)},  true},
+      // vertical shots
+      {{Eigen::Vector3d(0, 0, 5),     Eigen::Vector3d(0, 0, 1)},    true},
+      {{Eigen::Vector3d(0, 0, 10),    Eigen::Vector3d(0, 0, 2)},    true},
+      // repeat of first hit — verifies multiple hits in sequence
+      {{Eigen::Vector3d(0, -2, 2),    Eigen::Vector3d(0, 2, 2)},    true},
+      // misses
+      {{Eigen::Vector3d(2, 0, 10),    Eigen::Vector3d(-2, 0, 10)},  false},
+      {{Eigen::Vector3d(0, 2, 20),    Eigen::Vector3d(0, -2, 20)},  false},
+      {{Eigen::Vector3d(5, 5, 2),     Eigen::Vector3d(10, 5, 2)},   false},
+      {{Eigen::Vector3d(3, 3, 2),     Eigen::Vector3d(5, 3, 2)},    false},
+      {{Eigen::Vector3d(-2, 1.5, 2),  Eigen::Vector3d(2, 1.5, 2)},  false},
+    };
+
+    std::vector<RayQuery> rays;
+    rays.reserve(cases.size());
+    for (const auto &c : cases)
+      rays.push_back(c.ray);
+
+    BatchedRayIntersectionData output;
+    world->GetBatchRayIntersectionFromLastStep(rays, output);
+    const auto &results = output.Get<std::vector<RayIntersection>>();
+
+    ASSERT_EQ(cases.size(), results.size());
+
+    for (std::size_t i = 0; i < cases.size(); ++i)
+    {
+      EXPECT_EQ(cases[i].expectedHit, results[i].IsHit())
+        << "ray index " << i << " hit mismatch";
     }
   }
 }

--- a/test/common_test/worlds/multiple_objects_complex.sdf
+++ b/test/common_test/worlds/multiple_objects_complex.sdf
@@ -1,0 +1,204 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="multiple_objects_complex">
+    <gravity>0 0 0</gravity>
+    <physics name="default_physics" type="ode">
+    </physics>
+
+    <!-- Far object first in SDF so it is inserted into ODE's linked list first.
+         ODE's hash space processes the linked list from head (last inserted) to
+         tail (first inserted), so the first inserted object is processed last.
+         With the buggy ODE raycast, the last processed object overwrites the
+         closest hit. This should cause the test to fail when the bug is not fixed.
+    -->
+    <model name="far_box">
+      <pose>8 0 1.5 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>4 4 4</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Many objects along the X axis to confuse spatial traversal -->
+    <model name="box_1">
+      <pose>2 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.6 0.6 0.6</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_1">
+      <pose>2.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="cylinder_1">
+      <pose>3 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="cylinder_link">
+        <collision name="cylinder_collision">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>0.5</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="box_2">
+      <pose>3.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_2">
+      <pose>4 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="cylinder_2">
+      <pose>4.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="cylinder_link">
+        <collision name="cylinder_collision">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.4</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="box_3">
+      <pose>5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.4 0.4 0.4</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_3">
+      <pose>5.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.15</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="cylinder_3">
+      <pose>6 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="cylinder_link">
+        <collision name="cylinder_collision">
+          <geometry>
+            <cylinder>
+              <radius>0.15</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="box_4">
+      <pose>6.5 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>0.3 0.3 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="sphere_4">
+      <pose>7 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Closest object last in SDF so it is inserted into ODE's linked list last.
+         It will be processed first, allowing a later processed (far) object to
+         overwrite the closest hit with the ODE raycast bug.
+    -->
+    <model name="sphere_close">
+      <pose>1 0 0 0 0 0</pose>
+      <static>true</static>
+      <link name="sphere_link">
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

## This is a backport

It was requested by a maintainer on #880: a Jetty backport of the CPU-lidar
raycast API that does **not** carry the NaN->+INF behavior change those PRs
introduced on `main`. The two upstream commits are cherry-picked with their
original authorship preserved.

## Summary

Backports two features to the Jetty LTS:

- **#880** adds `GetBatchRayIntersectionFromLastStepFeature`: submit all rays in
  one call (Bullet fast path via `btCollisionWorld::rayTest`), the raycast
  primitive CPU lidar is built on.
- **#976** adds the ODE collision-detector raycast implementation.

On `main`, #880 also changed `RayIntersectionT::fraction` on a ray *miss* from
`NaN` to `+INF` (REP-117), documented as a breaking change in #986. Cherry-picking
that verbatim would push the break onto the released `gz-physics9` LTS. **This
backport delivers both features while keeping gz-physics9's existing NaN-on-miss
semantics unchanged.**

What is preserved (no behavior or ABI change on 9.x):

- **Miss `fraction` stays `NaN`** at every site: the pre-existing per-ray path,
  the new batch API (Bullet and ODE), and the unsupported-detector fallback.
  `+INF` stays a `gz-physics10`-only change.
- **Per-ray return type is byte-identical to what 9.x shipped.** #880's
  `ExtraRayIntersectionData` (collision-shape-id) slot is new devel-only API,
  unused by the CPU-lidar batch path, and is intentionally **not** included, so
  `RayIntersectionData`'s type is unchanged and no shipped-method ABI is altered.
- **`RayIntersectionT` stays defined nested** inside
  `GetRayIntersectionFromLastStepFeature`; `RayIntersection.hh` is an alias to it.

Also added: `RayIntersectionT::IsHit() = std::isfinite(fraction)`, the portable
hit-check that is correct under both the 9.x (NaN) and 10.x (+INF) conventions,
plus a regression test pinning the batch API's miss `fraction` to `NaN` so a
future cherry-pick from `main` cannot silently reintroduce the break.

Deliberately excluded: #986 (migration note; there is no breaking change here)
and gz-sim#3554 (it only adapts a test to `+INF`; gz-sim10 keeps its
`std::isnan`).

## Backport Policy
- [x] Other (fill in yourself)

This PR **is itself the Jetty backport** of #880 and #976. Whether to carry the
raycast API further back (Ionic, Harmonic, Fortress) is a separate effort and is
left to maintainer discretion.

## Test it

```bash
colcon build --merge-install --packages-select gz-physics \
  --cmake-args '-DBUILD_TESTING=ON'
colcon test --packages-select gz-physics \
  --ctest-args -R COMMON_TEST_simulation_features_dartsim
```

`COMMON_TEST_simulation_features_dartsim` passes 24/24 across **both** the ode and
bullet detectors (Ubuntu Noble, matching gz-physics9 CI). The new regression test
asserts a batch-raycast miss reports `fraction == NaN`; injecting `+INF` fails it
(verified). Full `gz-physics` suite: **211/211, 0 regressions**.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature <!-- N/A: raycast API, no visual -->
- [x] Added tests
- [ ] Added example and/or tutorial <!-- N/A: low-level physics API; runnable example ships in the gz-sim PR -->
- [x] Updated documentation (as needed) <!-- inline comments documenting the deliberate NaN-on-miss divergence from gz-physics10 -->
- [ ] Updated migration guide (as needed) <!-- N/A: no breaking change on 9.x, that is the point -->
- [ ] Consider updating Python bindings (if the library has them) <!-- N/A -->
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code)) <!-- pending run against final commits -->
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise. <!-- BUILD.bazel entries carried from #880/#976 -->
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Opus 4.8 (Anthropic Claude Code)

**Note to maintainers**: This is a **backport**. Please use **Rebase and Merge**
(not Squash-Merge) so the per-commit `Signed-off-by`, `Co-authored-by`, and
`Assisted-by` trailers are retained. The upstream #880 and #976 cherry-picks keep
their original authorship and carry no AI trailer.