### PR TITLE
bullet: Remove hash map allocation on every update step

### DIFF
--- a/bullet/src/Base.hh
+++ b/bullet/src/Base.hh
@@ -23,6 +23,7 @@
 
 #include <assert.h>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -88,6 +89,9 @@ struct LinkInfo
   std::shared_ptr<btCompoundShape> collisionShape;
   std::shared_ptr<btRigidBody> link;
   std::vector<std::size_t> shapes = {};
+  /// \brief Cached pose from the previous physics step, used for performance
+  /// optimization.
+  std::optional<math::Pose3d> prevPose = std::nullopt;
 };
 
 struct CollisionInfo

--- a/bullet/src/SimulationFeatures.cc
+++ b/bullet/src/SimulationFeatures.cc
@@ -69,8 +69,6 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
   _changedPoses.entries.clear();
   _changedPoses.entries.reserve(this->links.size());
 
-  std::unordered_map<std::size_t, math::Pose3d> newPoses;
-
   for (const auto &[id, info] : this->links)
   {
     // make sure the link exists
@@ -81,23 +79,17 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
                 info->inertialPose.Inverse();
       wp.body = id;
 
-      auto iter = this->prevLinkPoses.find(id);
-      if ((iter == this->prevLinkPoses.end()) ||
-          !iter->second.Pos().Equal(wp.pose.Pos(), 1e-6) ||
-          !iter->second.Rot().Equal(wp.pose.Rot(), 1e-6))
+      // If the link's pose is new or has changed, save this new pose and
+      // add it to the output poses. Otherwise, keep the existing link pose
+      if (!info->prevPose.has_value() ||
+          !info->prevPose->Pos().Equal(wp.pose.Pos(), 1e-6) ||
+          !info->prevPose->Rot().Equal(wp.pose.Rot(), 1e-6))
       {
         _changedPoses.entries.push_back(wp);
-        newPoses[id] = wp.pose;
+        info->prevPose = wp.pose;
       }
-      else
-        newPoses[id] = iter->second;
     }
   }
-
-  // Save the new poses so that they can be used to check for updates in the
-  // next iteration. Re-setting this->prevLinkPoses with the contents of
-  // newPoses ensures that we aren't caching data for links that were removed
-  this->prevLinkPoses = std::move(newPoses);
 }
 
 }  // namespace bullet

--- a/bullet/src/SimulationFeatures.hh
+++ b/bullet/src/SimulationFeatures.hh
@@ -51,10 +51,6 @@ class SimulationFeatures :
   public: void Write(ChangedWorldPoses &_changedPoses) const;
 
   private: double stepSize = 0.001;
-
-  /// \brief link poses from the most recent pose change/update.
-  /// The key is the link's ID, and the value is the link's pose
-  private: mutable std::unordered_map<std::size_t, math::Pose3d> prevLinkPoses;
 };
 
 }  // namespace bullet


### PR DESCRIPTION
## Summary
PR #1005 removed the per-step std::unordered_map allocation in
Write(ChangedWorldPoses) for the dartsim and bullet-featherstone
plugins; the discrete bullet plugin was missed and still rebuilt
this->prevLinkPoses from scratch on every tick (one map allocation,
plus a hash and node allocation per link, then discarding the previous
map each step).

Move the previous-pose cache onto LinkInfo as a per-link
std::optional<math::Pose3d> prevPose, mirroring #1005's fix: no
per-tick allocation, no hashing, and removed links evict their cache
automatically when their LinkInfo is destroyed.

Behavior is unchanged: a pose is emitted when it is new or has moved
beyond the 1e-6 tolerance. The full bullet common-test suite passes
(68/68) and the build is warning-clean. The prevPose field carries a
= std::nullopt default so the aggregate LinkInfo initializer in
SDFFeatures stays -Wmissing-field-initializers-clean.

The changed behavior is already covered by the existing
`COMMON_TEST_simulation_features` common test, which asserts
`ChangedWorldPoses().entries` is non-empty on the first step
(`test/common_test/simulation_features.cc:185-186`); #1005 likewise
added no new test.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: GPT-5.5 (OpenAI)

AI was used to triage and identify the missed update to `bullet/` that was applied elsewhere. Code changes are my own.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
