### PR TITLE
mujoco: Use GNUInstallDirs in vendor package

### DIFF
--- a/third_party/mujoco_vendor/CMakeLists.txt
+++ b/third_party/mujoco_vendor/CMakeLists.txt
@@ -2,6 +2,8 @@
 include(ExternalProject)
 set(MUJOCO_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/install")
 
+include(GNUInstallDirs)
+
 if(WIN32)
     set(MUJOCO_IMPLIB_FILE "${MUJOCO_INSTALL_DIR}/lib/mujoco.lib")
     set(MUJOCO_SHARED_FILE "${MUJOCO_INSTALL_DIR}/bin/mujoco.dll")
@@ -10,7 +12,7 @@ elseif(APPLE)
     set(MUJOCO_SHARED_FILE "${MUJOCO_INSTALL_DIR}/lib/libmujoco.dylib")
     set(MUJOCO_BYPRODUCTS "${MUJOCO_SHARED_FILE}")
 else()
-    set(MUJOCO_SHARED_FILE "${MUJOCO_INSTALL_DIR}/lib/libmujoco.so")
+    set(MUJOCO_SHARED_FILE "${MUJOCO_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libmujoco.so")
     set(MUJOCO_BYPRODUCTS "${MUJOCO_SHARED_FILE}")
 endif()
 
@@ -51,6 +53,7 @@ ExternalProject_Add(
   CMAKE_ARGS
     -Wno-dev # Suppress any CMake warnings from mujoco
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
     -DBUILD_SHARED_LIBS=ON
     -DCMAKE_SHARED_LINKER_FLAGS=${MUJOCO_LINK_FLAGS}
     -DMUJOCO_BUILD_EXAMPLES=OFF
@@ -78,8 +81,8 @@ if(WIN32)
 else()
     # Unix links directly against the .so / .dylib
     target_link_libraries(mujoco_internal INTERFACE "${MUJOCO_SHARED_FILE}")
-    install(DIRECTORY "${MUJOCO_INSTALL_DIR}/lib/"
-            DESTINATION lib
+    install(DIRECTORY "${MUJOCO_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/"
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
             FILES_MATCHING
             PATTERN "*mujoco.so*"
             PATTERN "*mujoco*.dylib*"


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Via gz-cmake, gz-physics is already respecting GNUInstallDirs to install libraries to the proper location. The Mujoco vendor package should inherit this behavior as well so that the libraries are all installed to the same location.

This is particularly important on Red Hat platforms where `CMAKE_INSTALL_LIBDIR` is `lib64` instead of `lib`.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.