### PR TITLE
Use custom comparator and wrapper around typeid() instead of type_index

### DIFF
--- a/include/gz/physics/CompositeData.hh
+++ b/include/gz/physics/CompositeData.hh
@@ -21,7 +21,6 @@
 #include <string>
 #include <map>
 #include <set>
-#include <typeindex>
 
 #include <gz/utils/SuppressWarning.hh>
 
@@ -964,7 +963,7 @@ namespace gz
 
       // We make this typedef public so that helper functions can use it without
       // being friends of the class.
-      public: using MapOfData = std::map<std::type_index, DataEntry>;
+      public: using MapOfData = std::map<std::string, DataEntry>;
 
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Map from the label of a data object type to its entry

--- a/include/gz/physics/CompositeData.hh
+++ b/include/gz/physics/CompositeData.hh
@@ -972,14 +972,10 @@ namespace gz
         const char *name = "";
         bool operator<(const TypeName &_other) const
         {
-          if (this->name == _other.name)
-            return false;
           return std::strcmp(this->name, _other.name) < 0;
         }
         bool operator==(const TypeName &_other) const
         {
-          if (this->name == _other.name)
-            return true;
           return std::strcmp(this->name, _other.name) == 0;
         }
         bool operator!=(const TypeName &_other) const

--- a/include/gz/physics/CompositeData.hh
+++ b/include/gz/physics/CompositeData.hh
@@ -18,9 +18,11 @@
 #ifndef GZ_PHYSICS_COMPOSITEDATA_HH_
 #define GZ_PHYSICS_COMPOSITEDATA_HH_
 
+#include <cstring>
 #include <string>
 #include <map>
 #include <set>
+#include <typeinfo>
 
 #include <gz/utils/SuppressWarning.hh>
 
@@ -961,9 +963,34 @@ namespace gz
       /// \private
       public: struct DataEntry;
 
+      /// \brief Lightweight wrapper around typeid(Data).name() with a custom
+      /// comparator to match types safely across dynamically loaded shared
+      /// library boundaries without heap allocations.
+      /// \private
+      public: struct TypeName
+      {
+        const char *name = "";
+        bool operator<(const TypeName &_other) const
+        {
+          if (this->name == _other.name)
+            return false;
+          return std::strcmp(this->name, _other.name) < 0;
+        }
+        bool operator==(const TypeName &_other) const
+        {
+          if (this->name == _other.name)
+            return true;
+          return std::strcmp(this->name, _other.name) == 0;
+        }
+        bool operator!=(const TypeName &_other) const
+        {
+          return !(*this == _other);
+        }
+      };
+
       // We make this typedef public so that helper functions can use it without
       // being friends of the class.
-      public: using MapOfData = std::map<std::string, DataEntry>;
+      public: using MapOfData = std::map<TypeName, DataEntry>;
 
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Map from the label of a data object type to its entry

--- a/include/gz/physics/CompositeData.hh
+++ b/include/gz/physics/CompositeData.hh
@@ -967,21 +967,23 @@ namespace gz
       /// comparator to match types safely across dynamically loaded shared
       /// library boundaries without heap allocations.
       /// \private
-      public: struct TypeName
+      public: class TypeName
       {
-        const char *name = "";
-        bool operator<(const TypeName &_other) const
+        public: TypeName(const std::type_info& _info) : _name(_info.name()) {}
+        public: const char *name() const { return this->_name; }
+        public: bool operator<(const TypeName &_other) const
         {
-          return std::strcmp(this->name, _other.name) < 0;
+          return std::strcmp(this->_name, _other._name) < 0;
         }
-        bool operator==(const TypeName &_other) const
+        public: bool operator==(const TypeName &_other) const
         {
-          return std::strcmp(this->name, _other.name) == 0;
+          return std::strcmp(this->_name, _other._name) == 0;
         }
-        bool operator!=(const TypeName &_other) const
+        public: bool operator!=(const TypeName &_other) const
         {
           return !(*this == _other);
         }
+        private: const char *_name = "";
       };
 
       // We make this typedef public so that helper functions can use it without

