### PR TITLE
mujoco: Disable contact generation between bodies attached with a detachable joint

### DIFF
--- a/mujoco/src/Base.cc
+++ b/mujoco/src/Base.cc
@@ -193,8 +193,7 @@ bool Base::RecompileSpec(WorldInfo &_worldInfo) const
     UserDataHeader header;
     header.magic = kUserDataMagicNumber;
     header.worldInfo = &_worldInfo;
-    std::memcpy(_worldInfo.mjDataObj->userdata, &header,
-                sizeof(UserDataHeader));
+    std::memcpy(_worldInfo.mjDataObj->userdata, &header, sizeof(header));
   }
 
   mjcb_contactfilter = ContactFilterCallback;

--- a/mujoco/src/Base.cc
+++ b/mujoco/src/Base.cc
@@ -35,32 +35,38 @@ struct UserDataHeader
   WorldInfo *worldInfo;
 };
 
+// Calculate required userdata slots (each slot is a mjtNum)
+constexpr int kRequiredUserDataSlots =
+    (sizeof(UserDataHeader) + sizeof(mjtNum) - 1) / sizeof(mjtNum);
+
+WorldInfo *GetWorldInfoFromUserData(const mjModel *m, const mjData *d)
+{
+  if (m && m->nuserdata >= kRequiredUserDataSlots && d && d->userdata)
+  {
+    UserDataHeader header;
+    std::memcpy(&header, d->userdata, sizeof(header));
+    if (header.magic == kUserDataMagicNumber)
+    {
+      return header.worldInfo;
+    }
+  }
+  return nullptr;
+}
+
 int ContactFilterCallback(const mjModel *m, mjData *d, int g1, int g2)
 {
   int b1 = m->geom_bodyid[g1];
   int b2 = m->geom_bodyid[g2];
 
-  if (m->nuserdata == 2 && d && d->userdata)
+  WorldInfo *worldInfo = GetWorldInfoFromUserData(m, d);
+  if (worldInfo && !worldInfo->dynamicWeldClusterMap.empty())
   {
-    UserDataHeader header;
-    std::memcpy(&header, d->userdata, sizeof(UserDataHeader));
+    int c1 = worldInfo->dynamicWeldClusterMap[m->body_weldid[b1]];
+    int c2 = worldInfo->dynamicWeldClusterMap[m->body_weldid[b2]];
 
-    // Only run if this mjModel is ours as indicated by the magic number. We do
-    // this because ContactFilterCallback is a global callback.
-    if (header.magic == kUserDataMagicNumber)
+    if (c1 != -1 && c1 == c2)
     {
-      WorldInfo *worldInfo = header.worldInfo;
-
-      if (worldInfo && !worldInfo->dynamicWeldClusterMap.empty())
-      {
-        int c1 = worldInfo->dynamicWeldClusterMap[m->body_weldid[b1]];
-        int c2 = worldInfo->dynamicWeldClusterMap[m->body_weldid[b2]];
-
-        if (c1 != -1 && c1 == c2)
-        {
-          return 1;  // Exclude collision
-        }
-      }
+      return 1;  // Exclude collision
     }
   }
 
@@ -159,9 +165,8 @@ void resolveJointIndices(WorldInfo &_worldInfo)
       }
     }
   }
-
 }
-}
+}  // namespace
 
 bool Base::RecompileSpec(WorldInfo &_worldInfo) const
 {
@@ -170,7 +175,7 @@ bool Base::RecompileSpec(WorldInfo &_worldInfo) const
 
   // Set nuserdata so that the compiler allocates the requested amount of data
   // in mjData::userdata
-  _worldInfo.mjSpecObj->nuserdata = 2;
+  _worldInfo.mjSpecObj->nuserdata = kRequiredUserDataSlots;
 
   int rc = mj_recompile(_worldInfo.mjSpecObj, nullptr, _worldInfo.mjModelObj,
                         _worldInfo.mjDataObj);
@@ -182,8 +187,8 @@ bool Base::RecompileSpec(WorldInfo &_worldInfo) const
     return false;
   }
 
