### PR TITLE
Skip batch ray tests for unsupported engines

### DIFF
--- a/test/common_test/simulation_features.cc
+++ b/test/common_test/simulation_features.cc
@@ -2412,6 +2412,8 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 
   for (const std::string &name : this->pluginNames)
   {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet", "bullet-featherstone", "tpe")
+
     for (const std::string &collisionDetector : supportedCollisionDetectors)
     {
       auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
@@ -2474,6 +2476,8 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 
   for (const std::string &name : this->pluginNames)
   {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet", "bullet-featherstone", "tpe")
+
     for (const std::string &collisionDetector : supportedCollisionDetectors)
     {
       auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
@@ -2507,6 +2511,8 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 
   for (const std::string &name : this->pluginNames)
   {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet", "bullet-featherstone", "tpe")
+
     for (const std::string &collisionDetector : unsupportedCollisionDetectors)
     {
       auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(
@@ -2550,6 +2556,8 @@ TYPED_TEST(SimulationFeaturesBatchRayIntersectionTest,
 
   for (const std::string &name : this->pluginNames)
   {
+    CHECK_UNSUPPORTED_ENGINE(name, "bullet", "bullet-featherstone", "tpe")
+
     for (const std::string &collisionDetector : supportedCollisionDetectors)
     {
       auto world = LoadPluginAndWorld<FeaturesBatchRayIntersections>(


### PR DESCRIPTION
# 🦟 Bug fix

Fixes the batch ray intersection tests failing on engines that do not implement `GetBatchRayIntersectionFromLastStepFeature` (suggested here: https://github.com/gazebosim/gz-physics/pull/1027#discussion_r3779542410).

## Summary
The `SimulationFeaturesBatchRayIntersectionTest` tests (`SupportedBatchRayIntersections`, `EmptyBatchRayIntersections`, `UnsupportedBatchRayIntersections`, `LargeBatchRayIntersections`) iterate over all plugins that advertise the batch ray feature set and run them against a fixed list of collision detectors. Only the dartsim plugin currently implements `GetBatchRayIntersectionFromLastStepFeature`; any other engine that starts advertising the feature set (e.g. bullet, bullet-featherstone, tpe) would fail these tests because the feature is not implemented there.

This PR adds the `CHECK_UNSUPPORTED_ENGINE(name, "bullet", "bullet-featherstone", "tpe")` guard to all four tests, matching the pattern already used by the single-ray `SupportedRayIntersections`/`UnsupportedRayIntersections` tests, so unsupported engines are skipped instead of failing.

Verified locally: all 4 tests pass against the dartsim plugin (ode/bullet/dart/fcl collision detectors), and are skipped against the bullet and tpe plugins.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Opus 4.8 (Anthropic Claude Code)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
