### PR TITLE
mujoco:Implement `GetJointTransmittedWrench`

### DIFF
--- a/mujoco/src/Base.cc
+++ b/mujoco/src/Base.cc
@@ -87,11 +87,24 @@ int ContactFilterCallback(const mjModel *m, mjData *d, int g1, int g2)
 void resolveJointIndices(WorldInfo &_worldInfo)
 {
   const auto &m = _worldInfo.mjModelObj;
+  auto resolveSensorId = [m](const mjsSensor *_spec) -> std::optional<int>
+  {
+    if (!_spec)
+      return std::nullopt;
+    int id = mjs_getId(_spec->element);
+    return (id >= 0 && id < m->nsensor) ? std::optional<int>(id) : std::nullopt;
+  };
+
   for (const auto &model : _worldInfo.models.idToObject)
   {
     for (auto &joint : model.second->joints.idToObject)
     {
       auto &jointInfo = joint.second;
+
+      // Resolve force & torque sensor compiled IDs
+      jointInfo->forceSensorId = resolveSensorId(jointInfo->forceSensorSpec);
+      jointInfo->torqueSensorId = resolveSensorId(jointInfo->torqueSensorSpec);
+
       if (!jointInfo->joint)
       {
         // Fixed joint

--- a/mujoco/src/Base.hh
+++ b/mujoco/src/Base.hh
@@ -246,6 +246,15 @@ struct JointInfo
   mjsEquality* weldConstraintSpec{nullptr};
   // Compiled weld joint equality constraint index in mjModel (max 1)
   std::optional<int> weldEqIndex{std::nullopt};
+
+  // Pointer to force sensor spec (mjSENS_FORCE)
+  mjsSensor* forceSensorSpec{nullptr};
+  // Compiled force sensor index in mjModel
+  std::optional<int> forceSensorId{std::nullopt};
+  // Pointer to torque sensor spec (mjSENS_TORQUE)
+  mjsSensor* torqueSensorSpec{nullptr};
+  // Compiled torque sensor index in mjModel
+  std::optional<int> torqueSensorId{std::nullopt};
 };
 
 

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -1122,6 +1122,8 @@ Wrench3d JointFeatures::GetJointTransmittedWrenchInJointFrame(
     {
       gzerr << "MuJoCo currently does not support wrench queries on detachable "
                "joints\n";
+      // TODO(azeey): Use constraint forces exposed by MuJoCo to compute
+      // wrenches on weld constraints.
     }
     else
     {

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -1109,11 +1109,25 @@ Wrench3d JointFeatures::GetJointTransmittedWrenchInJointFrame(
   auto *worldInfo = jointInfo->worldInfo;
   if (worldInfo->specDirty)
   {
-    this->RecompileSpec(*worldInfo);
+    if (!this->RecompileSpec(*worldInfo))
+    {
+      gzerr << "Failed to recompile spec.\n";
+      return {};
+    }
   }
 
   if (!jointInfo->forceSensorId || !jointInfo->torqueSensorId)
   {
+    if (jointInfo->weldEqIndex)
+    {
+      gzerr << "MuJoCo currently does not support wrench queries on detachable "
+               "joints\n";
+    }
+    else
+    {
+      gzerr << "Unkown error: Force and torque sensor IDs have not been "
+               "resolved\n";
+    }
     return {};
   }
 

--- a/mujoco/src/JointFeatures.cc
+++ b/mujoco/src/JointFeatures.cc
@@ -1095,6 +1095,39 @@ Identity JointFeatures::AttachFixedJoint(
   return this->GenerateIdentity(jointInfo->entityId, jointInfo);
 }
 
+/////////////////////////////////////////////////
+Wrench3d JointFeatures::GetJointTransmittedWrenchInJointFrame(
+    const Identity &_id) const
+{
+  auto jointInfo = this->ReferenceInterface<JointInfo>(_id);
+  if (!jointInfo || !jointInfo->worldInfo)
+  {
+    gzerr << "Invalid joint info when querying transmitted wrench.\n";
+    return {};
+  }
+
+  auto *worldInfo = jointInfo->worldInfo;
+  if (worldInfo->specDirty)
+  {
+    this->RecompileSpec(*worldInfo);
+  }
+
+  if (!jointInfo->forceSensorId || !jointInfo->torqueSensorId)
+  {
+    return {};
+  }
+
+  const auto *m = worldInfo->mjModelObj;
+  const auto *d = worldInfo->mjDataObj;
+  const int fAdr = m->sensor_adr[*jointInfo->forceSensorId];
+  const int tAdr = m->sensor_adr[*jointInfo->torqueSensorId];
+
+  Wrench3d wrench;
+  wrench.force = convertPos(&d->sensordata[fAdr]);
+  wrench.torque = convertPos(&d->sensordata[tAdr]);
+  return wrench;
+}
+
 namespace {
 /// \brief Disjoint-set data structure (Union-Find) to compute connected
 /// components of welded body clusters using contiguous vectors.

--- a/mujoco/src/JointFeatures.hh
+++ b/mujoco/src/JointFeatures.hh
@@ -40,8 +40,8 @@ struct JointFeatureList : FeatureList<
   AttachFixedJointFeature,
   DetachJointFeature,
   SetJointTransformFromParentFeature,
-  SetJointVelocityCommandFeature
-  // GetJointTransmittedWrench,
+  SetJointVelocityCommandFeature,
+  GetJointTransmittedWrench
   // GetPrismaticJointProperties,
   // GetRevoluteJointProperties,
   // SetFreeJointRelativeTransformFeature,
@@ -139,6 +139,10 @@ class JointFeatures :
       const Identity &_id, std::size_t _dof,
       double _value) override;
 
+  // ----- Transmitted wrench -----
+  public: Wrench3d GetJointTransmittedWrenchInJointFrame(
+      const Identity &_id) const override;
+
   #if 0
   // ----- Free Joint -----
   public: Identity CastToFreeJoint(
@@ -216,10 +220,6 @@ public: void SetJointDampingCoefficient(
   public: void SetJointSpringReference(
        const Identity &_id, std::size_t _dof,
        double _value) override;
-
-  // ----- Transmitted wrench -----
-  public: Wrench3d GetJointTransmittedWrenchInJointFrame(
-      const Identity &_id) const override;
 #endif
 };
 

--- a/mujoco/src/SDFFeatures.cc
+++ b/mujoco/src/SDFFeatures.cc
@@ -678,10 +678,25 @@ struct ModelKinematicStructure
       }
 
       auto jointSite = mjs_addSite(child, nullptr);
+      const std::string scopedJointName =
+          ::sdf::JoinName(_modelInfo->name, sdfJoint->Name());
+      const std::string jointSiteName = scopedJointName + "_site";
+      mjs_setName(jointSite->element, jointSiteName.c_str());
       copyPos(jointPose.Pos(), jointSite->pos);
       copyQuat(jointPose.Rot(), jointSite->quat);
       _base.frames[jointInfo->entityId] =
           std::make_shared<FrameInfo>(jointSite, worldInfo);
+
+      auto addSiteSensor = [&](mjtSensor _type, const std::string &_suffix) {
+        auto *sensor = mjs_addSensor(_spec);
+        sensor->type = _type;
+        sensor->objtype = mjOBJ_SITE;
+        mjs_setString(sensor->objname, jointSiteName.c_str());
+        mjs_setName(sensor->element, (scopedJointName + _suffix).c_str());
+        return sensor;
+      };
+      jointInfo->forceSensorSpec = addSiteSensor(mjSENS_FORCE, "_force");
+      jointInfo->torqueSensorSpec = addSiteSensor(mjSENS_TORQUE, "_torque");
 
       _modelInfo->joints.AddEntity(jointInfo->entityId, jointInfo,
                                    jointInfo->name, _modelInfo->entityId);

--- a/mujoco/src/SDFFeatures.cc
+++ b/mujoco/src/SDFFeatures.cc
@@ -687,7 +687,8 @@ struct ModelKinematicStructure
       _base.frames[jointInfo->entityId] =
           std::make_shared<FrameInfo>(jointSite, worldInfo);
 
-      auto addSiteSensor = [&](mjtSensor _type, const std::string &_suffix) {
+      auto addSiteSensor = [&](mjtSensor _type, const std::string &_suffix)
+      {
         auto *sensor = mjs_addSensor(_spec);
         sensor->type = _type;
         sensor->objtype = mjOBJ_SITE;


### PR DESCRIPTION
# 🎉 New feature

## Summary
Implement `GetJointTransmittedWrenchInJointFrame` for the MuJoCo physics engine plugin.

This feature uses native MuJoCo force and torque sensors (`mjSENS_FORCE` and `mjSENS_TORQUE`) attached to each joint's site in `mjSpec` (skipping free joints). This enables MuJoCo's internal simulation pipeline to automatically evaluate and project the reaction wrench into the joint frame natively, avoiding custom spatial algebra calculations or previous-step snapshot buffers.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it
Run the joint transmitted wrench common tests:
```bash
./bin/COMMON_TEST_joint_transmitted_wrench_features ./lib/libgz-physics-mujoco-plugin.dylib
```
All 5 tests in `JointTransmittedWrenchFixture` pass.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.8 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
