### PR TITLE
Use explicit element overload of Eigen::Vector3d

### DIFF
--- a/dartsim/src/GzCollisionDetector.cc
+++ b/dartsim/src/GzCollisionDetector.cc
@@ -230,8 +230,10 @@ void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
   {
 
       auto geomData = dGeomGetData(other);
-      rayHit.mNormal = Eigen::Vector3d(contact.normal);
-      rayHit.mPoint = Eigen::Vector3d(contact.pos);
+      rayHit.mNormal = Eigen::Vector3d(contact.normal[0], contact.normal[1],
+                                       contact.normal[2]);
+      rayHit.mPoint = Eigen::Vector3d(contact.pos[0], contact.pos[1],
+                                      contact.pos[2]);
       rayHit.mCollisionObject =
         static_cast<dart::collision::CollisionObject*>(geomData);
   };
@@ -239,7 +241,8 @@ void NearCallbackODE(void *_data, dGeomID _o1, dGeomID _o2)
   // param 3 makes sure that we only generate one collision per call
   if(dCollide(ray, other, 1, &contact, sizeof(dContactGeom)) > 0)
   {
-    Eigen::Vector3d contactPoint(contact.pos);
+    Eigen::Vector3d contactPoint(contact.pos[0], contact.pos[1],
+                                 contact.pos[2]);
 
     const double sqrDist = (*data->origin - contactPoint).squaredNorm();
     if(sqrDist > data->curContactDistSqr)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
If ODE is built with single-precision floating point, the float[] won't match the overload of `Eigen::Vector3d`. Instead, we can explicitly pass the elements so that they get casted.

It appears that ODE on Fedora 43 was built in this way.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.