### PR TITLE
Bump vendor Mujoco to latest 3.11.0

### DIFF
--- a/mujoco/src/SDFFeatures.cc
+++ b/mujoco/src/SDFFeatures.cc
@@ -137,17 +137,23 @@ void copyStandardJointAxisProperties(
     mjsJoint * _joint,
     const ::sdf::JointAxis *_sdfAxis)
 {
-  _joint->damping = _sdfAxis->Damping();
+  // Since MuJoCo 3.7.0, `damping` and `stiffness` are polynomial coefficient
+  // arrays. Element 0 is the linear coefficient, which is what SDFormat
+  // describes; the higher-order coefficients are left at their zero defaults.
+  _joint->damping[0] = _sdfAxis->Damping();
   _joint->frictionloss = _sdfAxis->Friction();
   _joint->springref = _sdfAxis->SpringReference();
-  _joint->stiffness = _sdfAxis->SpringStiffness();
-  _joint->limited = static_cast<int>(!std::isinf(_sdfAxis->Lower()) &&
-                                     !std::isinf(_sdfAxis->Upper()));
+  _joint->stiffness[0] = _sdfAxis->SpringStiffness();
+  _joint->limited = (!std::isinf(_sdfAxis->Lower()) &&
+                     !std::isinf(_sdfAxis->Upper()))
+                        ? mjLIMITED_TRUE
+                        : mjLIMITED_FALSE;
   _joint->range[0] = _sdfAxis->Lower();
   _joint->range[1] = _sdfAxis->Upper();
 
-  _joint->actfrclimited =
-      static_cast<int>(!std::isinf(infIfNeg(_sdfAxis->Effort())));
+  _joint->actfrclimited = !std::isinf(infIfNeg(_sdfAxis->Effort()))
+                              ? mjLIMITED_TRUE
+                              : mjLIMITED_FALSE;
 
   _joint->actfrcrange[0] = -infIfNeg(_sdfAxis->Effort());
   _joint->actfrcrange[1] = infIfNeg(_sdfAxis->Effort());
@@ -540,7 +546,7 @@ struct ModelKinematicStructure
           // premature solver clamping and massive numerical damping. By mapping
           // position limits purely onto the translational slide joint, we
           // ensure exact kinematic limit enforcement without solver resistance.
-          joint->limited = false;
+          joint->limited = mjLIMITED_FALSE;
         }
 
         joint2 = mjs_addJoint(child, nullptr);
@@ -553,9 +559,11 @@ struct ModelKinematicStructure
           // actuator effort limits are enforced purely on the primary
           // rotational hinge joint to avoid double-counting and physical unit
           // mismatches.