--- a/include/gz/physics/detail/CompositeData.hh
+++ b/include/gz/physics/detail/CompositeData.hh
@@ -94,7 +94,7 @@ namespace gz
       {
         bool inserted = false;
         const CompositeData::MapOfData::iterator it = _dataMap.insert(
-              std::make_pair(CompositeData::TypeName{typeid(Data).name()},
+              std::make_pair(CompositeData::TypeName(typeid(Data)),
                              CompositeData::DataEntry())).first;
 
         if (!it->second.data)
@@ -124,7 +124,7 @@ namespace gz
     {
       const MapOfData::iterator it = this->dataMap.insert(
             std::make_pair(
-              CompositeData::TypeName{typeid(Data).name()}, DataEntry())).first;
+              CompositeData::TypeName(typeid(Data)), DataEntry())).first;
 
       if (!it->second.data)
       {
@@ -160,7 +160,7 @@ namespace gz
     bool CompositeData::Remove()
     {
       const MapOfData::iterator it =
-          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
+          this->dataMap.find(CompositeData::TypeName(typeid(Data)));
 
       if (this->dataMap.end() == it || !it->second.data)
         return true;
@@ -186,7 +186,7 @@ namespace gz
     Data *CompositeData::Query(const QueryMode _mode)
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
+          this->dataMap.find(CompositeData::TypeName(typeid(Data)));
 
       if (this->dataMap.end() == it)
         return nullptr;
@@ -205,7 +205,7 @@ namespace gz
     const Data *CompositeData::Query(const QueryMode _mode) const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
+          this->dataMap.find(CompositeData::TypeName(typeid(Data)));
 
       if (this->dataMap.end() == it)
         return nullptr;
@@ -234,7 +234,7 @@ namespace gz
       DataStatus status;
 
       const MapOfData::const_iterator it =
-          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
+          this->dataMap.find(CompositeData::TypeName(typeid(Data)));
 
       if (this->dataMap.end() == it)
         return status;
@@ -254,7 +254,7 @@ namespace gz
     bool CompositeData::Unquery() const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
+          this->dataMap.find(CompositeData::TypeName(typeid(Data)));
 
       if (this->dataMap.end() == it)
         return false;
@@ -277,7 +277,7 @@ namespace gz
     {
       const MapOfData::iterator it = this->dataMap.insert(
             std::make_pair(
-              CompositeData::TypeName{typeid(Data).name()}, DataEntry())).first;
+              CompositeData::TypeName(typeid(Data)), DataEntry())).first;
 
       it->second.required = true;
       if (!it->second.data)
@@ -297,7 +297,7 @@ namespace gz
     bool CompositeData::Requires() const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
+          this->dataMap.find(CompositeData::TypeName(typeid(Data)));
 
       if (this->dataMap.end() == it)
         return false;

--- a/include/gz/physics/detail/CompositeData.hh
+++ b/include/gz/physics/detail/CompositeData.hh
@@ -18,8 +18,10 @@
 #ifndef GZ_PHYSICS_DETAIL_COMPOSITEDATA_HH_
 #define GZ_PHYSICS_DETAIL_COMPOSITEDATA_HH_
 
+#include <cstring>
 #include <memory>
 #include <utility>
+#include <typeinfo>
 
 #include <gz/utils/SuppressWarning.hh>
 
@@ -92,7 +94,7 @@ namespace gz
       {
         bool inserted = false;
         const CompositeData::MapOfData::iterator it = _dataMap.insert(
-              std::make_pair(typeid(Data).name(),
+              std::make_pair(CompositeData::TypeName{typeid(Data).name()},
                              CompositeData::DataEntry())).first;
 
         if (!it->second.data)
@@ -121,7 +123,8 @@ namespace gz
     Data &CompositeData::Get()
     {
       const MapOfData::iterator it = this->dataMap.insert(
-            std::make_pair(typeid(Data).name(), DataEntry())).first;
+            std::make_pair(
+              CompositeData::TypeName{typeid(Data).name()}, DataEntry())).first;
 
       if (!it->second.data)
       {
@@ -157,7 +160,7 @@ namespace gz
     bool CompositeData::Remove()
     {
       const MapOfData::iterator it =
-          this->dataMap.find(typeid(Data).name());
+          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
 
       if (this->dataMap.end() == it || !it->second.data)
         return true;
@@ -183,7 +186,7 @@ namespace gz
     Data *CompositeData::Query(const QueryMode _mode)
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(typeid(Data).name());
+          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
 
       if (this->dataMap.end() == it)
         return nullptr;
@@ -202,7 +205,7 @@ namespace gz
     const Data *CompositeData::Query(const QueryMode _mode) const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(typeid(Data).name());
+          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
 
       if (this->dataMap.end() == it)
         return nullptr;
@@ -231,7 +234,7 @@ namespace gz
       DataStatus status;
 
       const MapOfData::const_iterator it =
-          this->dataMap.find(typeid(Data).name());
+          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
 
       if (this->dataMap.end() == it)
         return status;
@@ -251,7 +254,7 @@ namespace gz
     bool CompositeData::Unquery() const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(typeid(Data).name());
+          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
 
       if (this->dataMap.end() == it)
         return false;
@@ -273,7 +276,8 @@ namespace gz
     Data &CompositeData::MakeRequired(Args &&..._args)
     {
       const MapOfData::iterator it = this->dataMap.insert(
-            std::make_pair(typeid(Data).name(), DataEntry())).first;
+            std::make_pair(
+              CompositeData::TypeName{typeid(Data).name()}, DataEntry())).first;
 
       it->second.required = true;
       if (!it->second.data)
@@ -293,7 +297,7 @@ namespace gz
     bool CompositeData::Requires() const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(typeid(Data).name());
+          this->dataMap.find(CompositeData::TypeName{typeid(Data).name()});
 
       if (this->dataMap.end() == it)
         return false;

--- a/include/gz/physics/detail/CompositeData.hh
+++ b/include/gz/physics/detail/CompositeData.hh
@@ -20,7 +20,6 @@
 
 #include <memory>
 #include <utility>
-#include <typeindex>
 
 #include <gz/utils/SuppressWarning.hh>
 
@@ -93,7 +92,7 @@ namespace gz
       {
         bool inserted = false;
         const CompositeData::MapOfData::iterator it = _dataMap.insert(
-              std::make_pair(std::type_index(typeid(Data)),
+              std::make_pair(typeid(Data).name(),
                              CompositeData::DataEntry())).first;
 
         if (!it->second.data)
@@ -122,7 +121,7 @@ namespace gz
     Data &CompositeData::Get()
     {
       const MapOfData::iterator it = this->dataMap.insert(
-            std::make_pair(std::type_index(typeid(Data)), DataEntry())).first;
+            std::make_pair(typeid(Data).name(), DataEntry())).first;
 
       if (!it->second.data)
       {
@@ -158,7 +157,7 @@ namespace gz
     bool CompositeData::Remove()
     {
       const MapOfData::iterator it =
-          this->dataMap.find(std::type_index(typeid(Data)));
+          this->dataMap.find(typeid(Data).name());
 
       if (this->dataMap.end() == it || !it->second.data)
         return true;
@@ -184,7 +183,7 @@ namespace gz
     Data *CompositeData::Query(const QueryMode _mode)
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(std::type_index(typeid(Data)));
+          this->dataMap.find(typeid(Data).name());
 
       if (this->dataMap.end() == it)
         return nullptr;
@@ -203,7 +202,7 @@ namespace gz
     const Data *CompositeData::Query(const QueryMode _mode) const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(std::type_index(typeid(Data)));
+          this->dataMap.find(typeid(Data).name());
 
       if (this->dataMap.end() == it)
         return nullptr;
@@ -232,7 +231,7 @@ namespace gz
       DataStatus status;
 
       const MapOfData::const_iterator it =
-          this->dataMap.find(std::type_index(typeid(Data)));
+          this->dataMap.find(typeid(Data).name());
 
       if (this->dataMap.end() == it)
         return status;
@@ -252,7 +251,7 @@ namespace gz
     bool CompositeData::Unquery() const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(std::type_index(typeid(Data)));
+          this->dataMap.find(typeid(Data).name());
 
       if (this->dataMap.end() == it)
         return false;
@@ -274,7 +273,7 @@ namespace gz
     Data &CompositeData::MakeRequired(Args &&..._args)
     {
       const MapOfData::iterator it = this->dataMap.insert(
-            std::make_pair(std::type_index(typeid(Data)), DataEntry())).first;
+            std::make_pair(typeid(Data).name(), DataEntry())).first;
 
       it->second.required = true;
       if (!it->second.data)
@@ -294,7 +293,7 @@ namespace gz
     bool CompositeData::Requires() const
     {
       const MapOfData::const_iterator it =
-          this->dataMap.find(std::type_index(typeid(Data)));
+          this->dataMap.find(typeid(Data).name());
 
       if (this->dataMap.end() == it)
         return false;

--- a/include/gz/physics/detail/SpecifyData.hh
+++ b/include/gz/physics/detail/SpecifyData.hh
@@ -36,7 +36,7 @@ namespace gz
       : CompositeData(),
         privateExpectData(
           this->dataMap.insert(
-            std::make_pair(CompositeData::TypeName{typeid(Expected).name()},
+            std::make_pair(CompositeData::TypeName(typeid(Expected)),
                            CompositeData::DataEntry())).first)
     {
       // Do nothing

--- a/include/gz/physics/detail/SpecifyData.hh
+++ b/include/gz/physics/detail/SpecifyData.hh
@@ -21,7 +21,6 @@
 #include <memory>
 #include <utility>
 #include <iostream>
-#include <typeindex>
 
 #include "gz/physics/SpecifyData.hh"
 
@@ -35,7 +34,7 @@ namespace gz
       : CompositeData(),
         privateExpectData(
           this->dataMap.insert(
-            std::make_pair(std::type_index(typeid(Expected)),
+            std::make_pair(typeid(Expected).name(),
                            CompositeData::DataEntry())).first)
     {
       // Do nothing

--- a/include/gz/physics/detail/SpecifyData.hh
+++ b/include/gz/physics/detail/SpecifyData.hh
@@ -18,9 +18,11 @@
 #ifndef GZ_PHYSICS_DETAIL_SPECIFYDATA_HH_
 #define GZ_PHYSICS_DETAIL_SPECIFYDATA_HH_
 
+#include <cstring>
 #include <memory>
 #include <utility>
 #include <iostream>
+#include <typeinfo>
 
 #include "gz/physics/SpecifyData.hh"
 
@@ -34,7 +36,7 @@ namespace gz
       : CompositeData(),
         privateExpectData(
           this->dataMap.insert(
-            std::make_pair(typeid(Expected).name(),
+            std::make_pair(CompositeData::TypeName{typeid(Expected).name()},
                            CompositeData::DataEntry())).first)
     {
       // Do nothing

--- a/src/CompositeData.cc
+++ b/src/CompositeData.cc
@@ -336,7 +336,7 @@ namespace gz
       for (const auto &entry : dataMap)
       {
         if (entry.second.data)
-          entries.insert(entries.end(), entry.first.name);
+          entries.insert(entries.end(), entry.first.name());
       }
 
       return entries;
@@ -353,7 +353,7 @@ namespace gz
       for (const auto &entry : dataMap)
       {
         if (entry.second.data && !entry.second.queried)
-          unqueried.insert(unqueried.end(), entry.first.name);
+          unqueried.insert(unqueried.end(), entry.first.name());
       }
 
       return unqueried;

--- a/src/CompositeData.cc
+++ b/src/CompositeData.cc
@@ -336,7 +336,7 @@ namespace gz
       for (const auto &entry : dataMap)
       {
         if (entry.second.data)
-          entries.insert(entries.end(), entry.first);
+          entries.insert(entries.end(), entry.first.name);
       }
 
       return entries;
@@ -353,7 +353,7 @@ namespace gz
       for (const auto &entry : dataMap)
       {
         if (entry.second.data && !entry.second.queried)
-          unqueried.insert(unqueried.end(), entry.first);
+          unqueried.insert(unqueried.end(), entry.first.name);
       }
 
       return unqueried;

--- a/src/CompositeData.cc
+++ b/src/CompositeData.cc
@@ -17,7 +17,6 @@
 
 #include <cassert>
 #include <utility>
-#include <typeindex>
 
 #include "gz/physics/CompositeData.hh"
 
@@ -337,7 +336,7 @@ namespace gz
       for (const auto &entry : dataMap)
       {
         if (entry.second.data)
-          entries.insert(entries.end(), entry.first.name());
+          entries.insert(entries.end(), entry.first);
       }
 
       return entries;
@@ -354,7 +353,7 @@ namespace gz
       for (const auto &entry : dataMap)
       {
         if (entry.second.data && !entry.second.queried)
-          unqueried.insert(unqueried.end(), entry.first.name());
+          unqueried.insert(unqueried.end(), entry.first);
       }
 
       return unqueried;

--- a/test/include/mock/MockCompositeData.hh
+++ b/test/include/mock/MockCompositeData.hh
@@ -19,38 +19,21 @@
 #define GZ_PHYSICS_TEST_MOCKCOMPOSITEDATA_HH_
 
 #include <gz/physics/CompositeData.hh>
-#include <gz/physics/GetContacts.hh>
-#include <gz/physics/FeatureList.hh>
-#include <gz/physics/FeaturePolicy.hh>
 
 namespace mock
 {
-  using ExtraContactData =
-      gz::physics::GetContactsFromLastStepFeature::ExtraContactDataT<
-          gz::physics::FeaturePolicy3d>;
-
-  struct MockCompositeDataFeature : public gz::physics::Feature
+  template <typename T>
+  struct MyCustomData
   {
-    template <typename PolicyT, typename FeaturesT>
-    class Engine : public virtual Feature::Engine<PolicyT, FeaturesT>
-    {
-      public: gz::physics::CompositeData GetCompositeData() const
-      {
-        return this->template Interface<MockCompositeDataFeature>()->
-            GetCompositeData();
-      }
-    };
-
-    template <typename PolicyT>
-    class Implementation : public virtual Feature::Implementation<PolicyT>
-    {
-      public: virtual gz::physics::CompositeData GetCompositeData() const = 0;
-    };
+    T depth;
   };
 
-  using MockCompositeDataList = gz::physics::FeatureList<
-      MockCompositeDataFeature
-  >;
-}
+  using ExtraContactData = MyCustomData<double>;
 
+  class MockCompositeDataPlugin
+  {
+    public: virtual ~MockCompositeDataPlugin() = default;
+    public: virtual gz::physics::CompositeData GetCompositeData() const = 0;
+  };
+}
 #endif

--- a/test/include/mock/MockCompositeData.hh
+++ b/test/include/mock/MockCompositeData.hh
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_PHYSICS_TEST_MOCKCOMPOSITEDATA_HH_
+#define GZ_PHYSICS_TEST_MOCKCOMPOSITEDATA_HH_
+
+#include <gz/physics/CompositeData.hh>
+#include <gz/physics/GetContacts.hh>
+#include <gz/physics/FeatureList.hh>
+#include <gz/physics/FeaturePolicy.hh>
+
+namespace mock
+{
+  using ExtraContactData =
+      gz::physics::GetContactsFromLastStepFeature::ExtraContactDataT<
+          gz::physics::FeaturePolicy3d>;
+
+  struct MockCompositeDataFeature : public gz::physics::Feature
+  {
+    template <typename PolicyT, typename FeaturesT>
+    class Engine : public virtual Feature::Engine<PolicyT, FeaturesT>
+    {
+      public: gz::physics::CompositeData GetCompositeData() const
+      {
+        return this->template Interface<MockCompositeDataFeature>()->
+            GetCompositeData();
+      }
+    };
+
+    template <typename PolicyT>
+    class Implementation : public virtual Feature::Implementation<PolicyT>
+    {
+      public: virtual gz::physics::CompositeData GetCompositeData() const = 0;
+    };
+  };
+
+  using MockCompositeDataList = gz::physics::FeatureList<
+      MockCompositeDataFeature
+  >;
+}
+
+#endif

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -5,11 +5,16 @@ endif()
 add_library(MockEntities SHARED MockEntities.cc)
 add_library(MockFrames SHARED frames.cc)
 add_library(MockJoints SHARED MockJoints.cc)
+add_library(MockCompositeData SHARED MockCompositeData.cc)
+if (NOT MSVC)
+  target_compile_options(MockCompositeData PRIVATE -fvisibility=hidden -fvisibility-inlines-hidden)
+endif()
 
 list(APPEND plugins
     MockEntities
     MockFrames
-    MockJoints)
+    MockJoints
+    MockCompositeData)
 if (DART_FOUND)
   list(APPEND plugins MockDoublePendulum)
 endif()

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -11,10 +11,10 @@ set_target_properties(MockCompositeData PROPERTIES
   VISIBILITY_INLINES_HIDDEN 1)
 
 list(APPEND plugins
+    MockCompositeData
     MockEntities
     MockFrames
-    MockJoints
-    MockCompositeData)
+    MockJoints)
 if (DART_FOUND)
   list(APPEND plugins MockDoublePendulum)
 endif()

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -6,9 +6,9 @@ add_library(MockEntities SHARED MockEntities.cc)
 add_library(MockFrames SHARED frames.cc)
 add_library(MockJoints SHARED MockJoints.cc)
 add_library(MockCompositeData SHARED MockCompositeData.cc)
-if (NOT MSVC)
-  target_compile_options(MockCompositeData PRIVATE -fvisibility=hidden -fvisibility-inlines-hidden)
-endif()
+set_target_properties(MockCompositeData PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN 1)
 
 list(APPEND plugins
     MockEntities

--- a/test/plugins/MockCompositeData.cc
+++ b/test/plugins/MockCompositeData.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "mock/MockCompositeData.hh"
+#include <gz/physics/Register.hh>
+
+namespace mock
+{
+  template <typename PolicyT>
+  class CompositeDataPlugin
+      : public gz::physics::Implements<PolicyT, MockCompositeDataList>
+  {
+    public: gz::physics::Identity InitiateEngine(
+        std::size_t /*_engineID*/) override
+    {
+      return this->GenerateIdentity(0);
+    }
+
+    public: gz::physics::CompositeData GetCompositeData() const override
+    {
+      gz::physics::CompositeData data;
+      auto &extra = data.Get<ExtraContactData>();
+      extra.depth = 42.0;
+      return data;
+    }
+  };
+
+  class CompositeDataPlugin3d
+      : public CompositeDataPlugin<gz::physics::FeaturePolicy3d> { };
+
+  GZ_PHYSICS_ADD_PLUGIN(
+      CompositeDataPlugin3d,
+      gz::physics::FeaturePolicy3d,
+      MockCompositeDataList)
+}

--- a/test/plugins/MockCompositeData.cc
+++ b/test/plugins/MockCompositeData.cc
@@ -16,20 +16,12 @@
 */
 
 #include "mock/MockCompositeData.hh"
-#include <gz/physics/Register.hh>
+#include <gz/plugin/Register.hh>
 
 namespace mock
 {
-  template <typename PolicyT>
-  class CompositeDataPlugin
-      : public gz::physics::Implements<PolicyT, MockCompositeDataList>
+  class CompositeDataPlugin : public virtual MockCompositeDataPlugin
   {
-    public: gz::physics::Identity InitiateEngine(
-        std::size_t /*_engineID*/) override
-    {
-      return this->GenerateIdentity(0);
-    }
-
     public: gz::physics::CompositeData GetCompositeData() const override
     {
       gz::physics::CompositeData data;
@@ -38,12 +30,6 @@ namespace mock
       return data;
     }
   };
-
-  class CompositeDataPlugin3d
-      : public CompositeDataPlugin<gz::physics::FeaturePolicy3d> { };
-
-  GZ_PHYSICS_ADD_PLUGIN(
-      CompositeDataPlugin3d,
-      gz::physics::FeaturePolicy3d,
-      MockCompositeDataList)
 }
+
+GZ_ADD_PLUGIN(mock::CompositeDataPlugin, mock::MockCompositeDataPlugin)

--- a/test/regression/1019_type_index_dso.cc
+++ b/test/regression/1019_type_index_dso.cc
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 
 #include <gz/plugin/Loader.hh>
-#include <gz/physics/RequestEngine.hh>
 #include "mock/MockCompositeData.hh"
 
 TEST(Issue1019Test, TypeIndexAcrossDSO)
@@ -27,14 +26,13 @@ TEST(Issue1019Test, TypeIndexAcrossDSO)
   const auto pluginNames = loader.LoadLib(MockCompositeData_LIB);
   ASSERT_EQ(1u, pluginNames.size());
 
-  auto plugin = loader.Instantiate("mock::CompositeDataPlugin3d");
+  auto plugin = loader.Instantiate("mock::CompositeDataPlugin");
   ASSERT_TRUE(plugin);
 
-  auto engine = gz::physics::RequestEngine3d<
-      mock::MockCompositeDataList>::From(plugin);
-  ASSERT_TRUE(engine);
+  auto *mockPlugin = plugin->QueryInterface<mock::MockCompositeDataPlugin>();
+  ASSERT_NE(nullptr, mockPlugin);
 
-  gz::physics::CompositeData data = engine->GetCompositeData();
+  gz::physics::CompositeData data = mockPlugin->GetCompositeData();
 
   // In PR #1019, CompositeData was changed to use std::type_index as the map
   // key. When a plugin DSO is compiled with hidden visibility for
@@ -42,11 +40,8 @@ TEST(Issue1019Test, TypeIndexAcrossDSO)
   // std::type_index(typeid(ExtraContactData)) has a different pointer in the
   // test binary than in the plugin DSO, causing Query to fail (return nullptr).
   const auto *extra = data.Query<mock::ExtraContactData>();
-  EXPECT_NE(nullptr, extra);
-  if (extra)
-  {
-    EXPECT_DOUBLE_EQ(42.0, extra->depth);
-  }
+  ASSERT_NE(nullptr, extra);
+  EXPECT_DOUBLE_EQ(42.0, extra->depth);
 }
 
 int main(int argc, char **argv)

--- a/test/regression/1019_type_index_dso.cc
+++ b/test/regression/1019_type_index_dso.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <gz/plugin/Loader.hh>
+#include <gz/physics/RequestEngine.hh>
+#include "mock/MockCompositeData.hh"
+
+TEST(Issue1019Test, TypeIndexAcrossDSO)
+{
+  gz::plugin::Loader loader;
+  const auto pluginNames = loader.LoadLib(MockCompositeData_LIB);
+  ASSERT_EQ(1u, pluginNames.size());
+
+  auto plugin = loader.Instantiate("mock::CompositeDataPlugin3d");
+  ASSERT_TRUE(plugin);
+
+  auto engine = gz::physics::RequestEngine3d<
+      mock::MockCompositeDataList>::From(plugin);
+  ASSERT_TRUE(engine);
+
+  gz::physics::CompositeData data = engine->GetCompositeData();
+
+  // In PR #1019, CompositeData was changed to use std::type_index as the map
+  // key. When a plugin DSO is compiled with hidden visibility for
+  // inlines/templates (e.g. in pixi / conda environments),
+  // std::type_index(typeid(ExtraContactData)) has a different pointer in the
+  // test binary than in the plugin DSO, causing Query to fail (return nullptr).
+  const auto *extra = data.Query<mock::ExtraContactData>();
+  EXPECT_NE(nullptr, extra);
+  if (extra)
+  {
+    EXPECT_DOUBLE_EQ(42.0, extra->depth);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -9,10 +9,8 @@ gz_build_tests(
     GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
   TEST_LIST list)
 
-if (BUILD_TESTING)
-  foreach(test ${list})
-    target_compile_definitions(${test} PRIVATE
-      "MockCompositeData_LIB=\"$<TARGET_FILE:MockCompositeData>\"")
-    add_dependencies(${test} MockCompositeData)
-  endforeach()
+if(TARGET REGRESSION_1019_type_index_dso)
+  target_compile_definitions(REGRESSION_1019_type_index_dso PRIVATE
+    "MockCompositeData_LIB=\"$<TARGET_FILE:MockCompositeData>\"")
+  add_dependencies(REGRESSION_1019_type_index_dso MockCompositeData)
 endif()

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -3,5 +3,16 @@ gz_get_sources(tests)
 gz_build_tests(
   TYPE REGRESSION
   SOURCES ${tests}
+  LIB_DEPS
+    gz-physics-test
   ENVIRONMENT
-    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+  TEST_LIST list)
+
+if (BUILD_TESTING)
+  foreach(test ${list})
+    target_compile_definitions(${test} PRIVATE
+      "MockCompositeData_LIB=\"$<TARGET_FILE:MockCompositeData>\"")
+    add_dependencies(${test} MockCompositeData)
+  endforeach()
+endif()


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The issue was surfaced [here](https://github.com/gazebosim/gz-physics/pull/1019#issuecomment-5172729649). Copying the description of the bug and the proposed fix here. 

This PR was largely generated with help from Gemini. 

> While the performance concern that motivated #1019 was completely valid (allocating a new `std::string` for every contact property during high-frequency physics steps is very expensive), `std::type_index` is fundamentally unsafe to use across dynamically loaded shared libraries (DSOs) on macOS and often on Linux if plugins are loaded with `RTLD_LOCAL`. 
> 
> The macOS Clang compiler (and `libc++`) does not guarantee that `std::type_info` instances for implicitly instantiated templates or inline structs are coalesced across library boundaries. As a result, when the test binary queries `std::type_index(typeid(ExtraContactDataT))`, it gets a different pointer than the one the `mujoco` plugin registered it with, and the `find()` fails.
> 
> **A better solution for #1019:**
> We can get the best of both worlds (zero heap allocations + safe cross-plugin type matching) by reverting `std::type_index` and instead using a lightweight wrapper around `typeid(Data).name()` with a custom comparator. 
> 
> Because `typeid(Data).name()` is guaranteed to return a static `const char*` that lives for the lifetime of the program, we can simply store the pointer and use `std::strcmp` for map lookups:
> 
> ```cpp
> struct TypeName {
>     const char* name;
>     bool operator<(const TypeName& other) const {
>         return std::strcmp(name, other.name) < 0;
>     }
> };
> 
> // Inside CompositeData:
> using MapOfData = std::map<TypeName, DataEntry>;
> 
> // Usage:
> this->dataMap.insert(std::make_pair(TypeName{typeid(Data).name()}, DataEntry()));
> ```
> 
> This completely eliminates the `std::string` allocations that #1019 was trying to solve, but correctly uses string comparison to match types safely across macOS plugin boundaries. 

## Testing
1. Checkout 045e5d2d352cc155a0f15c83827aee42016378e4, verify it fails (only on macOS, on Ubuntu it seems to pass)
2. Checkout 054890aa535791b476e8c83b8cda33058a8e58ac or 6ba44e07ea45a02b26d881a90c57bf8da2515bb3 and verify the test passes

## Performance
Performance seems to be on par with the `type_index` implementation
Ran `./build/gz-sim/bin/BENCHMARK_server_run --benchmark_filter="BM_RuntimeWorldContacts/lengthy"`
```
on 1032
BM_RuntimeWorldContacts/lengthy_sdf_3k_shapes_bullet/3000/iterations:1000       2.96 ms         2.96 ms         1000
BM_RuntimeWorldContacts/lengthy_sdf_3k_shapes_dart/1/iterations:1000            29.3 ms         29.2 ms         1000

main
BM_RuntimeWorldContacts/lengthy_sdf_3k_shapes_bullet/3000/iterations:1000       2.95 ms         2.95 ms         1000
BM_RuntimeWorldContacts/lengthy_sdf_3k_shapes_dart/1/iterations:1000            28.8 ms         28.8 ms         1000

main + revert 1019
BM_RuntimeWorldContacts/lengthy_sdf_3k_shapes_bullet/3000/iterations:1000       3.65 ms         3.64 ms         1000
BM_RuntimeWorldContacts/lengthy_sdf_3k_shapes_dart/1/iterations:1000            29.5 ms         29.4 ms         1000
```

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [X] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [X] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [X] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