-  // Inject magic number and pointer to WorldInfo in the two userdata slots
-  if (_worldInfo.mjModelObj->nuserdata == 2)
+  // Inject magic number and pointer to WorldInfo in the userdata slots
+  if (_worldInfo.mjModelObj->nuserdata >= kRequiredUserDataSlots)
   {
     UserDataHeader header;
     header.magic = kUserDataMagicNumber;

--- a/mujoco/src/Base.cc
+++ b/mujoco/src/Base.cc
@@ -29,6 +29,52 @@ namespace mujoco
 {
 namespace {
 
+struct UserDataHeader
+{
+  uint64_t magic;
+  WorldInfo *worldInfo;
+};
+
+int ContactFilterCallback(const mjModel *m, mjData *d, int g1, int g2)
+{
+  int b1 = m->geom_bodyid[g1];
+  int b2 = m->geom_bodyid[g2];
+
+  if (m->nuserdata == 2 && d && d->userdata)
+  {
+    UserDataHeader header;
+    std::memcpy(&header, d->userdata, sizeof(UserDataHeader));
+
+    // Only run if this mjModel is ours as indicated by the magic number. We do
+    // this because ContactFilterCallback is a global callback.
+    if (header.magic == kUserDataMagicNumber)
+    {
+      WorldInfo *worldInfo = header.worldInfo;
+
+      if (worldInfo && !worldInfo->dynamicWeldClusterMap.empty())
+      {
+        int c1 = worldInfo->dynamicWeldClusterMap[m->body_weldid[b1]];
+        int c2 = worldInfo->dynamicWeldClusterMap[m->body_weldid[b2]];
+
+        if (c1 != -1 && c1 == c2)
+        {
+          return 1;  // Exclude collision
+        }
+      }
+    }
+  }
+
+  // Fallback to default contype/conaffinity mask filtering.
+  // The global callback replaces the default mechanism, so we must re-implement
+  // the bitmask check manually.
+  int contype1 = m->geom_contype[g1];
+  int conaffinity1 = m->geom_conaffinity[g1];
+  int contype2 = m->geom_contype[g2];
+  int conaffinity2 = m->geom_conaffinity[g2];
+
+  return !(contype1 & conaffinity2) && !(contype2 & conaffinity1);
+}
+
 // Store joint position, velocity, acceleration and force indices. This is an
 // optimization that avoids looking up these values in every simulation step.
 // Note: qvelAddr is also used for acceleration
@@ -122,6 +168,10 @@ bool Base::RecompileSpec(WorldInfo &_worldInfo) const
   if (!_worldInfo.specDirty)
     return true;
 
+  // Set nuserdata so that the compiler allocates the requested amount of data
+  // in mjData::userdata
+  _worldInfo.mjSpecObj->nuserdata = 2;
+
   int rc = mj_recompile(_worldInfo.mjSpecObj, nullptr, _worldInfo.mjModelObj,
                         _worldInfo.mjDataObj);
   _worldInfo.specDirty = false;
@@ -131,6 +181,18 @@ bool Base::RecompileSpec(WorldInfo &_worldInfo) const
               << "\n";
     return false;
   }
+
+  // Inject magic number and pointer to WorldInfo in the two userdata slots
+  if (_worldInfo.mjModelObj->nuserdata == 2)
+  {
+    UserDataHeader header;
+    header.magic = kUserDataMagicNumber;
+    header.worldInfo = &_worldInfo;
+    std::memcpy(_worldInfo.mjDataObj->userdata, &header,
+                sizeof(UserDataHeader));
+  }
+
+  mjcb_contactfilter = ContactFilterCallback;
 
   // Ensure prevBodyPoses is sized correctly for the new model
   _worldInfo.prevBodyPoses.clear();
@@ -162,6 +224,8 @@ bool Base::RecompileSpec(WorldInfo &_worldInfo) const
   }
 
   resolveJointIndices(_worldInfo);
+
+  _worldInfo.UpdateWeldExclusions();
 
   mj_forward(_worldInfo.mjModelObj, _worldInfo.mjDataObj);
   return true;

--- a/mujoco/src/Base.hh
+++ b/mujoco/src/Base.hh
@@ -26,6 +26,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <gz/math/AxisAlignedBox.hh>
@@ -36,6 +37,7 @@
 #include <gz/physics/Geometry.hh>
 #include <gz/physics/Implements.hh>
 #include <gz/physics/detail/EntityStorage.hh>
+#include <gz/physics/mujoco-plugin/Export.hh>
 
 namespace gz
 {
@@ -337,12 +339,14 @@ struct WorldInfo
 
 /// \brief Compute the mapping from body_weldid to dynamic cluster ID based
 /// on current dynamic weld constraints.
-/// \param[in] m The MuJoCo model
-/// \param[in] d The MuJoCo data (used to check which equality constraints are
-/// active)
+/// \param[in] extraEdges Optional list of additional (weld1, weld2) edges
 /// \return Vector of size m->nbody mapping body_weldid to dynamic cluster ID
 /// (-1 if none)
-std::vector<int> ComputeWeldExclusions(const mjModel *m, const mjData *d);
+// Make the symbol visible so that it can be called from a unit test.
+GZ_PHYSICS_MUJOCO_PLUGIN_VISIBLE
+std::vector<int> ComputeWeldExclusions(
+    const mjModel *_m, const mjData *_d,
+    const std::vector<std::pair<int, int>> &_extraEdges = {});
 
 class Base
 {

--- a/mujoco/src/Base.hh
+++ b/mujoco/src/Base.hh
@@ -43,6 +43,18 @@ namespace physics
 {
 namespace mujoco
 {
+/// \brief A magic number embedded in mjData->userdata to safely verify
+/// ownership of the stored pointer during the global ContactFilterCallback.
+/// The bytes spell out 'GZPHGZPH'.
+///
+/// Example of how this helps: MuJoCo's `mjcb_contactfilter` is a global
+/// callback that fires for *every* mjModel evaluated in the current process.
+/// If a user runs a different MuJoCo simulation (not managed by gz-physics)
+/// in the same process, and they happen to store a float value like `3.14` in
+/// `userdata`, the global callback would try to reinterpret `3.14` as a pointer
+/// and segfault. The magic number ensures we only unpack the pointer if the
+/// userdata was strictly injected by our plugin.
+constexpr uint64_t kUserDataMagicNumber = 0x475A5048475A5048ULL;
 
 /// \brief Format the scoped name of a joint axis, appending a suffix
 /// for secondary degrees of freedom if the axis index is greater than 0.
@@ -300,6 +312,10 @@ struct WorldInfo
   // Key2 is the scoped name of the model, including the world name
   detail::EntityStorage<std::shared_ptr<ModelInfo>, std::string> models;
 
+  /// \brief Vector mapping each body_weldid to a dynamic cluster ID,
+  /// or -1 if the body is not part of any dynamic weld constraint.
+  std::vector<int> dynamicWeldClusterMap;
+
   // Vector of ShapeInfo, indexed by mujoco geom id
   std::vector<std::shared_ptr<ShapeInfo>> geomIdToShapeInfo{};
 
@@ -313,7 +329,20 @@ struct WorldInfo
   /// The cache is invalidated right before mj_step in
   /// SimulationFeatures::WorldForwardStep
   std::vector<std::optional<Eigen::Vector3d>> ballJointPositionsCache{};
+
+  /// \brief Recompute rigid cluster connected components from active fixed
+  /// joints. Updates dynamicWeldClusterMap.
+  void UpdateWeldExclusions();
 };
+
+/// \brief Compute the mapping from body_weldid to dynamic cluster ID based
+/// on current dynamic weld constraints.
+/// \param[in] m The MuJoCo model
+/// \param[in] d The MuJoCo data (used to check which equality constraints are
+/// active)
+/// \return Vector of size m->nbody mapping body_weldid to dynamic cluster ID
+/// (-1 if none)
+std::vector<int> ComputeWeldExclusions(const mjModel *m, const mjData *d);
 
 class Base
 {

--- a/mujoco/src/FreeGroupFeatures.cc
+++ b/mujoco/src/FreeGroupFeatures.cc
@@ -116,6 +116,9 @@ void FreeGroupFeatures::SetFreeGroupWorldPose(
   auto worldInfo = modelInfo->worldInfo;
   auto *d = worldInfo->mjDataObj;
   auto *m = worldInfo->mjModelObj;
+  if (!d || !m)
+    return;
+
   const auto bodyId = mjs_getId(modelInfo->body->element);
   const auto jntadr = m->body_jntadr[bodyId];
   const Eigen::Quaterniond quat(_pose.rotation());
@@ -140,8 +143,48 @@ void FreeGroupFeatures::SetFreeGroupWorldPose(
   else
   {
     const auto qposadr = m->jnt_qposadr[jntadr];
-    mju_copy3(&d->qpos[qposadr], _pose.translation().data());
-    mju_copy4(&d->qpos[qposadr]+3, quatCoeffs);
+    const Eigen::Isometry3d oldRootPose =
+        convertPose(&d->qpos[qposadr], &d->qpos[qposadr + 3]);
+    const Eigen::Isometry3d deltaPose = _pose * oldRootPose.inverse();
+
+    int clusterId = -1;
+    if (bodyId >= 0 &&
+        bodyId < static_cast<int>(worldInfo->dynamicWeldClusterMap.size()))
+    {
+      clusterId = worldInfo->dynamicWeldClusterMap[bodyId];
+    }
+
+    if (clusterId != -1)
+    {
+      for (int b = 1; b < m->nbody; ++b)
+      {
+        if (b < static_cast<int>(worldInfo->dynamicWeldClusterMap.size()) &&
+            worldInfo->dynamicWeldClusterMap[b] == clusterId)
+        {
+          int bJntadr = m->body_jntadr[b];
+          if (bJntadr >= 0 && m->jnt_type[bJntadr] == mjJNT_FREE)
+          {
+            int bQposadr = m->jnt_qposadr[bJntadr];
+            const Eigen::Isometry3d bOldPose =
+                convertPose(&d->qpos[bQposadr], &d->qpos[bQposadr + 3]);
+            const Eigen::Isometry3d bNewPose = deltaPose * bOldPose;
+
+            const Eigen::Vector3d bPos = bNewPose.translation();
+            const Eigen::Quaterniond bQuat(bNewPose.rotation());
+            const double bQuatCoeffs[] = {
+                bQuat.w(), bQuat.x(), bQuat.y(), bQuat.z()};
+
+            mju_copy3(&d->qpos[bQposadr], bPos.data());
+            mju_copy4(&d->qpos[bQposadr + 3], bQuatCoeffs);
+          }
+        }
+      }
+    }
+    else
+    {
+      mju_copy3(&d->qpos[qposadr], _pose.translation().data());
+      mju_copy4(&d->qpos[qposadr] + 3, quatCoeffs);
+    }
   }
   mj_forward(m, d);
 }

--- a/mujoco/src/FreeGroupFeatures.cc
+++ b/mujoco/src/FreeGroupFeatures.cc
@@ -148,18 +148,16 @@ void FreeGroupFeatures::SetFreeGroupWorldPose(
     const Eigen::Isometry3d deltaPose = _pose * oldRootPose.inverse();
 
     int clusterId = -1;
-    if (bodyId >= 0 &&
-        bodyId < static_cast<int>(worldInfo->dynamicWeldClusterMap.size()))
+    if (!worldInfo->dynamicWeldClusterMap.empty())
     {
-      clusterId = worldInfo->dynamicWeldClusterMap[bodyId];
+      clusterId = worldInfo->dynamicWeldClusterMap[m->body_weldid[bodyId]];
     }
 
     if (clusterId != -1)
     {
       for (int b = 1; b < m->nbody; ++b)
       {
-        if (b < static_cast<int>(worldInfo->dynamicWeldClusterMap.size()) &&
-            worldInfo->dynamicWeldClusterMap[b] == clusterId)
+        if (worldInfo->dynamicWeldClusterMap[m->body_weldid[b]] == clusterId)
         {
           int bJntadr = m->body_jntadr[b];
           if (bJntadr >= 0 && m->jnt_type[bJntadr] == mjJNT_FREE)

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstddef>
 #include <memory>
+#include <numeric>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -993,69 +994,53 @@ Identity JointFeatures::AttachFixedJoint(
 }
 
 namespace {
-/// \brief A simple graph data structure to encapsulate adjacency lists
-/// and connected component extraction using contiguous memory vectors.
-struct Graph
+/// \brief Disjoint-set data structure (Union-Find) to compute connected
+/// components of welded body clusters using contiguous vectors.
+class DisjointSet
 {
-  std::vector<std::vector<int>> adj;
-
   /// \brief Constructor.
-  /// \param[in] _numNodes The number of nodes in the graph.
-  explicit Graph(int _numNodes) : adj(_numNodes)
+  /// \param[in] _n Number of elements.
+  public: explicit DisjointSet(std::size_t _n)
+    : parent(_n), weldCount(_n, 1)
   {
+    std::iota(this->parent.begin(), this->parent.end(), 0);
   }
 
-  /// \brief Add an undirected edge between two nodes.
-  /// \param[in] _u First node.
-  /// \param[in] _v Second node.
-  void AddEdge(int _u, int _v)
+  /// \brief Find representative set root with path compression.
+  /// \param[in] _i Element ID.
+  /// \return Root ID.
+  public: int Find(int _i)
   {
-    this->adj[_u].push_back(_v);
-    this->adj[_v].push_back(_u);
+    if (this->parent[_i] == _i)
+      return _i;
+    return this->parent[_i] = this->Find(this->parent[_i]);
   }
 
-  /// \brief Extract all connected components (clusters) from the graph.
-  /// \return A list of connected components, where each component is a
-  /// vector of node IDs. Isolated nodes are ignored.
-  std::vector<std::vector<int>> GetConnectedComponents() const
+  /// \brief Merge sets containing _i and _j.
+  /// \param[in] _i First element ID.
+  /// \param[in] _j Second element ID.
+  public: void Union(int _i, int _j)
   {
-    std::vector<std::vector<int>> components;
-    std::vector<bool> visited(this->adj.size(), false);
-
-    for (std::size_t i = 1; i < this->adj.size(); ++i)
+    int rootI = this->Find(_i);
+    int rootJ = this->Find(_j);
+    if (rootI != rootJ)
     {
-      if (visited[i] || this->adj[i].empty())
-        continue;
-
-      std::vector<int> cluster;
-      std::vector<int> q;
-      q.push_back(i);
-      visited[i] = true;
-
-      std::size_t head = 0;
-      while (head < q.size())
-      {
-        int curr = q[head++];
-        cluster.push_back(curr);
-
-        for (int neighbor : this->adj[curr])
-        {
-          if (!visited[neighbor])
-          {
-            visited[neighbor] = true;
-            q.push_back(neighbor);
-          }
-        }
-      }
-
-      // Only keep clusters with at least 2 bodies to form an excluded pair
-      if (cluster.size() > 1)
-      {
-        components.push_back(std::move(cluster));
-      }
+      this->parent[rootI] = rootJ;
+      this->weldCount[rootJ] += this->weldCount[rootI];
     }
-    return components;
   }
+
+  /// \brief Return the number of distinct weld groups merged into the set
+  /// containing _i.
+  /// \param[in] _i Element ID.
+  /// \return Count of merged weld groups.
+  public: int WeldCount(int _i)
+  {
+    return this->weldCount[this->Find(_i)];
+  }
+
+  private: std::vector<int> parent;
+  private: std::vector<int> weldCount;
 };
 }  // namespace
 
@@ -1064,12 +1049,13 @@ std::vector<int> ComputeWeldExclusions(
     const mjModel *_m, const mjData *_d,
     const std::vector<std::pair<int, int>> &_extraEdges)
 {
+  if (!_m || !_d)
+    return {};
+
   std::vector<int> clusterMap(_m->nbody, -1);
 
-  Graph weldGraph(_m->nbody);
-
   // --------------------------------------------------------------------------
-  // Step 1: Build the Weld Graph (Add edges for every welded connection)
+  // Step 1: Merge Dynamic Welded Connections into Disjoint Sets
   // --------------------------------------------------------------------------
 
   // We only add edges for dynamic active fixed joints.
@@ -1077,51 +1063,78 @@ std::vector<int> ComputeWeldExclusions(
   // natively computes them and assigns rigidly connected bodies the exact
   // same `body_weldid`.
   // MuJoCo's broadphase inherently drops collisions where weld1 == weld2.
-  // Our graph's nodes will represent these `body_weldid`s, not raw body IDs.
+  // Our DSU sets will merge these `body_weldid`s, not raw body IDs.
 
-  if (_m && _d)
-  {
-    for (int eqId = 0; eqId < _m->neq; ++eqId)
+  DisjointSet dsu(_m->nbody);
+
+  auto addEdge = [&](int b1, int b2) {
+    if (b1 > 0 && b2 > 0 && b1 < _m->nbody && b2 < _m->nbody)
     {
-      if (_m->eq_type[eqId] == mjEQ_WELD && _d->eq_active[eqId] == 1)
+      int w1 = _m->body_weldid[b1];
+      int w2 = _m->body_weldid[b2];
+      if (w1 != w2)
       {
-        int b1 = _m->eq_obj1id[eqId];
-        int b2 = _m->eq_obj2id[eqId];
-        if (b1 > 0 && b2 > 0 && b1 < _m->nbody && b2 < _m->nbody)
-        {
-          int w1 = _m->body_weldid[b1];
-          int w2 = _m->body_weldid[b2];
-          // Only add edge if they are in different kinematic trees
-          // (weld groups)
-          if (w1 != w2)
-          {
-            weldGraph.AddEdge(w1, w2);
-          }
-        }
+        dsu.Union(w1, w2);
       }
+    }
+  };
+
+  for (int eqId = 0; eqId < _m->neq; ++eqId)
+  {
+    if (_m->eq_type[eqId] == mjEQ_WELD && _d->eq_active[eqId] == 1)
+    {
+      addEdge(_m->eq_obj1id[eqId], _m->eq_obj2id[eqId]);
     }
   }
 
   for (const auto &[w1, w2] : _extraEdges)
   {
-    if (w1 != w2)
+    if (w1 > 0 && w2 > 0 && w1 < _m->nbody && w2 < _m->nbody && w1 != w2)
     {
-      weldGraph.AddEdge(w1, w2);
+      dsu.Union(w1, w2);
     }
   }
 
   // --------------------------------------------------------------------------
   // Step 2: Extract Connected Components & Assign Cluster IDs
   // --------------------------------------------------------------------------
+  // We re-loop over active equality constraints and extra edges to assign
+  // cluster IDs directly to their endpoints. This is O(K) in the number of
+  // active constraints (where K << N_bodies) and avoids extra heap memory
+  // allocations or scanning all N_bodies in the model.
 
-  const auto clusters = weldGraph.GetConnectedComponents();
+  std::vector<int> rootToClusterId(_m->nbody, -1);
+  int nextClusterId = 0;
 
-  for (std::size_t clusterId = 0; clusterId < clusters.size(); ++clusterId)
-  {
-    for (int w : clusters[clusterId])
+  auto assignCluster = [&](int b) {
+    if (b > 0 && b < _m->nbody)
     {
-      clusterMap[w] = static_cast<int>(clusterId);
+      int w = _m->body_weldid[b];
+      if (dsu.WeldCount(w) > 1)
+      {
+        int root = dsu.Find(w);
+        if (rootToClusterId[root] == -1)
+        {
+          rootToClusterId[root] = nextClusterId++;
+        }
+        clusterMap[w] = rootToClusterId[root];
+      }
     }
+  };
+
+  for (int eqId = 0; eqId < _m->neq; ++eqId)
+  {
+    if (_m->eq_type[eqId] == mjEQ_WELD && _d->eq_active[eqId] == 1)
+    {
+      assignCluster(_m->eq_obj1id[eqId]);
+      assignCluster(_m->eq_obj2id[eqId]);
+    }
+  }
+
+  for (const auto &[w1, w2] : _extraEdges)
+  {
+    assignCluster(w1);
+    assignCluster(w2);
   }
 
   return clusterMap;

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -20,6 +20,8 @@
 #include <cstddef>
 #include <memory>
 #include <string_view>
+#include <utility>
+#include <vector>
 #include <Eigen/Geometry>
 #include <gz/common/Console.hh>
 #include <gz/math/Helpers.hh>
@@ -803,6 +805,8 @@ void JointFeatures::DetachJoint(const Identity &_jointId)
     this->frames.erase(jointInfo->entityId);
 
     modelInfo->joints.RemoveEntity(jointInfo->name);
+
+    worldInfo->UpdateWeldExclusions();
   }
 }
 
@@ -967,8 +971,143 @@ Identity JointFeatures::AttachFixedJoint(
   {
     worldInfo->specDirty = true;
   }
+  else
+  {
+    worldInfo->UpdateWeldExclusions();
+  }
 
   return this->GenerateIdentity(jointInfo->entityId, jointInfo);
+}
+
+namespace {
+/// \brief A simple graph data structure to encapsulate adjacency lists
+/// and connected component extraction using contiguous memory vectors.
+struct Graph
+{
+  std::vector<std::vector<int>> adj;
+
+  /// \brief Constructor.
+  /// \param[in] _numNodes The number of nodes in the graph.
+  explicit Graph(int _numNodes) : adj(_numNodes)
+  {
+  }
+
+  /// \brief Add an undirected edge between two nodes.
+  /// \param[in] _u First node.
+  /// \param[in] _v Second node.
+  void AddEdge(int _u, int _v)
+  {
+    this->adj[_u].push_back(_v);
+    this->adj[_v].push_back(_u);
+  }
+
+  /// \brief Extract all connected components (clusters) from the graph.
+  /// \return A list of connected components, where each component is a
+  /// vector of node IDs. Isolated nodes are ignored.
+  std::vector<std::vector<int>> GetConnectedComponents() const
+  {
+    std::vector<std::vector<int>> components;
+    std::vector<bool> visited(this->adj.size(), false);
+
+    for (std::size_t i = 1; i < this->adj.size(); ++i)
+    {
+      if (visited[i] || this->adj[i].empty())
+        continue;
+
+      std::vector<int> cluster;
+      std::vector<int> q;
+      q.push_back(i);
+      visited[i] = true;
+
+      std::size_t head = 0;
+      while (head < q.size())
+      {
+        int curr = q[head++];
+        cluster.push_back(curr);
+
+        for (int neighbor : this->adj[curr])
+        {
+          if (!visited[neighbor])
+          {
+            visited[neighbor] = true;
+            q.push_back(neighbor);
+          }
+        }
+      }
+
+      // Only keep clusters with at least 2 bodies to form an excluded pair
+      if (cluster.size() > 1)
+      {
+        components.push_back(std::move(cluster));
+      }
+    }
+    return components;
+  }
+};
+}  // namespace
+
+/////////////////////////////////////////////////
+std::vector<int> ComputeWeldExclusions(const mjModel *m, const mjData *d)
+{
+  std::vector<int> clusterMap(m->nbody, -1);
+
+  Graph weldGraph(m->nbody);
+
+  // --------------------------------------------------------------------------
+  // Step 1: Build the Weld Graph (Add edges for every welded connection)
+  // --------------------------------------------------------------------------
+
+  // We only add edges for dynamic active fixed joints.
+  // We do NOT need to manually traverse kinematic trees because MuJoCo
+  // natively computes them and assigns rigidly connected bodies the exact
+  // same `body_weldid`.
+  // MuJoCo's broadphase inherently drops collisions where weld1 == weld2.
+  // Our graph's nodes will represent these `body_weldid`s, not raw body IDs.
+
+  for (int eqId = 0; eqId < m->neq; ++eqId)
+  {
+    if (m->eq_type[eqId] == mjEQ_WELD && d->eq_active[eqId] == 1)
+    {
+      int b1 = m->eq_obj1id[eqId];
+      int b2 = m->eq_obj2id[eqId];
+      if (b1 > 0 && b2 > 0 && b1 < m->nbody && b2 < m->nbody)
+      {
+        int w1 = m->body_weldid[b1];
+        int w2 = m->body_weldid[b2];
+        // Only add edge if they are in different kinematic trees (weld groups)
+        if (w1 != w2)
+        {
+          weldGraph.AddEdge(w1, w2);
+        }
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Step 2: Extract Connected Components & Assign Cluster IDs
+  // --------------------------------------------------------------------------
+
+  const auto clusters = weldGraph.GetConnectedComponents();
+
+  for (std::size_t clusterId = 0; clusterId < clusters.size(); ++clusterId)
+  {
+    for (int w : clusters[clusterId])
+    {
+      clusterMap[w] = static_cast<int>(clusterId);
+    }
+  }
+
+  return clusterMap;
+}
+
+/////////////////////////////////////////////////
+void WorldInfo::UpdateWeldExclusions()
+{
+  if (!this->mjModelObj)
+    return;
+
+  this->dynamicWeldClusterMap =
+      ComputeWeldExclusions(this->mjModelObj, this->mjDataObj);
 }
 
 }  // namespace mujoco

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -1068,7 +1068,7 @@ std::vector<int> ComputeWeldExclusions(
   DisjointSet dsu(_m->nbody);
 
   auto addEdge = [&](int b1, int b2) {
-    if (b1 > 0 && b2 > 0 && b1 < _m->nbody && b2 < _m->nbody)
+    if (b1 >= 0 && b2 >= 0 && b1 < _m->nbody && b2 < _m->nbody)
     {
       int w1 = _m->body_weldid[b1];
       int w2 = _m->body_weldid[b2];
@@ -1089,7 +1089,7 @@ std::vector<int> ComputeWeldExclusions(
 
   for (const auto &[w1, w2] : _extraEdges)
   {
-    if (w1 > 0 && w2 > 0 && w1 < _m->nbody && w2 < _m->nbody && w1 != w2)
+    if (w1 >= 0 && w2 >= 0 && w1 < _m->nbody && w2 < _m->nbody && w1 != w2)
     {
       dsu.Union(w1, w2);
     }
@@ -1107,7 +1107,7 @@ std::vector<int> ComputeWeldExclusions(
   int nextClusterId = 0;
 
   auto assignCluster = [&](int b) {
-    if (b > 0 && b < _m->nbody)
+    if (b >= 0 && b < _m->nbody)
     {
       int w = _m->body_weldid[b];
       if (dsu.WeldCount(w) > 1)

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -970,6 +970,19 @@ Identity JointFeatures::AttachFixedJoint(
   if (requireRecompile)
   {
     worldInfo->specDirty = true;
+    if (worldInfo->mjModelObj)
+    {
+      int b1 = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, childBodyName);
+      int b2 = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, parentBodyName);
+      if (b1 > 0 && b2 > 0 && b1 < worldInfo->mjModelObj->nbody &&
+          b2 < worldInfo->mjModelObj->nbody)
+      {
+        int w1 = worldInfo->mjModelObj->body_weldid[b1];
+        int w2 = worldInfo->mjModelObj->body_weldid[b2];
+        worldInfo->dynamicWeldClusterMap = ComputeWeldExclusions(
+            worldInfo->mjModelObj, worldInfo->mjDataObj, {{w1, w2}});
+      }
+    }
   }
   else
   {
@@ -1047,11 +1060,13 @@ struct Graph
 }  // namespace
 
 /////////////////////////////////////////////////
-std::vector<int> ComputeWeldExclusions(const mjModel *m, const mjData *d)
+std::vector<int> ComputeWeldExclusions(
+    const mjModel *_m, const mjData *_d,
+    const std::vector<std::pair<int, int>> &_extraEdges)
 {
-  std::vector<int> clusterMap(m->nbody, -1);
+  std::vector<int> clusterMap(_m->nbody, -1);
 
-  Graph weldGraph(m->nbody);
+  Graph weldGraph(_m->nbody);
 
   // --------------------------------------------------------------------------
   // Step 1: Build the Weld Graph (Add edges for every welded connection)
@@ -1064,22 +1079,34 @@ std::vector<int> ComputeWeldExclusions(const mjModel *m, const mjData *d)
   // MuJoCo's broadphase inherently drops collisions where weld1 == weld2.
   // Our graph's nodes will represent these `body_weldid`s, not raw body IDs.
 
-  for (int eqId = 0; eqId < m->neq; ++eqId)
+  if (_m && _d)
   {
-    if (m->eq_type[eqId] == mjEQ_WELD && d->eq_active[eqId] == 1)
+    for (int eqId = 0; eqId < _m->neq; ++eqId)
     {
-      int b1 = m->eq_obj1id[eqId];
-      int b2 = m->eq_obj2id[eqId];
-      if (b1 > 0 && b2 > 0 && b1 < m->nbody && b2 < m->nbody)
+      if (_m->eq_type[eqId] == mjEQ_WELD && _d->eq_active[eqId] == 1)
       {
-        int w1 = m->body_weldid[b1];
-        int w2 = m->body_weldid[b2];
-        // Only add edge if they are in different kinematic trees (weld groups)
-        if (w1 != w2)
+        int b1 = _m->eq_obj1id[eqId];
+        int b2 = _m->eq_obj2id[eqId];
+        if (b1 > 0 && b2 > 0 && b1 < _m->nbody && b2 < _m->nbody)
         {
-          weldGraph.AddEdge(w1, w2);
+          int w1 = _m->body_weldid[b1];
+          int w2 = _m->body_weldid[b2];
+          // Only add edge if they are in different kinematic trees
+          // (weld groups)
+          if (w1 != w2)
+          {
+            weldGraph.AddEdge(w1, w2);
+          }
         }
       }
+    }
+  }
+
+  for (const auto &[w1, w2] : _extraEdges)
+  {
+    if (w1 != w2)
+    {
+      weldGraph.AddEdge(w1, w2);
     }
   }
 

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -973,9 +973,9 @@ Identity JointFeatures::AttachFixedJoint(
     worldInfo->specDirty = true;
     if (worldInfo->mjModelObj)
     {
-      int b1 = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, childBodyName);
-      int b2 = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, parentBodyName);
-      if (b1 > 0 && b2 > 0 && b1 < worldInfo->mjModelObj->nbody &&
+      int b1 = mjs_getId(childLinkInfo->body->element);
+      int b2 = parentLinkInfo ? mjs_getId(parentLinkInfo->body->element) : 0;
+      if (b1 >= 0 && b2 >= 0 && b1 < worldInfo->mjModelObj->nbody &&
           b2 < worldInfo->mjModelObj->nbody)
       {
         int w1 = worldInfo->mjModelObj->body_weldid[b1];

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -862,11 +862,11 @@ Identity JointFeatures::AttachFixedJoint(
     gzerr << "Invalid worldInfo or modelInfo when attaching fixed joint.\n";
     return this->GenerateInvalidId();
   }
-  if (modelInfo->joints.HasEntity(_name))
+  std::string uniqueName = _name;
+  std::size_t counter = 1;
+  while (modelInfo->joints.HasEntity(uniqueName))
   {
-    gzerr << "There's already a joint with the same name [ " << _name
-          << " ].\n";
-    return this->GenerateInvalidId();
+    uniqueName = _name + "_" + std::to_string(counter++);
   }
 
   const char *childBodyName
@@ -876,7 +876,7 @@ Identity JointFeatures::AttachFixedJoint(
             ? mjs_getString(mjs_getName(parentLinkInfo->body->element))
             : "";
 
-  const std::string mjJointName = ::sdf::JoinName(modelInfo->name, _name);
+  const std::string mjJointName = ::sdf::JoinName(modelInfo->name, uniqueName);
 
   mjsEquality *eqSpec = mjs_asEquality(mjs_findElement(
       worldInfo->mjSpecObj, mjOBJ_EQUALITY, mjJointName.c_str()));
@@ -937,7 +937,7 @@ Identity JointFeatures::AttachFixedJoint(
 
   auto jointInfo =
     std::make_shared<JointInfo>(this->GetNextEntity(), modelInfo);
-  jointInfo->name = _name;
+  jointInfo->name = uniqueName;
   jointInfo->childBody = childLinkInfo->body;
   jointInfo->worldInfo = worldInfo;
   jointInfo->weldConstraintSpec = eqSpec;
@@ -961,7 +961,7 @@ Identity JointFeatures::AttachFixedJoint(
   }
 
   modelInfo->joints.AddEntity(
-    jointInfo->entityId, jointInfo, jointInfo->name, modelInfo->entityId);
+    jointInfo->entityId, jointInfo, uniqueName, modelInfo->entityId);
 
   if (requireRecompile)
   {

--- a/mujoco/src/WeldExclusions_TEST.cc
+++ b/mujoco/src/WeldExclusions_TEST.cc
@@ -49,7 +49,74 @@ struct TestFeatures: public gz::physics::FeatureList<
 using WorldPtr = gz::physics::World3dPtr<TestFeatures>;
 
 /////////////////////////////////////////////////
-TEST(WeldExclusionsTest, DynamicWeldConnectedComponents)
+class WeldExclusionsTest : public ::testing::Test
+{
+  protected: void SetUp() override
+  {
+    this->loader.LoadLib(mujoco_plugin_LIB);
+    this->plugin = this->loader.Instantiate("gz::physics::mujoco::Plugin");
+    ASSERT_TRUE(this->plugin);
+    this->engine =
+        gz::physics::RequestEngine3d<TestFeatures>::From(this->plugin);
+    ASSERT_TRUE(this->engine);
+  }
+
+  protected: WorldPtr LoadWorld(const std::string &_sdfString,
+                                WorldInfo **_worldInfo)
+  {
+    sdf::Root root;
+    if (!root.LoadSdfString(_sdfString).empty())
+      return nullptr;
+
+    const sdf::World *sdfWorld = root.WorldByIndex(0);
+    if (!sdfWorld)
+      return nullptr;
+
+    WorldPtr world = this->engine->ConstructWorld(*sdfWorld);
+    if (!world)
+      return nullptr;
+
+    if (_worldInfo)
+    {
+      *_worldInfo =
+          static_cast<WorldInfo *>(world->FullIdentity().ref.get());
+    }
+    return world;
+  }
+
+  protected: gz::physics::Link3dPtr<TestFeatures> GetLink(
+      const WorldPtr &_world, const std::string &_scopedName)
+  {
+    std::size_t pos = _scopedName.find("::");
+    if (pos == std::string::npos)
+      return nullptr;
+    auto model = _world->GetModel(_scopedName.substr(0, pos));
+    if (!model)
+      return nullptr;
+    return model->GetLink(_scopedName.substr(pos + 2));
+  }
+
+  protected: int GetWeldId(WorldInfo *_worldInfo, const std::string &_bodyName)
+  {
+    int b = mj_name2id(_worldInfo->mjModelObj, mjOBJ_BODY, _bodyName.c_str());
+    if (b < 0 || b >= _worldInfo->mjModelObj->nbody)
+      return -1;
+    return _worldInfo->mjModelObj->body_weldid[b];
+  }
+
+  protected: void Recompile(WorldInfo *_worldInfo)
+  {
+    mj_recompile(_worldInfo->mjSpecObj, nullptr, _worldInfo->mjModelObj,
+                 _worldInfo->mjDataObj);
+  }
+
+  private: gz::plugin::Loader loader;
+  private: gz::plugin::PluginPtr plugin;
+  private: gz::physics::Engine3dPtr<TestFeatures> engine;
+};
+
+/////////////////////////////////////////////////
+TEST_F(WeldExclusionsTest, DynamicWeldConnectedComponents)
 {
   const std::string sdfString = R"(
 <?xml version="1.0" ?>
@@ -104,59 +171,24 @@ TEST(WeldExclusionsTest, DynamicWeldConnectedComponents)
 </sdf>
 )";
 
-  gz::plugin::Loader loader;
-  loader.LoadLib(mujoco_plugin_LIB);
-
-  gz::plugin::PluginPtr mujoco =
-      loader.Instantiate("gz::physics::mujoco::Plugin");
-  ASSERT_TRUE(mujoco);
-
-  auto engine = gz::physics::RequestEngine3d<TestFeatures>::From(mujoco);
-  ASSERT_TRUE(engine);
-
-  sdf::Root root;
-  const sdf::Errors errors = root.LoadSdfString(sdfString);
-  ASSERT_TRUE(errors.empty());
-
-  const sdf::World *sdfWorld = root.WorldByIndex(0);
-  ASSERT_NE(nullptr, sdfWorld);
-
-  WorldPtr world = engine->ConstructWorld(*sdfWorld);
+  WorldInfo *worldInfo = nullptr;
+  WorldPtr world = this->LoadWorld(sdfString, &worldInfo);
   ASSERT_NE(nullptr, world);
-
-  auto *worldInfo = static_cast<WorldInfo *>(
-      world->FullIdentity().ref.get());
   ASSERT_NE(nullptr, worldInfo);
-  ASSERT_NE(nullptr, worldInfo->mjModelObj);
-  ASSERT_NE(nullptr, worldInfo->mjDataObj);
 
-  auto m1 = world->GetModel("M1");
-  ASSERT_NE(nullptr, m1);
-  auto m2 = world->GetModel("M2");
-  ASSERT_NE(nullptr, m2);
-
-  auto link1A = m1->GetLink("link1A");
-  auto link1B = m1->GetLink("link1B");
-  auto link1C = m1->GetLink("link1C");
-  auto link2A = m2->GetLink("link2A");
-  auto link2B = m2->GetLink("link2B");
-  ASSERT_TRUE(link1A && link1B && link1C && link2A && link2B);
+  auto link1B = this->GetLink(world, "M1::link1B");
+  auto link2B = this->GetLink(world, "M2::link2B");
+  ASSERT_TRUE(link1B && link2B);
 
   // Attach M2::link2B to M1::link1B using a dynamic fixed joint
   auto fixedJoint = link2B->AttachFixedJoint(link1B);
   ASSERT_NE(nullptr, fixedJoint);
 
-  int b1A = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M1::link1A");
-  int b1B = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M1::link1B");
-  int b1C = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M1::link1C");
-  int b2A = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M2::link2A");
-  int b2B = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M2::link2B");
-
-  int w1A = worldInfo->mjModelObj->body_weldid[b1A];
-  int w1B = worldInfo->mjModelObj->body_weldid[b1B];
-  int w1C = worldInfo->mjModelObj->body_weldid[b1C];
-  int w2A = worldInfo->mjModelObj->body_weldid[b2A];
-  int w2B = worldInfo->mjModelObj->body_weldid[b2B];
+  int w1A = this->GetWeldId(worldInfo, "M1::link1A");
+  int w1B = this->GetWeldId(worldInfo, "M1::link1B");
+  int w1C = this->GetWeldId(worldInfo, "M1::link1C");
+  int w2A = this->GetWeldId(worldInfo, "M2::link2A");
+  int w2B = this->GetWeldId(worldInfo, "M2::link2B");
 
   // Verify MuJoCo's native body_weldid mapping:
   // Fixed child link1B has the same weldid as its parent link1A.
@@ -165,14 +197,9 @@ TEST(WeldExclusionsTest, DynamicWeldConnectedComponents)
   // Non-fixed child link1C has a unique weldid (terminates rigid tree).
   EXPECT_NE(w1A, w1C);
 
-  auto recompile = [&]() {
-    mj_recompile(worldInfo->mjSpecObj, nullptr, worldInfo->mjModelObj,
-                 worldInfo->mjDataObj);
-  };
-
   // When dynamic weld constraint is active:
   // Tree 1 (link1A, link1B) and Tree 2 (link2A, link2B) are merged into one.
-  recompile();
+  this->Recompile(worldInfo);
   auto clusterMap =
       ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
   EXPECT_NE(-1, clusterMap[w1A]);
@@ -182,11 +209,214 @@ TEST(WeldExclusionsTest, DynamicWeldConnectedComponents)
 
   // Detach dynamic weld constraint:
   fixedJoint->Detach();
-  recompile();
+  this->Recompile(worldInfo);
   clusterMap =
       ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
 
   // Cross-tree bodies are no longer in an active dynamic cluster.
   EXPECT_EQ(-1, clusterMap[w1A]);
   EXPECT_EQ(-1, clusterMap[w2A]);
+}
+
+/////////////////////////////////////////////////
+TEST_F(WeldExclusionsTest, DynamicWeldMultipleClusters)
+{
+  const std::string sdfString = R"(
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="multiple_clusters_world">
+    <model name="MA"><link name="lA"/></model>
+    <model name="MB"><link name="lB"/></model>
+    <model name="MC"><link name="lC"/></model>
+    <model name="MD"><link name="lD"/></model>
+  </world>
+</sdf>
+)";
+
+  WorldInfo *worldInfo = nullptr;
+  WorldPtr world = this->LoadWorld(sdfString, &worldInfo);
+  ASSERT_NE(nullptr, world);
+  ASSERT_NE(nullptr, worldInfo);
+
+  auto linkA = this->GetLink(world, "MA::lA");
+  auto linkB = this->GetLink(world, "MB::lB");
+  auto linkC = this->GetLink(world, "MC::lC");
+  auto linkD = this->GetLink(world, "MD::lD");
+  ASSERT_TRUE(linkA && linkB && linkC && linkD);
+
+  // Cluster 1: A attached to B
+  linkA->AttachFixedJoint(linkB);
+  // Cluster 2: C attached to D
+  linkC->AttachFixedJoint(linkD);
+
+  this->Recompile(worldInfo);
+
+  int wA = this->GetWeldId(worldInfo, "MA::lA");
+  int wB = this->GetWeldId(worldInfo, "MB::lB");
+  int wC = this->GetWeldId(worldInfo, "MC::lC");
+  int wD = this->GetWeldId(worldInfo, "MD::lD");
+
+  auto clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+
+  // Cluster 1: A and B are in the same cluster
+  EXPECT_NE(-1, clusterMap[wA]);
+  EXPECT_EQ(clusterMap[wA], clusterMap[wB]);
+
+  // Cluster 2: C and D are in the same cluster
+  EXPECT_NE(-1, clusterMap[wC]);
+  EXPECT_EQ(clusterMap[wC], clusterMap[wD]);
+
+  // Cluster 1 and Cluster 2 are distinct
+  EXPECT_NE(clusterMap[wA], clusterMap[wC]);
+}
+
+/////////////////////////////////////////////////
+TEST_F(WeldExclusionsTest, DynamicWeldChainedClusters)
+{
+  const std::string sdfString = R"(
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="chained_clusters_world">
+    <model name="MA"><link name="lA"/></model>
+    <model name="MB"><link name="lB"/></model>
+    <model name="MC"><link name="lC"/></model>
+  </world>
+</sdf>
+)";
+
+  WorldInfo *worldInfo = nullptr;
+  WorldPtr world = this->LoadWorld(sdfString, &worldInfo);
+  ASSERT_NE(nullptr, world);
+  ASSERT_NE(nullptr, worldInfo);
+
+  auto linkA = this->GetLink(world, "MA::lA");
+  auto linkB = this->GetLink(world, "MB::lB");
+  auto linkC = this->GetLink(world, "MC::lC");
+  ASSERT_TRUE(linkA && linkB && linkC);
+
+  // Chain: A -> B -> C
+  linkA->AttachFixedJoint(linkB);
+  linkB->AttachFixedJoint(linkC);
+
+  this->Recompile(worldInfo);
+
+  int wA = this->GetWeldId(worldInfo, "MA::lA");
+  int wB = this->GetWeldId(worldInfo, "MB::lB");
+  int wC = this->GetWeldId(worldInfo, "MC::lC");
+
+  auto clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+
+  // All 3 models should belong to the exact same cluster
+  EXPECT_NE(-1, clusterMap[wA]);
+  EXPECT_EQ(clusterMap[wA], clusterMap[wB]);
+  EXPECT_EQ(clusterMap[wB], clusterMap[wC]);
+}
+
+/////////////////////////////////////////////////
+TEST_F(WeldExclusionsTest, DynamicWeldLoops)
+{
+  const std::string sdfString = R"(
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="loop_clusters_world">
+    <model name="MA"><link name="lA"/></model>
+    <model name="MB"><link name="lB"/></model>
+    <model name="MC"><link name="lC"/></model>
+  </world>
+</sdf>
+)";
+
+  WorldInfo *worldInfo = nullptr;
+  WorldPtr world = this->LoadWorld(sdfString, &worldInfo);
+  ASSERT_NE(nullptr, world);
+  ASSERT_NE(nullptr, worldInfo);
+
+  auto linkA = this->GetLink(world, "MA::lA");
+  auto linkB = this->GetLink(world, "MB::lB");
+  auto linkC = this->GetLink(world, "MC::lC");
+  ASSERT_TRUE(linkA && linkB && linkC);
+
+  // Loop: A -> B -> C -> A
+  auto jAB = linkA->AttachFixedJoint(linkB);
+  auto jBC = linkB->AttachFixedJoint(linkC);
+  auto jCA = linkC->AttachFixedJoint(linkA);
+
+  this->Recompile(worldInfo);
+
+  int wA = this->GetWeldId(worldInfo, "MA::lA");
+  int wB = this->GetWeldId(worldInfo, "MB::lB");
+  int wC = this->GetWeldId(worldInfo, "MC::lC");
+
+  auto clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+
+  // All 3 models in the loop share the same cluster
+  EXPECT_NE(-1, clusterMap[wA]);
+  EXPECT_EQ(clusterMap[wA], clusterMap[wB]);
+  EXPECT_EQ(clusterMap[wB], clusterMap[wC]);
+
+  // Break the loop (detach C->A).
+  // The remaining chain A->B->C keeps all 3 connected.
+  jCA->Detach();
+  this->Recompile(worldInfo);
+  clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+
+  EXPECT_NE(-1, clusterMap[wA]);
+  EXPECT_EQ(clusterMap[wA], clusterMap[wB]);
+  EXPECT_EQ(clusterMap[wB], clusterMap[wC]);
+
+  // Detach remaining joints. Now no connections remain.
+  jBC->Detach();
+  jAB->Detach();
+  this->Recompile(worldInfo);
+  clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+
+  EXPECT_EQ(-1, clusterMap[wA]);
+  EXPECT_EQ(-1, clusterMap[wB]);
+  EXPECT_EQ(-1, clusterMap[wC]);
+}
+
+/////////////////////////////////////////////////
+TEST_F(WeldExclusionsTest, DynamicWeldWorldBody)
+{
+  const std::string sdfString = R"(
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="world_body_weld_world">
+    <model name="MA"><link name="lA"/></model>
+    <model name="MB"><link name="lB"/></model>
+  </world>
+</sdf>
+)";
+
+  WorldInfo *worldInfo = nullptr;
+  WorldPtr world = this->LoadWorld(sdfString, &worldInfo);
+  ASSERT_NE(nullptr, world);
+  ASSERT_NE(nullptr, worldInfo);
+
+  auto linkA = this->GetLink(world, "MA::lA");
+  auto linkB = this->GetLink(world, "MB::lB");
+  ASSERT_TRUE(linkA && linkB);
+
+  // Attach linkA and linkB to worldBody (nullptr parent)
+  linkA->AttachFixedJoint(nullptr);
+  linkB->AttachFixedJoint(nullptr);
+
+  this->Recompile(worldInfo);
+
+  int wA = this->GetWeldId(worldInfo, "MA::lA");
+  int wB = this->GetWeldId(worldInfo, "MB::lB");
+  int wWorld = worldInfo->mjModelObj->body_weldid[0];  // worldBody
+
+  auto clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+
+  // Both models attached to world should belong to the same world cluster
+  EXPECT_NE(-1, clusterMap[wA]);
+  EXPECT_EQ(clusterMap[wA], clusterMap[wB]);
+  EXPECT_EQ(clusterMap[wA], clusterMap[wWorld]);
 }

--- a/mujoco/src/WeldExclusions_TEST.cc
+++ b/mujoco/src/WeldExclusions_TEST.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <sdf/Root.hh>
+#include <sdf/World.hh>
+
+#include <gz/plugin/Loader.hh>
+#include <gz/physics/FeatureList.hh>
+#include <gz/physics/FixedJoint.hh>
+#include <gz/physics/GetEntities.hh>
+#include <gz/physics/Joint.hh>
+#include <gz/physics/RequestEngine.hh>
+#include <gz/physics/sdf/ConstructWorld.hh>
+
+#include <mujoco/mujoco.h>
+
+#include "Base.hh"
+
+using gz::physics::mujoco::ComputeWeldExclusions;
+using gz::physics::mujoco::WorldInfo;
+
+struct TestFeatures: public gz::physics::FeatureList<
+    gz::physics::AttachFixedJointFeature,
+    gz::physics::DetachJointFeature,
+    gz::physics::GetModelFromWorld,
+    gz::physics::GetLinkFromModel,
+    gz::physics::sdf::ConstructSdfWorld>
+{
+};
+
+using WorldPtr = gz::physics::World3dPtr<TestFeatures>;
+
+/////////////////////////////////////////////////
+TEST(WeldExclusionsTest, DynamicWeldConnectedComponents)
+{
+  const std::string sdfString = R"(
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="weld_exclusions_world">
+    <!-- Tree 1 -->
+    <model name="M1">
+      <link name="link1A">
+        <collision name="c1">
+          <geometry><sphere><radius>0.1</radius></sphere></geometry>
+        </collision>
+      </link>
+      <joint name="j1B" type="fixed">
+        <parent>link1A</parent>
+        <child>link1B</child>
+      </joint>
+      <link name="link1B">
+        <collision name="c1">
+          <geometry><sphere><radius>0.1</radius></sphere></geometry>
+        </collision>
+      </link>
+      <joint name="j1C" type="revolute">
+        <parent>link1B</parent>
+        <child>link1C</child>
+        <axis><xyz>0 0 1</xyz></axis>
+      </joint>
+      <link name="link1C">
+        <collision name="c1">
+          <geometry><sphere><radius>0.1</radius></sphere></geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Tree 2 -->
+    <model name="M2">
+      <link name="link2A">
+        <collision name="c1">
+          <geometry><sphere><radius>0.1</radius></sphere></geometry>
+        </collision>
+      </link>
+      <joint name="j2B" type="fixed">
+        <parent>link2A</parent>
+        <child>link2B</child>
+      </joint>
+      <link name="link2B">
+        <collision name="c1">
+          <geometry><sphere><radius>0.1</radius></sphere></geometry>
+        </collision>
+      </link>
+    </model>
+  </world>
+</sdf>
+)";
+
+  gz::plugin::Loader loader;
+  loader.LoadLib(mujoco_plugin_LIB);
+
+  gz::plugin::PluginPtr mujoco =
+      loader.Instantiate("gz::physics::mujoco::Plugin");
+  ASSERT_TRUE(mujoco);
+
+  auto engine = gz::physics::RequestEngine3d<TestFeatures>::From(mujoco);
+  ASSERT_TRUE(engine);
+
+  sdf::Root root;
+  const sdf::Errors errors = root.LoadSdfString(sdfString);
+  ASSERT_TRUE(errors.empty());
+
+  const sdf::World *sdfWorld = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, sdfWorld);
+
+  WorldPtr world = engine->ConstructWorld(*sdfWorld);
+  ASSERT_NE(nullptr, world);
+
+  auto *worldInfo = static_cast<WorldInfo *>(
+      world->FullIdentity().ref.get());
+  ASSERT_NE(nullptr, worldInfo);
+  ASSERT_NE(nullptr, worldInfo->mjModelObj);
+  ASSERT_NE(nullptr, worldInfo->mjDataObj);
+
+  auto m1 = world->GetModel("M1");
+  ASSERT_NE(nullptr, m1);
+  auto m2 = world->GetModel("M2");
+  ASSERT_NE(nullptr, m2);
+
+  auto link1A = m1->GetLink("link1A");
+  auto link1B = m1->GetLink("link1B");
+  auto link1C = m1->GetLink("link1C");
+  auto link2A = m2->GetLink("link2A");
+  auto link2B = m2->GetLink("link2B");
+  ASSERT_TRUE(link1A && link1B && link1C && link2A && link2B);
+
+  // Attach M2::link2B to M1::link1B using a dynamic fixed joint
+  auto fixedJoint = link2B->AttachFixedJoint(link1B);
+  ASSERT_NE(nullptr, fixedJoint);
+
+  int b1A = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M1::link1A");
+  int b1B = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M1::link1B");
+  int b1C = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M1::link1C");
+  int b2A = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M2::link2A");
+  int b2B = mj_name2id(worldInfo->mjModelObj, mjOBJ_BODY, "M2::link2B");
+
+  int w1A = worldInfo->mjModelObj->body_weldid[b1A];
+  int w1B = worldInfo->mjModelObj->body_weldid[b1B];
+  int w1C = worldInfo->mjModelObj->body_weldid[b1C];
+  int w2A = worldInfo->mjModelObj->body_weldid[b2A];
+  int w2B = worldInfo->mjModelObj->body_weldid[b2B];
+
+  // Verify MuJoCo's native body_weldid mapping:
+  // Fixed child link1B has the same weldid as its parent link1A.
+  EXPECT_EQ(w1A, w1B);
+  EXPECT_EQ(w2A, w2B);
+  // Non-fixed child link1C has a unique weldid (terminates rigid tree).
+  EXPECT_NE(w1A, w1C);
+
+  auto recompile = [&]() {
+    mj_recompile(worldInfo->mjSpecObj, nullptr, worldInfo->mjModelObj,
+                 worldInfo->mjDataObj);
+  };
+
+  // When dynamic weld constraint is active:
+  // Tree 1 (link1A, link1B) and Tree 2 (link2A, link2B) are merged into one.
+  recompile();
+  auto clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+  EXPECT_NE(-1, clusterMap[w1A]);
+  EXPECT_EQ(clusterMap[w1A], clusterMap[w2A]);
+  // Non-fixed body link1C is NOT part of the dynamic weld cluster.
+  EXPECT_EQ(-1, clusterMap[w1C]);
+
+  // Detach dynamic weld constraint:
+  fixedJoint->Detach();
+  recompile();
+  clusterMap =
+      ComputeWeldExclusions(worldInfo->mjModelObj, worldInfo->mjDataObj);
+
+  // Cross-tree bodies are no longer in an active dynamic cluster.
+  EXPECT_EQ(-1, clusterMap[w1A]);
+  EXPECT_EQ(-1, clusterMap[w2A]);
+}

--- a/test/common_test/Worlds.hh
+++ b/test/common_test/Worlds.hh
@@ -33,6 +33,7 @@ const auto kCollisionPairContactPointSdf =
   CommonTestWorld("collision_pair_contact_point.sdf");
 const auto kContactSdf = CommonTestWorld("contact.sdf");
 const auto kDetachableJointWorld = CommonTestWorld("detachable_joint.world");
+const auto kDetachableJointContactSdf = CommonTestWorld("detachable_joint_contact.sdf");
 const auto kEmptySdf = CommonTestWorld("empty.sdf");
 const auto kFallingWorld = CommonTestWorld("falling.world");
 const auto kFallingAddedMassWorld = CommonTestWorld("falling_added_mass.world");

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -1579,6 +1579,7 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachDetach)
 using JointFeatureAttachDetachContactList = gz::physics::FeatureList<
     gz::physics::AttachFixedJointFeature,
     gz::physics::DetachJointFeature,
+    gz::physics::FindFreeGroupFeature,
     gz::physics::ForwardStep,
     gz::physics::GetContactsFromLastStepFeature,
     gz::physics::GetEngineInfo,
@@ -1587,6 +1588,7 @@ using JointFeatureAttachDetachContactList = gz::physics::FeatureList<
     gz::physics::GetModelFromWorld,
     gz::physics::LinkFrameSemantics,
     gz::physics::SetBasicJointState,
+    gz::physics::SetFreeGroupWorldPose,
     gz::physics::SetJointTransformFromParentFeature,
     gz::physics::sdf::ConstructSdfWorld
 >;
@@ -1650,7 +1652,7 @@ TYPED_TEST(JointFeaturesAttachDetachContactTest, JointAttachDetachContact)
     // 2. Attach fixed joint between link1_base and link2_base
     auto fixedJoint = link2Base->AttachFixedJoint(link1Base);
     ASSERT_NE(nullptr, fixedJoint);
-    
+
     // Set the transform from the parent (link1Base) to the joint (which is at link2Base origin)
     // link1_base is at (0, 0, 0.5) and link2_base is at (0.8, 0, 0.5) in world frame.
     Eigen::Isometry3d parentToJoint = Eigen::Isometry3d::Identity();
@@ -1683,6 +1685,85 @@ TYPED_TEST(JointFeaturesAttachDetachContactTest, JointAttachDetachContact)
     auto detachedContacts = world->GetContactsFromLastStep();
     // Contact points are generated again between the previously welded bodies
     EXPECT_GT(detachedContacts.size(), 0u);
+  }
+}
+
+/////////////////////////////////////////////////
+// Verify contact generation and exclusion when SetWorldPose is called on a
+// free group immediately after AttachFixedJoint, before world->Step().
+TYPED_TEST(JointFeaturesAttachDetachContactTest, JointAttachFixedGroupMoveContact)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet-featherstone")
+
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<JointFeatureAttachDetachContactList>::From(
+            plugin);
+    ASSERT_NE(nullptr, engine);
+
+    sdf::Root root;
+    const sdf::Errors errors =
+        root.Load(common_test::worlds::kDetachableJointContactSdf);
+    ASSERT_TRUE(errors.empty()) << errors.front();
+
+    auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    auto model1 = world->GetModel("M1");
+    auto model2 = world->GetModel("M2");
+    ASSERT_NE(nullptr, model1);
+    ASSERT_NE(nullptr, model2);
+
+    auto link1Base = model1->GetLink("link1_base");
+    auto link2Base = model2->GetLink("link2_base");
+    auto link2Moving = model2->GetLink("link2_moving");
+    ASSERT_NE(nullptr, link1Base);
+    ASSERT_NE(nullptr, link2Base);
+    ASSERT_NE(nullptr, link2Moving);
+
+    auto j2Prism = model2->GetJoint("j2_prism");
+    ASSERT_NE(nullptr, j2Prism);
+
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+
+    // 1. Initial step without attached joint: link1_base and link2_base touch
+    world->Step(output, state, input);
+    auto initialContacts = world->GetContactsFromLastStep();
+    EXPECT_GT(initialContacts.size(), 0u);
+
+    // 2. Attach fixed joint between link1_base and link2_base
+    auto fixedJoint = link2Base->AttachFixedJoint(link1Base);
+    ASSERT_NE(nullptr, fixedJoint);
+
+    Eigen::Isometry3d parentToJoint = Eigen::Isometry3d::Identity();
+    parentToJoint.translation() = Eigen::Vector3d(0.8, 0.0, 0.0);
+    fixedJoint->SetTransformFromParent(parentToJoint);
+
+    // 3. Move model1 immediately using free group BEFORE world->Step()
+    auto freeGroupM1 = model1->FindFreeGroup();
+    ASSERT_NE(nullptr, freeGroupM1);
+    gz::math::Pose3d movePose(0.1, 0, 0.5, 0, 0, 0);
+    freeGroupM1->SetWorldPose(gz::math::eigen3::convert(movePose));
+
+    // Step world and verify contact behavior
+    world->Step(output, state, input);
+    auto weldedContacts = world->GetContactsFromLastStep();
+    // Attached links must not generate contacts with each other
+    EXPECT_EQ(0u, weldedContacts.size());
+
+    // 4. Move prismatic moving link to collide with cross-model link
+    j2Prism->SetPosition(0, -0.7);
+
+    world->Step(output, state, input);
+    auto movingContacts = world->GetContactsFromLastStep();
+    // Contacts ARE generated when non-welded links touch
+    EXPECT_GT(movingContacts.size(), 0u);
   }
 }
 
@@ -2638,6 +2719,14 @@ TEST_F(FixedJointFreeGroupFeatureTestTypes, FixedJointFreeGroupMove)
 
     // Move parent model using free group
     freeGroupM1->SetWorldPose(gz::math::eigen3::convert(newModel1Pose));
+
+    // Verify immediate pose update for attached links before world->Step()
+    frameDataModel1Body = model1Body->FrameDataRelativeToWorld();
+    frameDataModel2Body = model2Body->FrameDataRelativeToWorld();
+    EXPECT_EQ(newModel1Pose,
+              gz::math::eigen3::convert(frameDataModel1Body.pose));
+    EXPECT_EQ(newModel2Pose,
+              gz::math::eigen3::convert(frameDataModel2Body.pose));
 
     for (std::size_t i = 0; i < numSteps; ++i)
     {

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -1576,6 +1576,116 @@ TYPED_TEST(JointFeaturesAttachDetachTest, JointAttachDetach)
   }
 }
 
+using JointFeatureAttachDetachContactList = gz::physics::FeatureList<
+    gz::physics::AttachFixedJointFeature,
+    gz::physics::DetachJointFeature,
+    gz::physics::ForwardStep,
+    gz::physics::GetContactsFromLastStepFeature,
+    gz::physics::GetEngineInfo,
+    gz::physics::GetJointFromModel,
+    gz::physics::GetLinkFromModel,
+    gz::physics::GetModelFromWorld,
+    gz::physics::LinkFrameSemantics,
+    gz::physics::SetBasicJointState,
+    gz::physics::SetJointTransformFromParentFeature,
+    gz::physics::sdf::ConstructSdfWorld
+>;
+
+template <class T>
+class JointFeaturesAttachDetachContactTest :
+  public JointFeaturesTest<T>{};
+using JointFeaturesAttachDetachContactTestTypes =
+  ::testing::Types<JointFeatureAttachDetachContactList>;
+TYPED_TEST_SUITE(JointFeaturesAttachDetachContactTest,
+                 JointFeaturesAttachDetachContactTestTypes);
+
+/////////////////////////////////////////////////
+// Verify contact generation and exclusion behavior during attach and detach operations.
+TYPED_TEST(JointFeaturesAttachDetachContactTest, JointAttachDetachContact)
+{
+  for (const std::string &name : this->pluginNames)
+  {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet-featherstone")
+
+    std::cout << "Testing plugin: " << name << std::endl;
+    gz::plugin::PluginPtr plugin = this->loader.Instantiate(name);
+
+    auto engine =
+        gz::physics::RequestEngine3d<JointFeatureAttachDetachContactList>::From(
+            plugin);
+    ASSERT_NE(nullptr, engine);
+
+    sdf::Root root;
+    const sdf::Errors errors = root.Load(common_test::worlds::kDetachableJointContactSdf);
+    ASSERT_TRUE(errors.empty()) << errors.front();
+
+    auto world = engine->ConstructWorld(*root.WorldByIndex(0));
+    ASSERT_NE(nullptr, world);
+
+    auto model1 = world->GetModel("M1");
+    auto model2 = world->GetModel("M2");
+    ASSERT_NE(nullptr, model1);
+    ASSERT_NE(nullptr, model2);
+
+    auto link1Base = model1->GetLink("link1_base");
+    auto link2Base = model2->GetLink("link2_base");
+    auto link2Moving = model2->GetLink("link2_moving");
+    ASSERT_NE(nullptr, link1Base);
+    ASSERT_NE(nullptr, link2Base);
+    ASSERT_NE(nullptr, link2Moving);
+
+    auto j2Prism = model2->GetJoint("j2_prism");
+    ASSERT_NE(nullptr, j2Prism);
+
+    gz::physics::ForwardStep::Output output;
+    gz::physics::ForwardStep::State state;
+    gz::physics::ForwardStep::Input input;
+
+    // 1. Initial step without attached joint: link1_base and link2_base
+    // touch/overlap, generating contacts
+    world->Step(output, state, input);
+    auto initialContacts = world->GetContactsFromLastStep();
+    EXPECT_GT(initialContacts.size(), 0u);
+
+    // 2. Attach fixed joint between link1_base and link2_base
+    auto fixedJoint = link2Base->AttachFixedJoint(link1Base);
+    ASSERT_NE(nullptr, fixedJoint);
+    
+    // Set the transform from the parent (link1Base) to the joint (which is at link2Base origin)
+    // link1_base is at (0, 0, 0.5) and link2_base is at (0.8, 0, 0.5) in world frame.
+    Eigen::Isometry3d parentToJoint = Eigen::Isometry3d::Identity();
+    parentToJoint.translation() = Eigen::Vector3d(0.8, 0.0, 0.0);
+    fixedJoint->SetTransformFromParent(parentToJoint);
+
+    world->Step(output, state, input);
+    auto weldedContacts = world->GetContactsFromLastStep();
+    // Motionless welded bodies produce ZERO contacts between each other
+    EXPECT_EQ(0u, weldedContacts.size());
+
+    // 3. Move prismatic moving link from M2 (link2_moving) down to collide with
+    // revolute link from M1 (link1_moving)
+    j2Prism->SetPosition(0, -0.7);
+
+    world->Step(output, state, input);
+    auto movingContacts = world->GetContactsFromLastStep();
+    // Moving links with DOFs DO generate contact points when touching
+    // cross-model links
+    EXPECT_GT(movingContacts.size(), 0u);
+
+    // Reset link2_moving position
+    j2Prism->SetPosition(0, 0.0);
+    world->Step(output, state, input);
+
+    // 4. Detach fixed joint
+    fixedJoint->Detach();
+
+    world->Step(output, state, input);
+    auto detachedContacts = world->GetContactsFromLastStep();
+    // Contact points are generated again between the previously welded bodies
+    EXPECT_GT(detachedContacts.size(), 0u);
+  }
+}
+
 /////////////////////////////////////////////////
 // Attach a fixed joint between links from non-static models to a link
 // from a model fixed to the world. Verify the models are not moving when

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -1429,16 +1429,11 @@ struct JointFeatureAttachDetachList : gz::physics::FeatureList<
     gz::physics::AttachFixedJointFeature,
     gz::physics::DetachJointFeature,
     gz::physics::ForwardStep,
-    gz::physics::GetBasicJointProperties,
-    gz::physics::GetBasicJointState,
     gz::physics::GetEngineInfo,
-    gz::physics::GetJointFromModel,
     gz::physics::GetLinkFromModel,
     gz::physics::GetModelFromWorld,
     gz::physics::LinkFrameSemantics,
-    gz::physics::SetBasicJointState,
     gz::physics::SetJointTransformFromParentFeature,
-    gz::physics::SetJointVelocityCommandFeature,
     gz::physics::sdf::ConstructSdfModel,
     gz::physics::sdf::ConstructSdfWorld
 > { };

--- a/test/common_test/joint_features.cc
+++ b/test/common_test/joint_features.cc
@@ -2552,7 +2552,6 @@ using FixedJointFreeGroupFeatureList = gz::physics::FeatureList<
     gz::physics::LinkFrameSemantics,
     gz::physics::SetBasicJointState,
     gz::physics::SetJointTransformFromParentFeature,
-    gz::physics::SetJointVelocityCommandFeature,
     gz::physics::sdf::ConstructSdfModel,
     gz::physics::sdf::ConstructSdfWorld
 >;
@@ -2671,7 +2670,6 @@ using FixedJointWeldFeatureList = gz::physics::FeatureList<
     gz::physics::SetBasicJointState,
     gz::physics::SetFixedJointWeldChildToParentFeature,
     gz::physics::SetJointTransformFromParentFeature,
-    gz::physics::SetJointVelocityCommandFeature,
     gz::physics::sdf::ConstructSdfModel,
     gz::physics::sdf::ConstructSdfWorld
 >;

--- a/test/common_test/worlds/detachable_joint_contact.sdf
+++ b/test/common_test/worlds/detachable_joint_contact.sdf
@@ -1,0 +1,179 @@
+<?xml version="1.0" ?>
+<sdf version="1.9">
+  <world name="detachable_joint_contact">
+    <gravity>0 0 0</gravity>
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+    <model name="M1">
+      <self_collide>true</self_collide>
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="link1_base">
+        <collision name="c1_base">
+          <geometry>
+            <box><size>1.0 1.0 1.0</size></box>
+          </geometry>
+        </collision>
+        <visual name="v1_base">
+          <geometry>
+            <box><size>1.0 1.0 1.0</size></box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.1 0.1 1</ambient>
+            <diffuse>0.8 0.1 0.1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="link1_fixed">
+        <pose>0 0.8 0.8 0 0 0</pose>
+        <collision name="c1_fixed">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+        </collision>
+        <visual name="v1_fixed">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+          <material>
+            <ambient>0.1 0.8 0.1 1</ambient>
+            <diffuse>0.1 0.8 0.1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="j1_fixed" type="fixed">
+        <parent>link1_base</parent>
+        <child>link1_fixed</child>
+      </joint>
+      <link name="link1_moving">
+        <pose>0.4 0 0.8 0 0 0</pose>
+        <collision name="c1_moving">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+        </collision>
+        <visual name="v1_moving">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+          <material>
+            <ambient>0.1 0.1 0.8 1</ambient>
+            <diffuse>0.1 0.1 0.8 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="j1_rev" type="revolute">
+        <parent>link1_fixed</parent>
+        <child>link1_moving</child>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <limit>
+            <lower>-10</lower>
+            <upper>10</upper>
+          </limit>
+        </axis>
+      </joint>
+      <plugin filename="gz-sim-detachable-joint-system"
+              name="gz::sim::systems::DetachableJoint">
+        <parent_link>link1_base</parent_link>
+        <child_model>M2</child_model>
+        <child_link>link2_base</child_link>
+        <detach_topic>/M1/detach</detach_topic>
+        <attach_topic>/M1/attach</attach_topic>
+      </plugin>
+      <plugin filename="gz-sim-joint-position-controller-system"
+              name="gz::sim::systems::JointPositionController">
+        <joint_name>j1_rev</joint_name>
+        <p_gain>100</p_gain>
+        <i_gain>0.1</i_gain>
+        <d_gain>10</d_gain>
+      </plugin>
+    </model>
+    <model name="M2">
+      <self_collide>true</self_collide>
+      <pose>0.8 0 0.5 0 0 0</pose>
+      <link name="link2_base">
+        <collision name="c2_base">
+          <geometry>
+            <box><size>1.0 1.0 1.0</size></box>
+          </geometry>
+        </collision>
+        <visual name="v2_base">
+          <geometry>
+            <box><size>1.0 1.0 1.0</size></box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.1 1</ambient>
+            <diffuse>0.8 0.8 0.1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="link2_fixed">
+        <pose>0 -0.8 0.8 0 0 0</pose>
+        <collision name="c2_fixed">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+        </collision>
+        <visual name="v2_fixed">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.1 0.8 1</ambient>
+            <diffuse>0.8 0.1 0.8 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="j2_fixed" type="fixed">
+        <parent>link2_base</parent>
+        <child>link2_fixed</child>
+      </joint>
+      <link name="link2_moving">
+        <pose>-0.4 0 1.5 0 0 0</pose>
+        <collision name="c2_moving">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+        </collision>
+        <visual name="v2_moving">
+          <geometry>
+            <box><size>0.5 0.5 0.5</size></box>
+          </geometry>
+          <material>
+            <ambient>0.1 0.8 0.8 1</ambient>
+            <diffuse>0.1 0.8 0.8 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <joint name="j2_prism" type="prismatic">
+        <parent>link2_fixed</parent>
+        <child>link2_moving</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-10</lower>
+            <upper>10</upper>
+          </limit>
+        </axis>
+      </joint>
+      <plugin filename="gz-sim-joint-position-controller-system"
+              name="gz::sim::systems::JointPositionController">
+        <joint_name>j2_prism</joint_name>
+        <p_gain>100</p_gain>
+        <i_gain>0.1</i_gain>
+        <d_gain>10</d_gain>
+      </plugin>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
In the MuJoCo physics plugin, when a detachable joint is created dynamically at runtime via `AttachFixedJoint`, contact points were still being generated between the newly connected rigid components.

While MuJoCo natively prunes collision pairs within static rigid trees (`weldbody1 == weldbody2`), dynamic equality constraints (`mjEQ_WELD`) created across kinematic trees at runtime bypass this native broadphase check.

This PR resolves the issue by:
1. `ComputeWeldExclusions`: Performing connected component analysis on MuJoCo `body_weldid` trees and active dynamic `mjEQ_WELD` equality constraints to assign dynamic cluster IDs in O(1) lookup time.
2. `ContactFilterCallback`: Registering a custom `mjcb_contactfilter` callback that prunes contact generation if `dynamicWeldClusterMap[weld1] == dynamicWeldClusterMap[weld2]`, while preserving built-in `contype` and `conaffinity` bitmask filtering.

Additionally, a small issue was fixed in `AttachFixedJoint` to ensure unique joint names are generated when attaching fixed joints.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.6 Flash, Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