-          joint2->limited = static_cast<int>(!std::isinf(sdfAxis1->Lower()) &&
-                                             !std::isinf(sdfAxis1->Upper()));
-          if (joint2->limited)
+          joint2->limited = (!std::isinf(sdfAxis1->Lower()) &&
+                             !std::isinf(sdfAxis1->Upper()))
+                                ? mjLIMITED_TRUE
+                                : mjLIMITED_FALSE;
+          if (joint2->limited == mjLIMITED_TRUE)
           {
             const double pitch =
                 convertScrewThreadPitch(sdfJoint->ScrewThreadPitch());

--- a/mujoco/src/SDFFeatures_TEST.cc
+++ b/mujoco/src/SDFFeatures_TEST.cc
@@ -186,10 +186,12 @@ TEST_P(SDFFeatures_TEST, CheckMujocoData)
                    double springRest, double stiffness, double lower,
                    double upper, double maxForce)
   {
-    EXPECT_DOUBLE_EQ(damping, joint->damping);
+    // Element 0 of the damping/stiffness polynomials is the linear coefficient,
+    // which is the only one SDFormat populates.
+    EXPECT_DOUBLE_EQ(damping, joint->damping[0]);
     EXPECT_DOUBLE_EQ(friction, joint->frictionloss);
     EXPECT_DOUBLE_EQ(springRest, joint->springref);
-    EXPECT_DOUBLE_EQ(stiffness, joint->stiffness);
+    EXPECT_DOUBLE_EQ(stiffness, joint->stiffness[0]);
     EXPECT_DOUBLE_EQ(lower, joint->range[0]);
     EXPECT_DOUBLE_EQ(upper, joint->range[1]);
     EXPECT_DOUBLE_EQ(-maxForce, joint->actfrcrange[0]);
@@ -406,10 +408,12 @@ TEST_P(SDFFeatures_TEST, UniversalJoint)
                    double springRest, double stiffness, double lower,
                    double upper, double maxForce)
   {
-    EXPECT_DOUBLE_EQ(damping, joint->damping);
+    // Element 0 of the damping/stiffness polynomials is the linear coefficient,
+    // which is the only one SDFormat populates.
+    EXPECT_DOUBLE_EQ(damping, joint->damping[0]);
     EXPECT_DOUBLE_EQ(friction, joint->frictionloss);
     EXPECT_DOUBLE_EQ(springRest, joint->springref);
-    EXPECT_DOUBLE_EQ(stiffness, joint->stiffness);
+    EXPECT_DOUBLE_EQ(stiffness, joint->stiffness[0]);
     EXPECT_DOUBLE_EQ(lower, joint->range[0]);
     EXPECT_DOUBLE_EQ(upper, joint->range[1]);
     EXPECT_DOUBLE_EQ(-maxForce, joint->actfrcrange[0]);

--- a/third_party/mujoco_vendor/CMakeLists.txt
+++ b/third_party/mujoco_vendor/CMakeLists.txt
@@ -39,6 +39,13 @@ ExternalProject_Add(
   INSTALL_DIR    "${MUJOCO_INSTALL_DIR}"
   BUILD_BYPRODUCTS ${MUJOCO_BYPRODUCTS} # Needed for Ninja
   LOG_BUILD ON
+  # MuJoCo 3.11.0's cmake/FindOrFetch.cmake emits "Ignored CHECK_PASS without
+  # CHECK_START" for every fetched dependency. A bug in Mujoco code.
+  # The check-stack warning is emitted unconditionally, so -Wno-dev below
+  # does not silence it. Workaround: log the configure step to a file instead;
+  # combined with LOG_OUTPUT_ON_FAILURE the full output is still printed if it
+  # fails.
+  LOG_CONFIGURE ON
   LOG_OUTPUT_ON_FAILURE ON
   UPDATE_DISCONNECTED ON # Avoids configure/build steps everytime gz-physics built
   CMAKE_ARGS

--- a/third_party/mujoco_vendor/CMakeLists.txt
+++ b/third_party/mujoco_vendor/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 ExternalProject_Add(
   mujoco_ext
   GIT_REPOSITORY https://github.com/google-deepmind/mujoco
-  GIT_TAG 881544c0c58dc2e95fbd132a5ec90b99e012b6f7 # 3.5.0
+  GIT_TAG b85fdca54f0e0038b804af146a0b4e94199e00d0 # 3.11.0
   INSTALL_DIR    "${MUJOCO_INSTALL_DIR}"
   BUILD_BYPRODUCTS ${MUJOCO_BYPRODUCTS} # Needed for Ninja
   LOG_BUILD ON


### PR DESCRIPTION
# 🎉 New feature

Bump Mujoco version to use the latest 3.11.0

## Summary

The PR bumps Mujoco to the 3.11.0 release, agreed with @azeey in the last PMC. The required changes for building it are low, a couple of fixes detailed below in section A. I instructed the agent to detect in the Changelog the relevant aspects that have changed and affects our gz-physics plugin in the behaviour and there a good bunch of them that require an expert review, section B. 

### A) Compile breaking changes:

#### A.1 `mjsJoint.stiffness` / `mjsJoint.damping` became polynomial arrays — [**3.7.0**](https://mujoco.readthedocs.io/en/stable/changelog.html#version-3-3-7-october-13-2025)

> *"The `mjs` layer fields `stiffness` and `damping` in `mjsJoint` and `mjsTendon` have been widened
> from `mjtNum` scalars to `mjtNum[mjNPOLY+1]` arrays. Element 0 is the linear coefficient."*

This is the single most invasive change for the plugin. `mjNPOLY` is 2, so both fields are now `double[3]`.

**Sites:** `mujoco/src/SDFFeatures.cc:140,143` (`copyStandardJointAxisProperties`) and four assertions in `mujoco/src/SDFFeatures_TEST.cc`.

**Fix applied:** write/read index `[0]`. I think that SDFormat's `<damping>` and `<spring_stiffness>` are linear coefficients, so element 0 is the correct target and the higher-order terms keep their zero defaults. The IA agent claims: "Behaviour is identical to 3.5.0."

#### A.2 `mjtByte`/`int` fields became strongly-typed enums — [**3.9.0**](https://mujoco.readthedocs.io/en/stable/changelog.html#version-3-9-0-may-27-2026)

> *"Added `mjtBool` to represent boolean variables, replacing `mjtByte` across all boolean fields."*

Alongside `mjtBool`, several `int` spec fields were retyped to their real enums. `mjsJoint.limited` and `mjsJoint.actfrclimited` are now `mjtLimited`, and C++ rejects implicit `int → enum`.

**Sites:** `SDFFeatures.cc:144`, `:150`, `:543`, `:556`.

**Fix applied:** assign `mjLIMITED_TRUE` / `mjLIMITED_FALSE` explicitly, and compare against `mjLIMITED_TRUE` in the screw-joint branch. Values are unchanged (0/1), so this is purely a typing fix. `mjsEquality.active` (`mjtByte` → `mjtBool`) also changed but `eq->active = 1` still compiles, since `mjtBool` is a `bool` typedef in C++.

### B) Behaviour changes affecting gz-physics:

#### B.1 `implicitfast` free-body integration was replaced — **3.11.0, high relevance**

> *"Replaced midpoint integration of free bodies with gyroscopic derivatives in the `implicitfast`
> integrator … Spinning free bodies no longer gain energy, but tumbling motion is now mildly damped;
> models requiring long-horizon energy conservation of tumbling bodies in vacuum should use `RK4`.
> The `invdiscrete` flag no longer has any effect on forward dynamics."*

**This directly applies.** `EntityManagementFeatures.cc:102` hardcodes `option.integrator = mjINT_IMPLICITFAST` for every world the plugin creates.

Net effect for gz-physics users: free-body rotational dynamics changed between 3.5.0 and 3.11.0 — strictly more stable (no more energy gain on spinning bodies), at the cost of mild damping on tumbling bodies. The test suite does not cover long-horizon tumbling, so this passed unnoticed.

#### B.2 `multiccd` is now on by default — **3.8.0**

> *"The `multiccd` option (multiple contacts returned from the convex collision detection pipeline)
> is now enabled by default … Disable `multiccd` to recover the previous behavior."*

The plugin does not touch `enableflags`, so it inherits the new default. `GetContactsFromLastStep` (`SimulationFeatures.cc:159`) walks all `d->ncon` contacts, so **downstream consumers may now see more contact points per convex pair than with 3.5.0.** `COMMON_TEST_collisions_mujoco` passes, so no assertion depends on the old count — but anything counting contacts externally could notice.3.11.0 additionally extends multiccd to arbitrarily large meshes.

#### B.3 Coriolis term added to `connect`/`weld` equality bias — **3.7.0**

> *"Added the centripetal/Coriolis acceleration term Jv̇ to the constraint solver bias for `connect`
> and `weld` equality constraints. This significantly improves the stability of constrained
> mechanisms."*

Applies: the plugin uses `mjEQ_WELD` for `AttachFixedJoint`/detachable joints and `mjEQ_JOINT` for mimic and screw coupling. Expect *better* behaviour, but numerically different.

#### B.4 Solver changes — 3.9.0, 3.10.0, 3.11.0

The plugin never selects a solver, so it gets MuJoCo's default (Newton). Relevant accumulated changes: exact-diagonal option (`diagexact`, opt-in), Newton-decrement early termination (3.11.0 !28), and duality-gap zero-iteration exits for warmstarted solutions (3.11.0 !29). These change iteration counts and therefore produce small numerical differences at the same tolerance.

#### B.5 Mesh compiler fixes — 3.7.0, 3.10.0, 3.11.0

Three fixes land on the plugin's mesh path (`mjs_addMesh` with `uservert`/`userface`, plus the built-in cone via `mjs_makeMesh` with a non-unit `scale`):
- negative mesh scaling now handled correctly (3.7.0 !14),
- convex-hull polygon normals are now unit (3.10.0 !12),
- mesh normals are scaled as covectors, not vectors (3.11.0 !36).

All are corrections; the cone primitive uses `scale`, so !36 is directly relevant.

There are some other follow-ups recommended by the IA agent, I stored them in https://gist.github.com/j-rivero/c106bd3da58f7637c86119ff221c39e3 . I'm actively looking into `mju_threadpool` (parallelism for collision detection) but that will require fixes to our kinematics code.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5.0, Opus 5.0, Sonnet 5.0

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.