### PR TITLE
Clarify deferred DART mesh construction logs

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -347,8 +347,9 @@ static ShapeAndTransform ConstructHeightmap(
   // TODO(mjcarroll) Allow dartsim to construct heightmaps internally rather
   // than relying on the physics consumer constructing and attaching:
   // https://github.com/gazebosim/gz-physics/issues/451
-  gzdbg << "Heightmap construction from an SDF has not been implemented yet "
-        << "for dartsim. Use AttachHeightmapShapeFeature to use heightmaps.\n";
+  gzdbg << "Dartsim did not construct the heightmap during this SDF "
+        << "construction stage. A physics consumer may still attach it later "
+        << "through AttachHeightmapShapeFeature.\n";
   return {nullptr};
 }
 
@@ -361,8 +362,9 @@ static ShapeAndTransform ConstructMesh(
   // TODO(mjcarroll) Allow dartsim to construct meshes internally rather
   // than relying on the physics consumer constructing and attaching:
   // https://github.com/gazebosim/gz-physics/issues/451
-  gzdbg << "Mesh construction from an SDF has not been implemented yet for "
-        << "dartsim. Use AttachMeshShapeFeature to use mesh shapes.\n";
+  gzdbg << "Dartsim did not construct the mesh during this SDF construction "
+        << "stage. A physics consumer may still attach it later through "
+        << "AttachMeshShapeFeature.\n";
   return {nullptr};
 }
 
@@ -893,8 +895,10 @@ Identity SDFFeatures::ConstructSdfCollision(
   if (!shape)
   {
     // The geometry element was empty, or the shape type is not supported
-    gzdbg << "The geometry element of collision [" << _collision.Name() << "] "
-          << "couldn't be created\n";
+    gzdbg << "ConstructSdfCollision did not create the geometry element of "
+          << "collision [" << _collision.Name() << "] at this stage. Mesh and "
+          << "heightmap geometry may still be attached later by the physics "
+          << "consumer.\n";
     return this->GenerateInvalidId();
   }
 


### PR DESCRIPTION
## Summary

Clarify DART's SDF-construction debug output so it does not imply that mesh or heightmap collision creation necessarily failed.

`ConstructSdfCollision` still returns an invalid identity for these shapes, exactly as before. The messages now explain that this is the result of the current construction stage and that the physics consumer may attach the geometry later through `AttachMeshShapeFeature` or `AttachHeightmapShapeFeature`.

This changes diagnostics only; there is no runtime, API, or ABI behavior change.

Fixes #985.

## Validation

Validated from exact parent `db8795c0cbbb7704430a98f1ce5d7512ec62d732` in an Ubuntu Noble / Rotary environment using the repository's declared CI dependency list:

- built `gz-physics-dartsim-plugin` and `UNIT_SDFFeatures_TEST`;
- `UNIT_SDFFeatures_TEST` and its result checker: 2/2 passed;
- `codecheck`: passed, including cpplint and cppcheck;
- `git diff --check`: passed.

## Checklist

- [x] Signed all commits for DCO
- [x] Existing test covering the modified DART SDF path passes
- [x] `codecheck` passed
- [x] No documentation or migration update is needed for a debug-message clarification

## Generative AI disclosure

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-17)

I reviewed the final diff, wording, provenance, and validation results before submission.
